### PR TITLE
Support TensorDataset for scenario creations

### DIFF
--- a/avalanche/benchmarks/generators/scenario_generators.py
+++ b/avalanche/benchmarks/generators/scenario_generators.py
@@ -25,15 +25,16 @@ from avalanche.benchmarks.scenarios.generic_scenario_creation import *
 from avalanche.benchmarks.scenarios.new_classes.nc_scenario import \
     NCScenario
 from avalanche.benchmarks.scenarios.new_instances.ni_scenario import NIScenario
-from avalanche.benchmarks.utils import IDatasetWithTargets, \
+from avalanche.benchmarks.utils import \
     concat_datasets_sequentially, as_transformation_dataset
+from avalanche.benchmarks.utils.transform_dataset import SupportedDataset
 
 
 def nc_scenario(
         train_dataset: Union[
-            Sequence[IDatasetWithTargets], IDatasetWithTargets],
+            Sequence[SupportedDataset], SupportedDataset],
         test_dataset: Union[
-            Sequence[IDatasetWithTargets], IDatasetWithTargets],
+            Sequence[SupportedDataset], SupportedDataset],
         n_steps: int,
         task_labels: bool,
         *,
@@ -182,9 +183,9 @@ def nc_scenario(
 
 def ni_scenario(
         train_dataset: Union[
-            Sequence[IDatasetWithTargets], IDatasetWithTargets],
+            Sequence[SupportedDataset], SupportedDataset],
         test_dataset: Union[
-            Sequence[IDatasetWithTargets], IDatasetWithTargets],
+            Sequence[SupportedDataset], SupportedDataset],
         n_steps: int,
         *,
         task_labels: bool = False,
@@ -273,8 +274,8 @@ def ni_scenario(
 
 
 def dataset_scenario(
-        train_dataset_list: Sequence[IDatasetWithTargets],
-        test_dataset_list: Sequence[IDatasetWithTargets],
+        train_dataset_list: Sequence[SupportedDataset],
+        test_dataset_list: Sequence[SupportedDataset],
         task_labels: Sequence[int],
         complete_test_set_only: bool = False) -> GenericCLScenario:
     """

--- a/avalanche/benchmarks/scenarios/generic_scenario_creation.py
+++ b/avalanche/benchmarks/scenarios/generic_scenario_creation.py
@@ -4,14 +4,15 @@ from typing import Sequence, Union, SupportsInt, Any
 from torch import Tensor
 
 from avalanche.benchmarks.utils import TransformationTensorDataset, \
-    IDatasetWithTargets, TransformationConcatDataset, as_transformation_dataset
+    TransformationConcatDataset, as_transformation_dataset, \
+    SupportedDataset
 from avalanche.benchmarks.datasets import datasets_from_filelists
 from .generic_cl_scenario import GenericCLScenario
 
 
 def create_multi_dataset_generic_scenario(
-        train_dataset_list: Sequence[IDatasetWithTargets],
-        test_dataset_list: Sequence[IDatasetWithTargets],
+        train_dataset_list: Sequence[SupportedDataset],
+        test_dataset_list: Sequence[SupportedDataset],
         task_labels: Sequence[int],
         complete_test_set_only: bool = False) -> GenericCLScenario:
     """

--- a/avalanche/benchmarks/scenarios/new_classes/nc_utils.py
+++ b/avalanche/benchmarks/scenarios/new_classes/nc_utils.py
@@ -14,7 +14,8 @@ from typing import List, Sequence, Dict, Any, Union, SupportsInt
 
 import torch
 
-from avalanche.benchmarks.utils import TransformationSubset, IDatasetWithTargets
+from avalanche.benchmarks.utils import TransformationSubset, \
+    SupportedDataset
 from avalanche.benchmarks.utils import tensor_as_list
 
 
@@ -143,7 +144,7 @@ def _indexes_from_set(sequence: Sequence[SupportsInt],
                                      sort_indexes=sort_indexes)
 
 
-def make_nc_transformation_subset(dataset: IDatasetWithTargets,
+def make_nc_transformation_subset(dataset: SupportedDataset,
                                   transform: Any, target_transform: Any,
                                   classes: Union[None, Sequence[int]],
                                   bucket_classes: bool = False,

--- a/avalanche/benchmarks/scenarios/new_instances/ni_utils.py
+++ b/avalanche/benchmarks/scenarios/new_instances/ni_utils.py
@@ -133,11 +133,12 @@ def make_ni_transformation_subset(dataset: IDatasetWithTargets,
         ``sort_classes`` and ``sort_indexes`` parameters.
     """
     return TransformationSubset(dataset,
-                                _indexes_from_set(dataset.targets,
-                                                  patterns_indexes,
-                                                  bucket_classes=bucket_classes,
-                                                  sort_classes=sort_classes,
-                                                  sort_indexes=sort_indexes),
+                                indices=_indexes_from_set(
+                                    dataset.targets,
+                                    patterns_indexes,
+                                    bucket_classes=bucket_classes,
+                                    sort_classes=sort_classes,
+                                    sort_indexes=sort_indexes),
                                 transform=transform,
                                 target_transform=target_transform)
 

--- a/tests/test_transform_dataset.py
+++ b/tests/test_transform_dataset.py
@@ -4,6 +4,7 @@ import torch
 from PIL import ImageChops
 from PIL.Image import Image
 from torch import Tensor
+from torch.utils.data import TensorDataset
 from torchvision.datasets import MNIST
 from torchvision.transforms import ToTensor, RandomCrop, ToPILImage, Compose, \
     Lambda
@@ -92,6 +93,28 @@ class TransformationDatasetTests(unittest.TestCase):
         self.assertEqual(x2.shape, (1, 16, 16))
         self.assertIsInstance(y2, int)
         self.assertEqual(y2, -1)
+
+    def test_transform_dataset_tensor_dataset_input(self):
+        train_x = torch.rand(500, 3, 28, 28)
+        train_y = torch.zeros(500)
+        test_x = torch.rand(200, 3, 28, 28)
+        test_y = torch.ones(200)
+
+        train = TensorDataset(train_x, train_y)
+        test = TensorDataset(test_x, test_y)
+        train_dataset = TransformationDataset(train)
+        test_dataset = TransformationDataset(test)
+
+        self.assertEqual(500, len(train_dataset))
+        self.assertEqual(200, len(test_dataset))
+
+        x, y = train_dataset[0]
+        self.assertIsInstance(x, Tensor)
+        self.assertEqual(0, y)
+
+        x2, y2 = test_dataset[0]
+        self.assertIsInstance(x2, Tensor)
+        self.assertEqual(1, y2)
 
 
 class TransformationSubsetTests(unittest.TestCase):


### PR DESCRIPTION
TransformationDataset (and its subclasses) can now be created using instances of PyTorch TensorDataset.

This will allow users to use benchmark generators using those datasets. The required "targets" field will be taken from the "tensors" field of TensorDataset.

Solves issue #191 