### PR TITLE
Added MAC metric

### DIFF
--- a/avalanche/evaluation/metrics/accuracy.py
+++ b/avalanche/evaluation/metrics/accuracy.py
@@ -9,7 +9,6 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from collections import defaultdict
 from typing import TYPE_CHECKING, List
 
 import torch

--- a/avalanche/evaluation/metrics/forgetting.py
+++ b/avalanche/evaluation/metrics/forgetting.py
@@ -9,7 +9,7 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
 
 from torch import Tensor
 

--- a/avalanche/evaluation/metrics/loss.py
+++ b/avalanche/evaluation/metrics/loss.py
@@ -9,7 +9,6 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from collections import defaultdict
 from typing import TYPE_CHECKING, List
 
 import torch

--- a/avalanche/evaluation/metrics/mac.py
+++ b/avalanche/evaluation/metrics/mac.py
@@ -9,12 +9,17 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from typing import Optional
-
-from torch import Tensor
 from torch.nn import Module
+from typing import TYPE_CHECKING, List, Optional
+from torch import Tensor
 
-from avalanche.evaluation import Metric
+from avalanche.evaluation import Metric, PluginMetric
+from avalanche.evaluation.metric_results import MetricValue, MetricResult
+from avalanche.evaluation.metric_utils import get_metric_name, \
+    phase_and_task, stream_type
+
+if TYPE_CHECKING:
+    from avalanche.training.plugins import PluggableStrategy
 
 
 class MAC(Metric[int]):
@@ -37,7 +42,7 @@ class MAC(Metric[int]):
 
         :param model: current model.
         :param dummy_input: A tensor of the correct size to feed as input
