### PR TITLE
Sliceable scenarios

### DIFF
--- a/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
@@ -21,7 +21,7 @@ from avalanche.benchmarks.utils import grouped_and_ordered_indexes
 
 
 class NCMultiTaskScenario(GenericCLScenario[TrainSetWithTargets,
-                                            TestSetWithTargets],
+                                            TestSetWithTargets, 'NCTaskInfo'],
                           Generic[TrainSetWithTargets, TestSetWithTargets]):
     """
     This class defines a "New Classes" multi task scenario based on a
@@ -112,14 +112,7 @@ class NCMultiTaskScenario(GenericCLScenario[TrainSetWithTargets,
             self.nc_generic_scenario.test_dataset,
             self.nc_generic_scenario.train_steps_patterns_assignment,
             self.nc_generic_scenario.test_steps_patterns_assignment,
-            list(range(self.n_tasks)))
-
-    def __getitem__(self, task_id) -> 'NCTaskInfo[' \
-                                      'TrainSetWithTargets, ' \
-                                      'TestSetWithTargets]':
-        if task_id < len(self):
-            return NCTaskInfo(self, task_id)
-        raise IndexError('Task ID out of bounds' + str(int(task_id)))
+            list(range(self.n_tasks)), step_factory=NCTaskInfo)
 
     def get_reproducibility_data(self) -> Dict[str, Any]:
         rep_data = super().get_reproducibility_data()
@@ -262,7 +255,7 @@ class NCTaskInfo(GenericStepInfo[NCMultiTaskScenario[TrainSetWithTargets,
 
 
 class NCSingleTaskScenario(GenericCLScenario[TrainSetWithTargets,
-                                             TestSetWithTargets],
+                                             TestSetWithTargets, 'NCBatchInfo'],
                            Generic[TrainSetWithTargets, TestSetWithTargets]):
     """
     This class defines a "New Classes" Single Incremental Task scenario based
@@ -310,14 +303,7 @@ class NCSingleTaskScenario(GenericCLScenario[TrainSetWithTargets,
             self.nc_generic_scenario.test_dataset,
             self.nc_generic_scenario.train_steps_patterns_assignment,
             self.nc_generic_scenario.test_steps_patterns_assignment,
-            [0] * self.n_batches)
-
-    def __getitem__(self, batch_id) -> 'NCBatchInfo[' \
-                                       'TrainSetWithTargets,' \
-                                       'TestSetWithTargets]':
-        if batch_id < len(self):
-            return NCBatchInfo(self, batch_id)
-        raise IndexError('Batch ID out of bounds' + str(int(batch_id)))
+            [0] * self.n_batches, step_factory=NCBatchInfo)
 
     def get_reproducibility_data(self) -> Dict[str, Any]:
         rep_data = super().get_reproducibility_data()

