### PR TITLE
Added StreamConfusionMatrix at eval time and modified references

### DIFF
--- a/avalanche/evaluation/metric_utils.py
+++ b/avalanche/evaluation/metric_utils.py
@@ -23,6 +23,10 @@ if TYPE_CHECKING:
     from avalanche.evaluation import PluginMetric
 
 
+EVAL = "eval"
+TRAIN = "train"
+
+
 def default_cm_image_creator(confusion_matrix_tensor: Tensor,
                              display_labels=None,
                              include_values=True,
@@ -123,9 +127,9 @@ def phase_and_task(strategy: 'PluggableStrategy') -> Tuple[str, int]:
     """
 
     if strategy.is_eval:
-        return "Eval", strategy.eval_task_label
+        return EVAL, strategy.eval_task_label
 
-    return "Train", strategy.train_task_label
+    return TRAIN, strategy.train_task_label
 
 
 def bytes2human(n):
@@ -167,7 +171,9 @@ def get_metric_name(metric: 'PluginMetric',
     phase_name, task_label = phase_and_task(strategy)
     stream = stream_type(strategy.step_info)
     if add_step:
-        step_label = strategy.eval_step_id
+
+        step_label = strategy.eval_step_id if phase_name == EVAL \
+            else strategy.training_step_counter
         metric_name = '{}/{}_phase/{}_stream/Task{:03}/Step{:03}' \
             .format(str(metric),
                     phase_name,

--- a/docs/gitbook/examples/evaluation.md
+++ b/docs/gitbook/examples/evaluation.md
@@ -55,7 +55,7 @@ eval_plugin = EvaluationPlugin(
     timing_metrics(epoch=True, epoch_average=True, test=False),
     cpu_usage_metrics(step=True),
     StepForgetting(),
-    TaskConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
+    StreamConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
     DiskUsageMonitor(), RamUsageMonitor(), GpuUsageMonitor(0),
     loggers=[interactive_logger, text_logger, tb_logger])
 

--- a/docs/gitbook/examples/loggers.md
+++ b/docs/gitbook/examples/loggers.md
@@ -55,7 +55,7 @@ eval_plugin = EvaluationPlugin(
     timing_metrics(epoch=True, epoch_average=True, test=False),
     cpu_usage_metrics(step=True),
     StepForgetting(),
-    TaskConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
+    StreamConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
     DiskUsageMonitor(), RamUsageMonitor(), GpuUsageMonitor(0),
     loggers=[interactive_logger, text_logger, tb_logger])
 

--- a/docs/gitbook/from-zero-to-hero-tutorial/4.-evaluation.md
+++ b/docs/gitbook/from-zero-to-hero-tutorial/4.-evaluation.md
@@ -20,8 +20,8 @@ The metrics already available in the current _Avalanche_ release are:
 
 ```python
 from avalanche.evaluation.metrics import Accuracy, MinibatchAccuracy, \
-EpochAccuracy, RunningEpochAccuracy, StepAccuracyAccuracy, ConfusionMatrix, \
-TaskConfusionMatrix, CpuUsage, MinibatchCpuUsage, EpochCpuUsage, \
+EpochAccuracy, RunningEpochAccuracy, StepAccuracy, ConfusionMatrix, \
+StreamConfusionMatrix, CpuUsage, MinibatchCpuUsage, EpochCpuUsage, \
 AverageEpochCpuUsage, StepCpuUsage, DiskUsage, DiskUsageMonitor, \
 StepForgetting, GpuUsage, GpuUsageMonitor, Loss, MinibatchLoss, \
 EpochLoss, RunningEpochLoss, StepLoss, MAC, Mean, RamUsage, RamUsageMonitor, \
@@ -54,8 +54,7 @@ The **Evaluation Plugin**, is the object in charge of configuring and controllin
 ```python
 from avalanche.benchmarks.classic import SplitMNIST
 from avalanche.evaluation.metrics import StepForgetting, accuracy_metrics,
-
-loss_metrics, timing_metrics, cpu_usage_metrics, TaskConfusionMatrix,
+loss_metrics, timing_metrics, cpu_usage_metrics, StreamConfusionMatrix,
 DiskUsageMonitor, GpuUsageMonitor, RamUsageMonitor
 from avalanche.models import SimpleMLP
 from avalanche.logging import InteractiveLogger, TextLogger, TensorboardLogger
@@ -78,7 +77,7 @@ eval_plugin = EvaluationPlugin(
     timing_metrics(epoch=True, epoch_average=True),
     cpu_usage_metrics(step=True),
     StepForgetting(),
-    TaskConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
+    StreamConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
     DiskUsageMonitor(), RamUsageMonitor(), GpuUsageMonitor(0)
 )
 

--- a/docs/gitbook/from-zero-to-hero-tutorial/6.-putting-all-together.md
+++ b/docs/gitbook/from-zero-to-hero-tutorial/6.-putting-all-together.md
@@ -14,7 +14,7 @@ Here we report a complete example of the _Avalanche_ usage:
 from avalanche.benchmarks.classic import SplitMNIST
 from avalanche.evaluation.metrics import StepForgetting, accuracy_metrics,
 
-loss_metrics, timing_metrics, cpu_usage_metrics, TaskConfusionMatrix,
+loss_metrics, timing_metrics, cpu_usage_metrics, StreamConfusionMatrix,
 DiskUsageMonitor, GpuUsageMonitor, RamUsageMonitor
 from avalanche.models import SimpleMLP
 from avalanche.logging import InteractiveLogger, TextLogger, TensorboardLogger
@@ -46,7 +46,7 @@ eval_plugin = EvaluationPlugin(
     timing_metrics(epoch=True, epoch_average=True, test=False),
     cpu_usage_metrics(step=True),
     StepForgetting(),
-    TaskConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
+    StreamConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
     DiskUsageMonitor(), RamUsageMonitor(), GpuUsageMonitor(0),
     loggers=[interactive_logger, text_logger, tb_logger]
 )

--- a/docs/gitbook/from-zero-to-hero-tutorial/loggers.md
+++ b/docs/gitbook/from-zero-to-hero-tutorial/loggers.md
@@ -28,7 +28,7 @@ _Avalanche_ at the moment supports three main Loggers:
 from avalanche.benchmarks.classic import SplitMNIST
 from avalanche.evaluation.metrics import StepForgetting, accuracy_metrics,
 
-loss_metrics, timing_metrics, cpu_usage_metrics, TaskConfusionMatrix,
+loss_metrics, timing_metrics, cpu_usage_metrics, StreamConfusionMatrix,
 DiskUsageMonitor, GpuUsageMonitor, RamUsageMonitor
 from avalanche.models import SimpleMLP
 from avalanche.logging import InteractiveLogger, TextLogger, TensorboardLogger
@@ -60,7 +60,7 @@ eval_plugin = EvaluationPlugin(
     timing_metrics(epoch=True, epoch_average=True, test=False),
     cpu_usage_metrics(step=True),
     StepForgetting(),
-    TaskConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
+    StreamConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
     DiskUsageMonitor(), RamUsageMonitor(), GpuUsageMonitor(0),
     loggers=[interactive_logger, text_logger, tb_logger]
 )

--- a/docs/gitbook/getting-started-1/learn-avalanche-in-5-minutes.md
+++ b/docs/gitbook/getting-started-1/learn-avalanche-in-5-minutes.md
@@ -269,7 +269,7 @@ The metrics already available in the current _Avalanche_ release are:
 ```python
 from avalanche.evaluation.metrics import Accuracy, MinibatchAccuracy, \
 EpochAccuracy, RunningEpochAccuracy, StepAccuracy, ConfusionMatrix, \
-TaskConfusionMatrix, CpuUsage, MinibatchCpuUsage, EpochCpuUsage, \
+StreamConfusionMatrix, CpuUsage, MinibatchCpuUsage, EpochCpuUsage, \
 AverageEpochCpuUsage, StepCpuUsage, DiskUsage, DiskUsageMonitor, \
 StepForgetting, GpuUsage, GpuUsageMonitor, Loss, MinibatchLoss, \
 EpochLoss, RunningEpochLoss, StepLoss, MAC, Mean, RamUsage, RamUsageMonitor, \
@@ -303,7 +303,7 @@ Here we show how you can use all these modules together to **design your experim
 from avalanche.benchmarks.classic import SplitMNIST
 from avalanche.evaluation.metrics import StepForgetting, accuracy_metrics,
 
-loss_metrics, timing_metrics, cpu_usage_metrics, TaskConfusionMatrix,
+loss_metrics, timing_metrics, cpu_usage_metrics, StreamConfusionMatrix,
 DiskUsageMonitor, GpuUsageMonitor, RamUsageMonitor
 from avalanche.models import SimpleMLP
 from avalanche.logging import InteractiveLogger, TextLogger, TensorboardLogger
@@ -335,7 +335,7 @@ eval_plugin = EvaluationPlugin(
     timing_metrics(epoch=True, epoch_average=True, test=False),
     cpu_usage_metrics(step=True),
     StepForgetting(),
-    TaskConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
+    StreamConfusionMatrix(num_classes=scenario.n_classes, save_image=False),
     DiskUsageMonitor(), RamUsageMonitor(), GpuUsageMonitor(0),
     loggers=[interactive_logger, text_logger, tb_logger]
 )

--- a/examples/confusion_matrix.py
+++ b/examples/confusion_matrix.py
@@ -1,0 +1,102 @@
+################################################################################
+# Copyright (c) 2021 ContinualAI.                                              #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 24-05-2020                                                             #
+# Author(s): Andrea Cossu                                                      #
+# E-mail: contact@continualai.org                                              #
+# Website: clair.continualai.org                                               #
+################################################################################
+
+"""
+This example shows how to produce confusion matrix during training and evaluation.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import torch
+from torch.nn import CrossEntropyLoss
+from torch.optim import SGD
+from torchvision import transforms
+from torchvision.datasets import MNIST
+from torchvision.transforms import ToTensor, RandomCrop
+
+from avalanche.benchmarks import nc_scenario
+from avalanche.models import SimpleMLP
+from avalanche.training.strategies import Naive
+from avalanche.training.plugins import EvaluationPlugin, ReplayPlugin
+from avalanche.evaluation.metrics import StreamConfusionMatrix, \
+    accuracy_metrics, loss_metrics
+from avalanche.logging import InteractiveLogger
+
+def main(args):
+    # --- CONFIG
+    device = torch.device(f"cuda:{args.cuda}"
+                          if torch.cuda.is_available() and
+                          args.cuda >= 0 else "cpu")
+    # ---------
+
+    # --- TRANSFORMATIONS
+    train_transform = transforms.Compose([
+        RandomCrop(28, padding=4),
+        ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+    test_transform = transforms.Compose([
+        ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+    # ---------
+
+    # --- SCENARIO CREATION
+    mnist_train = MNIST('./data/mnist', train=True,
+                        download=True, transform=train_transform)
+    mnist_test = MNIST('./data/mnist', train=False,
+                       download=True, transform=test_transform)
+    scenario = nc_scenario(
+        mnist_train, mnist_test, 5, task_labels=False, seed=1234)
+    # ---------
+
+    # MODEL CREATION
+    model = SimpleMLP(num_classes=scenario.n_classes)
+
+    eval_plugin = EvaluationPlugin(
+        accuracy_metrics(epoch=True, step=True, stream=True),
+        loss_metrics(epoch=True, step=True, stream=True),
+        # save image should be False to appropriately view
+        # results in Interactive Logger.
+        # a tensor will be printed
+        StreamConfusionMatrix(save_image=False, normalize='all'),
+        loggers=InteractiveLogger()
+    )
+
+    # CREATE THE STRATEGY INSTANCE (NAIVE)
+    cl_strategy = Naive(
+        model, SGD(model.parameters(), lr=0.001, momentum=0.9),
+        CrossEntropyLoss(), train_mb_size=100, train_epochs=4, eval_mb_size=100,
+        device=device, evaluator=eval_plugin, plugins=[ReplayPlugin(5000)])
+
+    # TRAINING LOOP
+    print('Starting experiment...')
+    results = []
+    for step in scenario.train_stream:
+        print("Start of step: ", step.current_step)
+        print("Current Classes: ", step.classes_in_this_step)
+
+        cl_strategy.train(step)
+        print('Training completed')
+
+        print('Computing accuracy on the whole test set')
+        results.append(cl_strategy.eval(scenario.test_stream))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--cuda', type=int, default=0,
+                        help='Select zero-indexed cuda device. -1 to use CPU.')
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
This PR adds the `StreamConfusionMatrix` metric and a related example.
This metric is supported only at eval time, as for losses and accuracies on `Stream`.

We could also provide a `EpochConfusionMatrix` in the future.

Currently, the user has to disable `save_image` when creating the metric to be able to see the output in the `InteractiveLogger`.

Tests passed locally :grin: 