### PR TITLE
fixed package name for building env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - pytorch::torchvision
 - tensorflow-gpu
 - tensorboard
-- sklearn
+- scikit-learn
 - matplotlib
 
 - pip:


### PR DESCRIPTION
name 'sklearn' needed to be fixed to build the environment on my local machine (linux) with an anaconda install. 