### PR TITLE
add CPUUsage metric

### DIFF
--- a/avalanche/evaluation/eval_protocol.py
+++ b/avalanche/evaluation/eval_protocol.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-from .metrics import ACC, CF, RAMU, CM
+from .metrics import ACC, CF, RAMU, CM, CPUUsage
 import numpy as np
 from .tensorboard import TensorboardLogging
 
@@ -53,6 +53,10 @@ class EvalProtocol(object):
                 results[RAMU] = metric.compute(train_t)
             elif isinstance(metric, CM):
                 results[CM] = metric.compute(true_y, y_hat)
+            elif isinstance(metric, CPUUsage):
+                results[CPUUsage] = metric.compute(train_t)
+            else:
+                raise ValueError("Unknown metric")
 
         self.global_step += 1
 

--- a/avalanche/evaluation/metrics.py
+++ b/avalanche/evaluation/metrics.py
@@ -33,6 +33,27 @@ from torchvision.transforms import ToTensor
 from sklearn.utils.multiclass import unique_labels
 import io
 
+
+class CPUUsage:
+    """
+        CPU usage metric measured in seconds.
+    """
+
+    def compute(self, t):
+        """
+        Compute CPU usage measured in seconds.
+
+        :param t: task id
+        :return: tuple (float, float): (user CPU time, system CPU time)
+        """
+        p = psutil.Process(os.getpid())
+        times = p.cpu_times()
+        user, sys = times.user, times.system
+        print("Train Task {:} - CPU usage: user {} system {}"
+              .format(t, user, sys))
+        return user, sys
+
+
 class ACC(object):
 
     def __init__(self, num_class=None):


### PR DESCRIPTION
Partially addresses #20.
Currently I added the metric to track CPU usage.

Tracking the GPU usage is more difficult since  as far as I know nvidia-smi only returns the current load of each GPU. I am not aware of an easy solution to track the GPU usage at the moment. A possible solution could be to call nvidia-smi repeatedly in a separate thread and compute the average load, for example with:
```
nvidia-smi --loop=1 --query-gpu=utilization.gpu --format=csv
```
This method cannot distinguish if different processes are using the same GPU concurrently.