### PR TITLE
Added general metric Forgetting, improved documentation and tests

### DIFF
--- a/avalanche/benchmarks/scenarios/generic_definitions.py
+++ b/avalanche/benchmarks/scenarios/generic_definitions.py
@@ -24,8 +24,8 @@ from avalanche.benchmarks.utils import AvalancheDataset
 TrainSet = TypeVar('TrainSet', bound=AvalancheDataset)
 TestSet = TypeVar('TestSet', bound=AvalancheDataset)
 TScenario = TypeVar('TScenario')
-TExperience = TypeVar('TExperience', bound='IExperience')
-TScenarioStream = TypeVar('TScenarioStream', bound='IScenarioStream')
+TExperience = TypeVar('TExperience', bound='Experience')
+TScenarioStream = TypeVar('TScenarioStream', bound='ScenarioStream')
 
 
 @runtime_checkable

--- a/avalanche/evaluation/metrics/forgetting.py
+++ b/avalanche/evaluation/metrics/forgetting.py
@@ -9,11 +9,9 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING, Union
 
-from torch import Tensor
-
-from avalanche.evaluation.metric_definitions import PluginMetric
+from avalanche.evaluation.metric_definitions import Metric, PluginMetric
 from avalanche.evaluation.metric_results import MetricValue, MetricResult
 from avalanche.evaluation.metrics import Accuracy
 from avalanche.evaluation.metric_utils import get_metric_name
@@ -22,10 +20,92 @@ if TYPE_CHECKING:
     from avalanche.training.plugins import PluggableStrategy
 
 
+class Forgetting(Metric[Union[float, None, Dict[int, float]]]):
+    """
+    The Forgetting metric.
+    This metric returns the forgetting relative to a specific key.
+    Alternatively, this metric returns a dict in which each key is associated
+    to the forgetting.
+    Forgetting is computed as the difference between the first value recorded
+    for a specific key and the last value recorded for that key.
+    The value associated to a key can be update with the `update` method.
+
+    At initialization, this metric returns an empty dictionary.
+    """
+
+    def __init__(self):
+        """
+        Creates an instance of the Forgetting metric
+        """
+
+        super().__init__()
+
+        self._initial: Dict[int, float] = dict()
+        """
+        The initial value for each key.
+        """
+
+        self._last: Dict[int, float] = dict()
+        """
+        The last value detected for each key
+        """
+
+    def update_initial(self, k, v):
+        self._initial[k] = v
+
+    def update_last(self, k, v):
+        self._last[k] = v
+
+    def update(self, k, v):
+        if k not in self._initial:
+            self.update_initial(k, v)
+        else:
+            self.update_last(k, v)
+
+    def result(self, k=None) -> Union[float, None, Dict[int, float]]:
+        """
+        Forgetting is returned only for keys encountered twice.
+
+        :param k: the key for which returning forgetting. If k has not
+            updated at least twice it returns None. If k is None,
+            forgetting will be returned for all keys encountered at least
+            twice.
+
+        :return: the difference between the first and last value encountered
+            for k, if k is not None. It returns None if k has not been updated
+            at least twice. If k is None, returns a dictionary
+            containing keys whose value has been updated at least twice. The
+            associated value is the difference between the first and last
+            value recorded for that key.
+        """
+
+        forgetting = {}
+        if k is not None:
+            if k in self._initial and k in self._last:
+                return self._initial[k] - self._last[k]
+            else:
+                return None
+
+        ik = set(self._initial.keys())
+        both_keys = list(ik.intersection(set(self._last.keys())))
+
+        for k in both_keys:
+            forgetting[k] = self._initial[k] - self._last[k]
+
+        return forgetting
+
+    def reset_last(self) -> None:
+        self._last: Dict[int, float] = dict()
+
+    def reset(self) -> None:
+        self._initial: Dict[int, float] = dict()
+        self._last: Dict[int, float] = dict()
+
+
 class ExperienceForgetting(PluginMetric[Dict[int, float]]):
     """
-    The Forgetting metric, describing the accuracy loss detected for a
-    certain experience.
+    The ExperienceForgetting metric, describing the accuracy loss
+    detected for a certain experience.
 
     This metric, computed separately for each experience,
     is the difference between the accuracy result obtained after
@@ -42,14 +122,14 @@ class ExperienceForgetting(PluginMetric[Dict[int, float]]):
 
         super().__init__()
 
-        self._initial_accuracy: Dict[int, float] = dict()
+        self.forgetting = Forgetting()
         """
-        The initial accuracy of each experience.
+        The general metric to compute forgetting
         """
 
-        self._current_accuracy: Dict[int, Accuracy] = dict()
+        self._last_accuracy = Accuracy()
         """
