### PR TITLE
Add installation script for the conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,23 +1,18 @@
 ################################################################################
-# Copyright (c) 2020 ContinualAI Research                                      #
+# Copyright (c) 2021 ContinualAI Research                                      #
 # Copyrights licensed under the CC BY 4.0 License.                             #
 # See the accompanying LICENSE file for terms.                                 #
 #                                                                              #
-# Date: 1-05-2020                                                              #
-# Author(s): Vincenzo Lomonaco                                                 #
+# Date: 09-02-2021                                                             #
+# Author(s): Gabriele Graffieti                                                #
 # E-mail: contact@continualai.org                                              #
 # Website: clair.continualai.org                                               #
 ################################################################################
 
-name: avalanche-env
 channels:
-- pytorch
 - conda-forge
 dependencies:
 - psutil
-- python>=3.6,<3.9
-- pytorch::pytorch
-- pytorch::torchvision
 - tensorboard
 - scikit-learn
 - matplotlib

--- a/install_script.sh
+++ b/install_script.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+################################################################################
+# Copyright (c) 2021 ContinualAI Research                                      #
+# Copyrights licensed under the CC BY 4.0 License.                             #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 09-02-2021                                                             #
+# Author(s): Gabriele Graffieti                                                #
+# E-mail: contact@continualai.org                                              #
+# Website: clair.continualai.org                                               #
+################################################################################
+
+python="3.8"
+cuda_version="none"
+
+while test $# -gt 0; do
+         case "$1" in
+              --python)
+                  shift
+                  python=$1
+                  shift
+                  ;;
+              --cuda_version)
+                  shift
+                  cuda_version=$1
+                  shift
+                  ;;
+              *)
+                 echo "$1 is not a recognized flag! Use --python and/or --cuda_version."
+                 exit 1;
+                 ;;
+        esac
+done  
+
+echo "python version : $python";
+echo "cuda version : $cuda_version";
+
+if ! [[ "$python" =~ ^(3.6|3.7|3.8)$ ]]; then
+    echo "Select a python version between 3.6, 3.7, 3.8"
+    exit 1
+fi
+
+if ! [[ "$cuda_version" =~ ^(9.2|10.1|10.2|11.0|"none")$ ]]; then
+    echo "Select a CUDA version between 9.2 10.1, 10.2, 11.0, none"
+    exit 1
+fi
+
+conda create -n avalanche-env python=$python -c conda-forge
+conda activate avalanche-env
+if [[ "$cuda_version" = "none" ]]; then 
+    conda install pytorch torchvision cpuonly -c pytorch
+else 
+    conda install pytorch torchvision cudatoolkit=$cuda_version -c pytorch
+fi
+conda env update --file environment.yml
+


### PR DESCRIPTION
Installation script for the conda environment. 
It takes 2 arguments: `--python` and `--cuda_device`.
`--python` can take the values [3.6, 3.7, 3.8], default 3.8
`--cuda_device` can take the values [9.2, 10.1, 10.2, 11.0, none], default none

The script *must* be launched with `bash -i ./prova_bash.sh <arguments>`

Note: we should test this way to create the conda environment, I tested the environment with some tests and examples and it works, but it requires more (beta) testing. 

This PR solves the issue #255 