-            to model.
+            to model. It includes batch size
         :return: MAC metric.
         """
 
@@ -80,6 +85,170 @@ class MAC(Metric[int]):
         return modname == 'Linear' or modname == 'Conv2d'
 
 
+class MinibatchMAC(PluginMetric[float]):
+    """
+    The minibatch MAC metric.
+    This metric only works at training time.
+
+    This metric computes the MAC over 1 pattern
+    from a single minibatch.
+    It reports the result after each iteration.
+
+    If a more coarse-grained logging is needed, consider using
+    :class:`EpochMAC` instead.
+    """
+
+    def __init__(self):
+        """
+        Creates an instance of the MinibatchMAC metric.
+        """
+
+        super().__init__()
+
+        self._minibatch_MAC = MAC()
+
+    def reset(self) -> None:
+        pass
+
+    def result(self) -> float:
+        return self._minibatch_MAC.result()
+
+    def after_training_iteration(self, strategy: 'PluggableStrategy') \
+            -> MetricResult:
+        self._minibatch_MAC.update(strategy.model,
+                                   strategy.mb_x[0].unsqueeze(0))
+        return self._package_result(strategy)
+
+    def _package_result(self, strategy: 'PluggableStrategy') -> MetricResult:
+        metric_value = self.result()
+
+        metric_name = get_metric_name(self, strategy)
+        plot_x_position = self._next_x_position(metric_name)
+
+        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+
+    def __str__(self):
+        return "MAC_MB"
+
+
+class EpochMAC(PluginMetric[float]):
+    """
+    The MAC at the end of each epoch computed on a
+    single pattern.
+    This metric only works at training time.
+
+    The MAC will be logged after each training epoch.
+    """
+
+    def __init__(self):
+        """
+        Creates an instance of the EpochMAC metric.
+        """
+        super().__init__()
+
+        self._MAC_metric = MAC()
+
+    def reset(self) -> None:
+        pass
+
+    def result(self) -> float:
+        return self._MAC_metric.result()
+
+    def after_training_epoch(self, strategy: 'PluggableStrategy') \
+            -> MetricResult:
+        self._MAC_metric.update(strategy.model,
+                                strategy.mb_x[0].unsqueeze(0))
+        return self._package_result(strategy)
+
+    def _package_result(self, strategy: 'PluggableStrategy') -> MetricResult:
+        metric_value = self.result()
+
+        metric_name = get_metric_name(self, strategy)
+        plot_x_position = self._next_x_position(metric_name)
+
+        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+
+    def __str__(self):
+        return "MAC_Epoch"
+
+
+class StreamMAC(PluginMetric[float]):
+    """
+    At the end of the entire stream of experiences, this metric reports the
+    MAC computed on a single pattern.
+    This metric only works at eval time.
+    """
+
+    def __init__(self):
+        """
+        Creates an instance of StreamMAC metric
+        """
+        super().__init__()
+
+        self._MAC_metric = MAC()
+
+    def reset(self) -> None:
+        pass
+
+    def result(self) -> float:
+        return self._MAC_metric.result()
+
+    def after_eval(self, strategy: 'PluggableStrategy') -> \
+            'MetricResult':
+        self._MAC_metric.update(strategy.model,
+                                strategy.mb_x[0].unsqueeze(0))
+        return self._package_result(strategy)
+
+    def _package_result(self, strategy: 'PluggableStrategy') -> \
+            MetricResult:
+        metric_value = self.result()
+
+        phase_name, _ = phase_and_task(strategy)
+        stream = stream_type(strategy.experience)
+        metric_name = '{}/{}_phase/{}_stream' \
+            .format(str(self),
+                    phase_name,
+                    stream)
+        plot_x_position = self._next_x_position(metric_name)
+
+        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+
+    def __str__(self):
+        return "MAC_Stream"
+
+
+def MAC_metrics(*, minibatch=False, epoch=False,stream=False) \
+        -> List[PluginMetric]:
+    """
+    Helper method that can be used to obtain the desired set of metric.
+
+    :param minibatch: If True, will return a metric able to log
+        the MAC after each iteration at training time.
+    :param epoch: If True, will return a metric able to log
+        the MAC after each epoch at training time.
+    :param stream: If True, will return a metric able to log
+        the MAC after the evaluation stream.
+
+    :return: A list of plugin metrics.
+    """
+
+    metrics = []
+    if minibatch:
+        metrics.append(MinibatchMAC())
+
+    if epoch:
+        metrics.append(EpochMAC())
+
+    if stream:
+        metrics.append(StreamMAC())
+
+    return metrics
+
+
 __all__ = [
-    'MAC'
+    'MAC',
+    'MinibatchMAC',
+    'EpochMAC',
+    'StreamMAC',
+    'MAC_metrics'
 ]

--- a/examples/eval_plugin.py
+++ b/examples/eval_plugin.py
@@ -96,7 +96,7 @@ def main(args):
         disk_usage_metrics(
             minibatch=True, epoch=True, experience=True, stream=True),
         MAC_metrics(
-            minibatch=True, epoch=True, experience=True, stream=True),
+            minibatch=True, epoch=True, experience=True),
         loggers=[interactive_logger, text_logger])
 
 

--- a/examples/eval_plugin.py
+++ b/examples/eval_plugin.py
@@ -28,7 +28,7 @@ from torchvision.transforms import ToTensor, RandomCrop
 from avalanche.benchmarks import nc_scenario
 from avalanche.evaluation.metrics import ExperienceForgetting, \
     accuracy_metrics, loss_metrics, cpu_usage_metrics, timing_metrics, \
-    gpu_usage_metrics, ram_usage_metrics, disk_usage_metrics
+    gpu_usage_metrics, ram_usage_metrics, disk_usage_metrics, MAC_metrics
 from avalanche.models import SimpleMLP
 from avalanche.logging import InteractiveLogger, TextLogger
 from avalanche.training.plugins import EvaluationPlugin
@@ -88,11 +88,14 @@ def main(args):
         timing_metrics(
             minibatch=True, epoch=True, experience=True, stream=True),
         ram_usage_metrics(
-            minibatch=True, epoch=True, experience=True, stream=True),
+            every=0.5, minibatch=True, epoch=True, experience=True,
+            stream=True),
         gpu_usage_metrics(
-            args.cuda, minibatch=True, epoch=True, experience=True, stream=True),
+            args.cuda, every=0.5, minibatch=True, epoch=True,
+            experience=True, stream=True),
         disk_usage_metrics(
             minibatch=True, epoch=True, experience=True, stream=True),
+        MAC_metrics(minibatch=True, epoch=True, stream=True),
         loggers=[interactive_logger, text_logger])
 
 

--- a/examples/eval_plugin.py
+++ b/examples/eval_plugin.py
@@ -95,7 +95,8 @@ def main(args):
             experience=True, stream=True),
         disk_usage_metrics(
             minibatch=True, epoch=True, experience=True, stream=True),
-        MAC_metrics(minibatch=True, epoch=True, stream=True),
+        MAC_metrics(
+            minibatch=True, epoch=True, experience=True, stream=True),
         loggers=[interactive_logger, text_logger])
 
 


### PR DESCRIPTION
MAC metric is computed on a single pattern taken from the current minibatch.
It can be updated at the end of each training iteration, training epoch or at the end of each eval experience. This last option is needed because the model could use different components for each eval experience, so we need to provide a way to monitor also this case (this should reflect the MAC on the corresponding experience at training time).

This closes #338 