-        The current accuracy of each experience.
+        The average accuracy over the current evaluation experience
         """
 
         self.eval_exp_id = None
@@ -71,94 +151,53 @@ class ExperienceForgetting(PluginMetric[Dict[int, float]]):
 
         :return: None.
         """
-        self._initial_accuracy = dict()
-        self._current_accuracy = dict()
+        self.forgetting.reset()
 
-    def reset_current_accuracy(self) -> None:
+    def reset_last_accuracy(self) -> None:
         """
-        Resets the current accuracy.
+        Resets the last accuracy.
 
         This will preserve the initial accuracy value of each experience.
         To be used at the beginning of each eval experience.
 
         :return: None.
         """
-        self._current_accuracy = dict()
+        self.forgetting.reset_last()
 
-    def update(self, true_y: Tensor, predicted_y: Tensor, label: int) \
-            -> None:
+    def result(self, k=None) -> Union[float, None, Dict[int, float]]:
         """
-        Updates the running accuracy of a experience given the ground truth and
-        predicted labels of a minibatch.
+        See `Forgetting` documentation for more detailed information.
 
-        :param true_y: The ground truth. Both labels and one-hot vectors
-            are supported.
-        :param predicted_y: The ground truth. Both labels and logit vectors
-            are supported.
-        :param label: The experience label.
-        :return: None.
+        k: optional key from which compute forgetting.
         """
-        if label not in self._current_accuracy:
-            self._current_accuracy[label] = Accuracy()
-        self._current_accuracy[label].update(true_y, predicted_y)
-
-    def before_training_exp(self, strategy: 'PluggableStrategy') -> None:
-        self.train_exp_id = strategy.experience.current_experience
+        return self.forgetting.result(k=k)
 
     def before_eval(self, strategy) -> None:
-        self.reset_current_accuracy()
+        self.reset_last_accuracy()
+
+    def before_eval_exp(self, strategy: 'PluggableStrategy') -> None:
+        self._last_accuracy.reset()
 
     def after_eval_iteration(self, strategy: 'PluggableStrategy') -> None:
         self.eval_exp_id = strategy.experience.current_experience
-        self.update(strategy.mb_y,
-                    strategy.logits,
-                    self.eval_exp_id)
+        self._last_accuracy.update(strategy.mb_y,
+                                   strategy.logits)
 
     def after_eval_exp(self, strategy: 'PluggableStrategy') \
             -> MetricResult:
-        # eval experience never encountered during training
-        # or eval experience is the current training experience
-        # forgetting not reported in both cases
-        if self.eval_exp_id not in self._initial_accuracy:
-            train_label = self.train_exp_id
-            # the test accuracy on the training experience we have just
-            # trained on. This is the initial accuracy.
-            if train_label not in self._initial_accuracy:
-                self._initial_accuracy[train_label] = \
-                    self._current_accuracy[train_label].result()
-            return None
+        self.forgetting.update(self.eval_exp_id, self._last_accuracy.result())
 
-        # eval experience previously encountered during training
-        # which is not the most recent training experience
-        # return forgetting
-        return self._package_result(strategy)
-
-    def result(self) -> float:
-        """
-        Return the amount of forgetting for the eval experience
-        associated to `eval_label`.
-
-        The forgetting is computed as the accuracy difference between the
-        initial experience accuracy (when first encountered
-        in the training stream) and the current accuracy.
-        A positive value means that forgetting occurred. A negative value
-        means that the accuracy on that experience increased.
-
-        :param eval_label: integer label describing the eval experience
-                of which measuring the forgetting
-        :return: The amount of forgetting on `eval_exp` experience
-                 (as float in range [-1, 1]).
-        """
-
-        prev_accuracy: float = self._initial_accuracy[self.eval_exp_id]
-        accuracy: Accuracy = self._current_accuracy[self.eval_exp_id]
-        forgetting = prev_accuracy - accuracy.result()
-        return forgetting
+        # this checks if the evaluation experience has been
+        # already encountered at training time
+        # before the last training.
+        # If not, forgetting should not be returned.
+        if self.result(k=self.eval_exp_id) is not None:
+            return self._package_result(strategy)
 
     def _package_result(self, strategy: 'PluggableStrategy') \
             -> MetricResult:
 
-        forgetting = self.result()
+        forgetting = self.result(k=self.eval_exp_id)
         metric_name = get_metric_name(self, strategy, add_experience=True)
         plot_x_position = self._next_x_position(metric_name)
 
@@ -170,4 +209,7 @@ class ExperienceForgetting(PluginMetric[Dict[int, float]]):
         return "ExperienceForgetting"
 
 
-__all__ = ['ExperienceForgetting']
+__all__ = [
+    'Forgetting',
+    'ExperienceForgetting'
+]

