### PR TITLE
Fixed an issue in NCGenericScenario

### DIFF
--- a/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
@@ -83,7 +83,9 @@ class NCMultiTaskScenario(GenericCLScenario[TrainSetWithTargets,
             self.classes_ids_from_zero_in_each_task = \
                 classes_ids_from_zero_in_each_task
 
-        self.class_mapping = [-1 for _ in range(self.n_classes)]
+        max_class_id = max(nc_generic_scenario.classes_order)
+        n_original_classes = max_class_id + 1
+        self.class_mapping = [-1 for _ in range(n_original_classes)]
 
         if classes_ids_from_zero_in_each_task:
             for task_id in range(self.n_tasks):
@@ -100,7 +102,7 @@ class NCMultiTaskScenario(GenericCLScenario[TrainSetWithTargets,
                 self.classes_in_task.append(
                     list(range(0, n_classes_this_task)))
         else:
-            self.class_mapping = list(range(self.n_classes))
+            self.class_mapping = list(range(n_original_classes))
             self.classes_in_task = nc_generic_scenario.classes_in_batch
 
         self.original_classes_in_task = nc_generic_scenario.classes_in_batch

--- a/tests/test_nc_mt_scenario.py
+++ b/tests/test_nc_mt_scenario.py
@@ -64,6 +64,43 @@ class MultiTaskTests(unittest.TestCase):
 
         self.assertEqual(order, all_classes)
 
+    def test_sit_single_dataset_fixed_order_subset(self):
+        order = [2, 5, 7, 8, 9, 0, 1, 4]
+        mnist_train = MNIST('./data/mnist', train=True, download=True)
+        mnist_test = MNIST('./data/mnist', train=False, download=True)
+        nc_scenario = create_nc_single_dataset_multi_task_scenario(
+            mnist_train, mnist_test, 4, fixed_class_order=order)
+
+        self.assertEqual(4, len(nc_scenario.classes_in_task))
+
+        all_classes = []
+        for task_id in range(4):
+            self.assertEqual(2, len(nc_scenario.classes_in_task[task_id]))
+            self.assertEqual(order[task_id*2:(task_id+1)*2],
+                             nc_scenario.original_classes_in_task[task_id])
+            all_classes.extend(nc_scenario.classes_in_task[task_id])
+
+        self.assertEqual([0, 1] * 4, all_classes)
+
+    def test_sit_single_dataset_fixed_subset_no_remap_idx(self):
+        order = [2, 5, 7, 8, 9, 0, 1, 4]
+        mnist_train = MNIST('./data/mnist', train=True, download=True)
+        mnist_test = MNIST('./data/mnist', train=False, download=True)
+        nc_scenario = create_nc_single_dataset_multi_task_scenario(
+            mnist_train, mnist_test, 2, fixed_class_order=order,
+            classes_ids_from_zero_in_each_task=False)
+
+        self.assertEqual(2, len(nc_scenario.classes_in_task))
+
+        all_classes = []
+        for task_id in range(2):
+            self.assertEqual(4, len(nc_scenario.classes_in_task[task_id]))
+            self.assertEqual(order[task_id*4:(task_id+1)*4],
+                             nc_scenario.original_classes_in_task[task_id])
+            all_classes.extend(nc_scenario.classes_in_task[task_id])
+
+        self.assertEqual(order, all_classes)
+
     def test_mt_single_dataset_reproducibility_data(self):
         mnist_train = MNIST('./data/mnist', train=True, download=True)
         mnist_test = MNIST('./data/mnist', train=False, download=True)

--- a/tests/test_nc_sit_scenario.py
+++ b/tests/test_nc_sit_scenario.py
@@ -42,6 +42,39 @@ class SITTests(unittest.TestCase):
 
         self.assertEqual(order, all_classes)
 
+    def test_sit_single_dataset_fixed_order_subset(self):
+        order = [2, 3, 5, 8, 9, 1, 4, 6]
+        mnist_train = MNIST('./data/mnist', train=True, download=True)
+        mnist_test = MNIST('./data/mnist', train=False, download=True)
+        nc_scenario = create_nc_single_dataset_sit_scenario(
+            mnist_train, mnist_test, 4, fixed_class_order=order)
+
+        self.assertEqual(4, len(nc_scenario.classes_in_batch))
+
+        all_classes = []
+        for batch_id in range(4):
+            self.assertEqual(2, len(nc_scenario.classes_in_batch[batch_id]))
+            all_classes.extend(nc_scenario.classes_in_batch[batch_id])
+
+        self.assertEqual(order, all_classes)
+
+    def test_sit_single_dataset_remap_indexes(self):
+        order = [2, 3, 5, 8, 9, 1, 4, 6]
+        mnist_train = MNIST('./data/mnist', train=True, download=True)
+        mnist_test = MNIST('./data/mnist', train=False, download=True)
+        nc_scenario = create_nc_single_dataset_sit_scenario(
+            mnist_train, mnist_test, 4, fixed_class_order=order,
+            remap_class_ids=True)
+
+        self.assertEqual(4, len(nc_scenario.classes_in_batch))
+
+        all_classes = []
+        for batch_id in range(4):
+            self.assertEqual(2, len(nc_scenario.classes_in_batch[batch_id]))
+            all_classes.extend(nc_scenario.classes_in_batch[batch_id])
+
+        self.assertEqual(list(range(8)), all_classes)
+
     def test_sit_single_dataset_reproducibility_data(self):
         mnist_train = MNIST('./data/mnist', train=True, download=True)
         mnist_test = MNIST('./data/mnist', train=False, download=True)


### PR DESCRIPTION
Fixed an issue in NCGenericScenario that allowed the user to define a fixed_class_order with non existing class IDs.

This fix also allows NCGenericScenario to manage a fixed_class_order describing a subset of the classes contained in the original dataset.