--- a/avalanche/benchmarks/scenarios/new_instances/ni_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_instances/ni_scenario.py
@@ -41,7 +41,8 @@ def _batch_structure_from_assignment(dataset: IDatasetWithTargets,
     return batch_structure
 
 
-class NIScenario(GenericCLScenario[TrainSetWithTargets, TestSetWithTargets],
+class NIScenario(GenericCLScenario[TrainSetWithTargets,
+                                   TestSetWithTargets, 'NIBatchInfo'],
                  Generic[TrainSetWithTargets, TestSetWithTargets]):
 
     """
@@ -376,12 +377,7 @@ class NIScenario(GenericCLScenario[TrainSetWithTargets, TestSetWithTargets],
         super(NIScenario, self).__init__(
             train_dataset, test_dataset, batch_patterns, [],
             task_labels=[0] * self.n_batches,
-            return_complete_test_set_only=True)
-
-    def __getitem__(self, batch_id):
-        if batch_id < len(self):
-            return NIBatchInfo(self, batch_id)
-        raise IndexError('Batch ID out of bounds' + str(int(batch_id)))
+            return_complete_test_set_only=True, step_factory=NIBatchInfo)
 
     def get_reproducibility_data(self) -> Dict[str, Any]:
         # In fact, the only data required for reproducibility of a NI Scenario

--- a/tests/test_nc_mt_scenario.py
+++ b/tests/test_nc_mt_scenario.py
@@ -4,10 +4,11 @@ from torchvision.datasets import MNIST
 
 from avalanche.benchmarks.scenarios import \
     create_nc_single_dataset_multi_task_scenario, \
-    create_nc_multi_dataset_multi_task_scenario
+    create_nc_multi_dataset_multi_task_scenario, NCTaskInfo
 from avalanche.training.utils import TransformationSubset
 from avalanche.benchmarks.scenarios.new_classes.nc_utils import \
     make_nc_transformation_subset
+from avalanche.benchmarks.scenarios.generic_cl_scenario import ScenarioSlice
 
 
 class MultiTaskTests(unittest.TestCase):
@@ -180,6 +181,28 @@ class MultiTaskTests(unittest.TestCase):
 
         self.assertTrue(step_classes == step_classes_ref1 or
                         step_classes == step_classes_ref2)
+
+    def test_nc_mt_slicing(self):
+        mnist_train = MNIST(
+            './data/mnist', train=True, download=True)
+        mnist_test = MNIST(
+            './data/mnist', train=False, download=True)
+        nc_scenario = create_nc_single_dataset_multi_task_scenario(
+            mnist_train, mnist_test, 5, shuffle=True, seed=1234)
+
+        step_info: NCTaskInfo
+        for batch_id, step_info in enumerate(nc_scenario):
+            self.assertEqual(batch_id, step_info.current_step)
+            self.assertIsInstance(step_info, NCTaskInfo)
+
+        iterable_slice = [3, 4, 1]
+        sliced_scenario = nc_scenario[iterable_slice]
+        self.assertIsInstance(sliced_scenario, ScenarioSlice)
+        self.assertEqual(len(iterable_slice), len(sliced_scenario))
+
+        for batch_id, step_info in enumerate(sliced_scenario):
+            self.assertEqual(iterable_slice[batch_id], step_info.current_step)
+            self.assertIsInstance(step_info, NCTaskInfo)
 
 
 if __name__ == '__main__':

--- a/tests/test_ni_sit_scenario.py
+++ b/tests/test_ni_sit_scenario.py
@@ -8,6 +8,7 @@ from avalanche.benchmarks.scenarios import \
 from avalanche.training.utils import TransformationSubset, torch
 from avalanche.benchmarks.scenarios.new_classes.nc_utils import \
     make_nc_transformation_subset
+from avalanche.benchmarks.scenarios.generic_cl_scenario import ScenarioSlice
 
 
 class NISITTests(unittest.TestCase):
@@ -112,6 +113,28 @@ class NISITTests(unittest.TestCase):
             all_classes.update(ni_scenario.classes_in_batch[batch_id])
 
         self.assertEqual(10, len(all_classes))
+
+    def test_ni_sit_slicing(self):
+        mnist_train = MNIST(
+            './data/mnist', train=True, download=True)
+        mnist_test = MNIST(
+            './data/mnist', train=False, download=True)
+        nc_scenario = create_ni_single_dataset_sit_scenario(
+            mnist_train, mnist_test, 5, shuffle=True, seed=1234)
+
+        step_info: NIBatchInfo
+        for batch_id, step_info in enumerate(nc_scenario):
+            self.assertEqual(batch_id, step_info.current_step)
+            self.assertIsInstance(step_info, NIBatchInfo)
+
+        iterable_slice = [3, 4, 1]
+        sliced_scenario = nc_scenario[iterable_slice]
+        self.assertIsInstance(sliced_scenario, ScenarioSlice)
+        self.assertEqual(len(iterable_slice), len(sliced_scenario))
+
+        for batch_id, step_info in enumerate(sliced_scenario):
+            self.assertEqual(iterable_slice[batch_id], step_info.current_step)
+            self.assertIsInstance(step_info, NIBatchInfo)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implementation of the slicing operation on scenarios. Slicing allows the user to define alternative step orders. Supported operations:

- Standard Python slicing operation (`my_scenario[3: 7]`)
- Define step indexes using an Iterable of ints (`my_scenario[3, 5, 1, 3]` or `my_scenario[range(2, 5)]`)
- Slicing of slices

Includes tests!

Solves #116 