--- a/avalanche/evaluation/metrics/gpu_usage.py
+++ b/avalanche/evaluation/metrics/gpu_usage.py
@@ -31,8 +31,8 @@ class MaxGPU(Metric[float]):
      usage since it sample at discrete amount of time the GPU values.
 
     Instances of this metric keeps the maximum GPU usage percentage detected.
-    The `start_thread` method starts the usage tracking. The `stop_thread` method stops
-    the tracking.
+    The `start_thread` method starts the usage tracking.
+    The `stop_thread` method stops the tracking.
 
     The result, obtained using the `result` method, is the usage in mega-bytes.
 

--- a/avalanche/evaluation/metrics/gpu_usage.py
+++ b/avalanche/evaluation/metrics/gpu_usage.py
@@ -31,7 +31,7 @@ class MaxGPU(Metric[float]):
      usage since it sample at discrete amount of time the GPU values.
 
     Instances of this metric keeps the maximum GPU usage percentage detected.
-    The update method starts the usage tracking. The reset method stops
+    The `start_thread` method starts the usage tracking. The `stop_thread` method stops
     the tracking.
 
     The result, obtained using the `result` method, is the usage in mega-bytes.

--- a/avalanche/evaluation/metrics/mac.py
+++ b/avalanche/evaluation/metrics/mac.py
@@ -34,7 +34,7 @@ class MAC(Metric[int]):
         Creates an instance of the MAC metric.
         """
         self.hooks = []
-        self._compute_cost: Optional[int] = None
+        self._compute_cost: Optional[int] = 0
 
     def update(self, model: Module, dummy_input: Tensor):
         """

--- a/avalanche/evaluation/metrics/ram_usage.py
+++ b/avalanche/evaluation/metrics/ram_usage.py
@@ -31,7 +31,7 @@ class MaxRAM(Metric[float]):
     it sample at discrete amount of time the RAM values.
 
     Instances of this metric keeps the maximum RAM usage detected.
-    The update method starts the usage tracking. The reset method stops
+    The `start_thread` method starts the usage tracking. The `stop_thread` method stops
     the tracking.
 
     The result, obtained using the `result` method, is the usage in mega-bytes.

--- a/avalanche/evaluation/metrics/ram_usage.py
+++ b/avalanche/evaluation/metrics/ram_usage.py
@@ -31,8 +31,8 @@ class MaxRAM(Metric[float]):
     it sample at discrete amount of time the RAM values.
 
     Instances of this metric keeps the maximum RAM usage detected.
-    The `start_thread` method starts the usage tracking. The `stop_thread` method stops
-    the tracking.
+    The `start_thread` method starts the usage tracking.
+    The `stop_thread` method stops the tracking.
 
     The result, obtained using the `result` method, is the usage in mega-bytes.
 

--- a/avalanche/evaluation/metrics/timing.py
+++ b/avalanche/evaluation/metrics/timing.py
@@ -41,7 +41,7 @@ class ElapsedTime(Metric[float]):
     """
     def __init__(self):
         """
-        Creates an instance of the accuracy metric.
+        Creates an instance of the ElapsedTime metric.
 
         This metric in its initial state (or if the `update` method was invoked
         only once) will return an elapsed time of 0. The metric can be updated

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -56,7 +56,6 @@ class GeneralMetricTests(unittest.TestCase):
         metric.update(self.y, self.out)
         cm = metric.result()
         self.assertTrue((cm >= 0).all().item())
-        self.assertTrue((cm <= 1).all().item())
         metric.reset()
         cm = metric.result()
         self.assertTrue((cm == 0).all().item())

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -135,7 +135,7 @@ class GeneralMetricTests(unittest.TestCase):
         self.assertEqual(f, {})
         f = metric.result(k=0)
         self.assertIsNone(f)
-        metric.update(0, 1)
+        metric.update(0, 1, initial=True)
         f = metric.result(k=0)
         self.assertIsNone(f)
         metric.update(0, 0.4)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -11,10 +11,144 @@ from torch import nn
 
 from avalanche.evaluation import PluginMetric
 from avalanche.evaluation.metrics import Accuracy, Loss, ConfusionMatrix, \
-    DiskUsage, MAC, accuracy_metrics, loss_metrics
-from avalanche.evaluation.metrics.cpu_usage import CPUUsage, cpu_usage_metrics
-from avalanche.evaluation.metrics.ram_usage import MaxRAM
+    DiskUsage, MAC, CPUUsage, MaxGPU, MaxRAM, Mean, Sum, ElapsedTime, Forgetting
+from avalanche.evaluation.metrics import accuracy_metrics, loss_metrics, StreamConfusionMatrix, \
+    disk_usage_metrics, MAC_metrics, cpu_usage_metrics, gpu_usage_metrics, ram_usage_metrics, \
+    timing_metrics
 from tests.unit_tests_utils import common_setups
