### PR TITLE
remove Experience attributes from BaseStrategy

### DIFF
--- a/avalanche/evaluation/metric_utils.py
+++ b/avalanche/evaluation/metric_utils.py
@@ -94,11 +94,7 @@ def get_task_label(strategy: 'PluggableStrategy') -> int:
     :param strategy: The strategy instance to get the task label from.
     :return: The current train or eval task label.
     """
-
-    if strategy.is_eval:
-        return strategy.eval_task_label
-
-    return strategy.train_task_label
+    return strategy.experience.task_label
 
 
 def stream_type(experience: 'Experience') -> str:
@@ -127,9 +123,9 @@ def phase_and_task(strategy: 'PluggableStrategy') -> Tuple[str, int]:
     """
 
     if strategy.is_eval:
-        return EVAL, strategy.eval_task_label
+        return EVAL, strategy.experience.task_label
 
-    return TRAIN, strategy.train_task_label
+    return TRAIN, strategy.experience.task_label
 
 
 def bytes2human(n):
@@ -171,9 +167,7 @@ def get_metric_name(metric: 'PluginMetric',
     phase_name, task_label = phase_and_task(strategy)
     stream = stream_type(strategy.experience)
     if add_experience:
-
-        experience_label = strategy.eval_exp_id if phase_name == EVAL \
-            else strategy.training_exp_counter
+        experience_label = strategy.experience.current_experience
         metric_name = '{}/{}_phase/{}_stream/Task{:03}/Exp{:03}' \
             .format(str(metric),
                     phase_name,
@@ -196,4 +190,4 @@ __all__ = [
     'phase_and_task',
     'stream_type',
     'bytes2human',
-    'get_metric_name']
+    '  ']

--- a/avalanche/evaluation/metrics/forgetting.py
+++ b/avalanche/evaluation/metrics/forgetting.py
@@ -101,10 +101,10 @@ class ExperienceForgetting(PluginMetric[Dict[int, float]]):
         self.reset_current_accuracy()
 
     def before_eval_exp(self, strategy: 'PluggableStrategy') -> None:
-        self.eval_exp_id = strategy.eval_exp_id
+        self.eval_exp_id = strategy.experience.current_experience
 
     def after_eval_iteration(self, strategy: 'PluggableStrategy') -> None:
-        label = strategy.eval_exp_id
+        label = strategy.experience.current_experience
         self.update(strategy.mb_y,
                     strategy.logits,
                     label)

--- a/avalanche/logging/text_logging.py
+++ b/avalanche/logging/text_logging.py
@@ -95,8 +95,9 @@ class TextLogger(StrategyLogger):
     def after_eval_exp(self, strategy: 'PluggableStrategy',
                        metric_values: List['MetricValue'], **kwargs):
         super().after_eval_exp(strategy, metric_values, **kwargs)
-        print(f'> Eval on experience {strategy.eval_exp_id} (Task '
-              f'{strategy.eval_task_label}) '
+        exp_id = strategy.experience.current_experience
+        print(f'> Eval on experience {exp_id} (Task '
+              f'{strategy.experience.task_label}) '
               f'from {stream_type(strategy.experience)} stream ended.',
               file=self.file, flush=True)
         self.print_current_metrics()
@@ -127,9 +128,8 @@ class TextLogger(StrategyLogger):
     def _on_exp_start(self, strategy: 'PluggableStrategy'):
         action_name = 'training' if strategy.is_training else 'eval'
         exp_id = strategy.training_exp_counter if strategy.is_training \
-            else strategy.eval_exp_id
-        task_id = strategy.train_task_label if strategy.is_training \
-            else strategy.eval_task_label
+            else strategy.experience.current_experience
+        task_id = strategy.experience.task_label
         stream = stream_type(strategy.experience)
         print('-- Starting {} on experience {} (Task {}) from {} stream --'
               .format(action_name, exp_id, task_id, stream), file=self.file,

--- a/avalanche/training/strategies/base_strategy.py
+++ b/avalanche/training/strategies/base_strategy.py
@@ -21,6 +21,7 @@ from avalanche.logging import default_logger
 from typing import TYPE_CHECKING
 
 from avalanche.training.plugins import EvaluationPlugin
+
 if TYPE_CHECKING:
     from avalanche.training.plugins import StrategyPlugin
 
@@ -231,7 +232,8 @@ class BaseStrategy:
 
     def train(self, experiences: Union[Experience, Sequence[Experience]],
               eval_streams: Optional[Sequence[Union[Experience,
-                                Sequence[Experience]]]] = None,
+                                                    Sequence[
+                                                        Experience]]]] = None,
               **kwargs):
         """ Training loop. if experiences is a single element trains on it.
         If it is a sequence, trains the model on each experience in order.


### PR DESCRIPTION
I removed experience attributes (`task_label`, `eval_label`, ...) from the `BaseStrategy`. They can still be used through `strategy.experience`. I removed them because they are more confusing than helpful. In fact, there was a small bug in the text logger because of this, where it was printing the training exp counter instead of the current experience id.