+
+
+#################################
+#################################
+##### GENERAL METRIC TEST #######
+#################################
+#################################
+
+class GeneralMetricTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.batch_size = 3
+        self.input_size = 10
+        self.n_classes = 3
+        self.out = torch.randn(self.batch_size, self.input_size)
+        self.y = torch.randint(0, self.n_classes, (self.batch_size,))
+
+    def test_accuracy(self):
+        metric = Accuracy()
+        self.assertEqual(metric.result(), 0)
+        metric.update(self.out, self.y)
+        self.assertLessEqual(metric.result(), 1)
+        self.assertGreaterEqual(metric.result(), 0)
+        metric.reset()
+        self.assertEqual(metric.result(), 0)
+
+    def test_loss(self):
+        metric = Loss()
+        self.assertEqual(metric.result(), 0)
+        metric.update(torch.tensor(1.), self.batch_size)
+        self.assertGreaterEqual(metric.result(), 0)
+        metric.reset()
+        self.assertEqual(metric.result(), 0)
+
+    def test_cm(self):
+        metric = ConfusionMatrix()
+        cm = metric.result()
+        self.assertTrue((cm == 0).all().item())
+        metric.update(self.y, self.out)
+        cm = metric.result()
+        self.assertTrue((cm >= 0).all().item())
+        self.assertTrue((cm <= 1).all().item())
+        metric.reset()
+        cm = metric.result()
+        self.assertTrue((cm == 0).all().item())
+
+    def test_ram(self):
+        metric = MaxRAM()
+        self.assertEqual(metric.result(), 0)
+        metric.start_thread()  # start thread
+        self.assertGreaterEqual(metric.result(), 0)
+        metric.stop_thread() # stop thread
+        metric.reset()  # stop thread
+        self.assertEqual(metric.result(), 0)
+
+    def test_gpu(self):
+        if torch.cuda.is_available():
+            metric = MaxGPU(0)
+            self.assertEqual(metric.result(), 0)
+            metric.start_thread()  # start thread
+            self.assertGreaterEqual(metric.result(), 0)
+            metric.stop_thread() # stop thread
+            metric.reset()  # stop thread
+            self.assertEqual(metric.result(), 0)
+
+    def test_cpu(self):
+        metric = CPUUsage()
+        self.assertEqual(metric.result(), 0)
+        metric.update()
+        self.assertGreaterEqual(metric.result(), 0)
+        metric.reset()
+        self.assertEqual(metric.result(), 0)
+
+    def test_disk(self):
+        metric = DiskUsage()
+        self.assertEqual(metric.result(), 0)
+        metric.update()
+        self.assertGreaterEqual(metric.result(), 0)
+        metric.reset()
+        self.assertEqual(metric.result(), 0)
+
+    def test_timing(self):
+        metric = ElapsedTime()
+        self.assertEqual(metric.result(), 0)
+        metric.update()  # need two update calls
+        self.assertEqual(metric.result(), 0)
+        metric.update()
+        self.assertGreaterEqual(metric.result(), 0)
+        metric.reset()
+        self.assertEqual(metric.result(), 0)
+
+    def test_mac(self):
+        model = torch.nn.Linear(self.input_size, 2)
+        metric = MAC()
+        self.assertEqual(metric.result(), 0)
+        metric.update(model, self.out)
+        self.assertGreaterEqual(metric.result(), 0)
+
+    def test_mean(self):
+        metric = Mean()
+        self.assertEqual(metric.result(), 0)
+        metric.update(0.1, 1)
+        self.assertEqual(metric.result(), 0.1)
+        metric.reset()
+        self.assertEqual(metric.result(), 0)
+
+    def test_sum(self):
+        metric = Sum()
+        self.assertEqual(metric.result(), 0)
+        metric.update(5)
+        self.assertEqual(metric.result(), 5)
+        metric.reset()
+        self.assertEqual(metric.result(), 0)
+
+    def test_forgetting(self):
+        metric = Forgetting()
+        f = metric.result()
+        self.assertEqual(f, {})
+        f = metric.result(k=0)
+        self.assertIsNone(f)
+        metric.update(0, 1)
+        f = metric.result(k=0)
+        self.assertIsNone(f)
+        metric.update(0, 0.4)
+        f = metric.result(k=0)
+        self.assertEqual(f, 0.6)
+        metric.reset()
+        self.assertEqual(metric.result(), {})
+
+#################################
+#################################
+### FINE GRAINED METRIC TEST ####
+#################################
+#################################
 
 
 class MACMetricTests(unittest.TestCase):


### PR DESCRIPTION
`ExperienceForgetting` was the only metric without a general metric. I implemented `Forgetting` to be used as off-the-shelf general metric and updated `ExperienceForgetting` accordingly.

I updated tests to test general metrics. I still have to write tests for the plugin metrics, which are a bit more complex since they require integration with the training and evaluation loops.