### PR TITLE
Added standalone and plugin metric name into API doc

### DIFF
--- a/avalanche/evaluation/metric_definitions.py
+++ b/avalanche/evaluation/metric_definitions.py
@@ -26,9 +26,9 @@ TAggregated = TypeVar('TAggregated', bound='PluginMetric')
 
 class Metric(Protocol[TResult]):
     """
-    Definition of a metric.
+    Definition of a standalone metric.
 
-    A metric exposes methods to reset its internal state and
+    A standalone metric exposes methods to reset its internal state and
     to emit a result. Emitting a result does not automatically cause
     a reset in the internal state.
 
@@ -36,7 +36,7 @@ class Metric(Protocol[TResult]):
     state. Usually, standalone metrics like :class:`Sum`, :class:`Mean`,
     :class:`Accuracy`, ... expose an `update` method.
 
-    The `Metric` class can be used as a stand-alone metric by directly calling
+    The `Metric` class can be used as a standalone metric by directly calling
     its methods.
     In order to automatically integrate the metric with the training and
     evaluation flows, you can use :class:`PluginMetric` class. The class

--- a/avalanche/evaluation/metrics/__init__.py
+++ b/avalanche/evaluation/metrics/__init__.py
@@ -1,8 +1,8 @@
 """
 The :py:mod:`metrics` module provides a set of already
-implemented metrics, ready to be used both stand-alone
+implemented metrics, ready to be used both standalone
 and together with the `EvaluationPlugin`.
-To use a stand-alone metric, please use the class which
+To use a standalone metric, please use the class which
 inherits from `Metric` and manually call the appropriate
 `update`, `reset` and 'result` method.
 To automatically monitor metrics during training and evaluation

--- a/avalanche/evaluation/metrics/accuracy.py
+++ b/avalanche/evaluation/metrics/accuracy.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 class Accuracy(Metric[float]):
     """
-    The Accuracy metric. This is a general metric
+    The Accuracy metric. This is a standalone metric
     used to compute more specific ones.
 
     Instances of this metric keeps the running average accuracy
@@ -44,7 +44,7 @@ class Accuracy(Metric[float]):
 
     def __init__(self):
         """
-        Creates an instance of the Accuracy metric.
+        Creates an instance of the standalone Accuracy metric.
 
         By default this metric in its initial state will return an accuracy
         value of 0. The metric can be updated by using the `update` method
@@ -109,7 +109,7 @@ class Accuracy(Metric[float]):
 
 class MinibatchAccuracy(PluginMetric[float]):
     """
-    The minibatch accuracy metric.
+    The minibatch plugin accuracy metric.
     This metric only works at training time.
 
     This metric computes the average accuracy over patterns
@@ -157,7 +157,7 @@ class MinibatchAccuracy(PluginMetric[float]):
 class EpochAccuracy(PluginMetric[float]):
     """
     The average accuracy over a single training epoch.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     The accuracy will be logged after each training epoch by computing
     the number of correctly predicted patterns during the epoch divided by
@@ -205,7 +205,7 @@ class RunningEpochAccuracy(EpochAccuracy):
     """
     The average accuracy across all minibatches up to the current
     epoch iteration.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     At each iteration, this metric logs the accuracy averaged over all patterns
     seen so far in the current epoch.
@@ -243,7 +243,7 @@ class RunningEpochAccuracy(EpochAccuracy):
 
 class ExperienceAccuracy(PluginMetric[float]):
     """
-    At the end of each experience, this metric reports
+    At the end of each experience, this plugin metric reports
     the average accuracy over all patterns seen in that experience.
     This metric only works at eval time.
     """
@@ -289,8 +289,8 @@ class ExperienceAccuracy(PluginMetric[float]):
 
 class StreamAccuracy(PluginMetric[float]):
     """
-    At the end of the entire stream of experiences, this metric reports the
-    average accuracy over all patterns seen in all experiences.
+    At the end of the entire stream of experiences, this plugin metric
+    reports the average accuracy over all patterns seen in all experiences.
     This metric only works at eval time.
     """
 
@@ -340,7 +340,8 @@ class StreamAccuracy(PluginMetric[float]):
 def accuracy_metrics(*, minibatch=False, epoch=False, epoch_running=False,
                      experience=False, stream=False) -> List[PluginMetric]:
     """
-    Helper method that can be used to obtain the desired set of metric.
+    Helper method that can be used to obtain the desired set of
+    plugin metrics.
 
     :param minibatch: If True, will return a metric able to log
         the minibatch accuracy at training time.

--- a/avalanche/evaluation/metrics/confusion_matrix.py
+++ b/avalanche/evaluation/metrics/confusion_matrix.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 class ConfusionMatrix(Metric[Tensor]):
     """
-    The confusion matrix metric.
+    The standalone confusion matrix metric.
 
     Instances of this metric keep track of the confusion matrix by receiving a
     pair of "ground truth" and "prediction" Tensors describing the labels of a
@@ -52,7 +52,7 @@ class ConfusionMatrix(Metric[Tensor]):
 
     def __init__(self, num_classes: int = None):
         """
-        Creates an instance of the confusion matrix metric.
+        Creates an instance of the standalone confusion matrix metric.
 
         By default this metric in its initial state will return an empty Tensor.
         The metric can be updated by using the `update` method while the running
@@ -161,7 +161,7 @@ class ConfusionMatrix(Metric[Tensor]):
 class StreamConfusionMatrix(PluginMetric[Tensor]):
     """
     The Stream Confusion Matrix metric.
-    This metric only works on the eval phase.
+    This plugin metric only works on the eval phase.
 
     At the end of the eval phase, this metric logs the confusion matrix
     relative to all the patterns seen during eval.

--- a/avalanche/evaluation/metrics/cpu_usage.py
+++ b/avalanche/evaluation/metrics/cpu_usage.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 class CPUUsage(Metric[float]):
     """
-    The CPU usage metric.
+    The standalone CPU usage metric.
 
     Instances of this metric compute the average CPU usage as a float value.
     The metric starts tracking the CPU usage when the `update` method is called
@@ -46,7 +46,7 @@ class CPUUsage(Metric[float]):
 
     def __init__(self):
         """
-        Creates an instance of the CPU usage metric.
+        Creates an instance of the standalone CPU usage metric.
 
         By default this metric in its initial state will return a CPU usage
         value of 0. The metric can be updated by using the `update` method
@@ -122,7 +122,7 @@ class CPUUsage(Metric[float]):
 class MinibatchCPUUsage(PluginMetric[float]):
     """
     The minibatch CPU usage metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     This metric "logs" the CPU usage for each iteration.
 
@@ -169,7 +169,7 @@ class MinibatchCPUUsage(PluginMetric[float]):
 class EpochCPUUsage(PluginMetric[float]):
     """
     The Epoch CPU usage metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     The average usage will be logged after each epoch.
     """
@@ -212,7 +212,7 @@ class EpochCPUUsage(PluginMetric[float]):
 class RunningEpochCPUUsage(PluginMetric[float]):
     """
     The running epoch CPU usage metric.
-    This metric only works at training time
+    This plugin metric only works at training time
 
     After each iteration, the metric logs the average CPU usage up
     to the current epoch iteration.
@@ -265,7 +265,7 @@ class RunningEpochCPUUsage(PluginMetric[float]):
 class ExperienceCPUUsage(PluginMetric[float]):
     """
     The average experience CPU usage metric.
-    This metric works only at eval time.
+    This plugin metric works only at eval time.
 
     After each experience, this metric emits the average CPU usage on that
     experienc.
@@ -308,7 +308,7 @@ class ExperienceCPUUsage(PluginMetric[float]):
 class StreamCPUUsage(PluginMetric[float]):
     """
     The average stream CPU usage metric.
-    This metric works only at eval time.
+    This plugin metric works only at eval time.
 
     After the entire evaluation stream, this metric emits
     the average CPU usage on all experiences.
@@ -356,7 +356,8 @@ class StreamCPUUsage(PluginMetric[float]):
 def cpu_usage_metrics(*, minibatch=False, epoch=False, epoch_running=False,
                       experience=False, stream=False) -> List[PluginMetric]:
     """
-    Helper method that can be used to obtain the desired set of metric.
+    Helper method that can be used to obtain the desired set of
+    plugin metrics.
 
     :param minibatch: If True, will return a metric able to log the minibatch
         CPU usage

--- a/avalanche/evaluation/metrics/disk_usage.py
+++ b/avalanche/evaluation/metrics/disk_usage.py
@@ -26,7 +26,7 @@ PathAlike = Union[Union[str, Path]]
 
 class DiskUsage(Metric[float]):
     """
-    The disk usage metric.
+    The standalone disk usage metric.
 
     This metric can be used to monitor the size of a set of directories.
     e.g. This can be useful to monitor the size of a replay buffer,
@@ -35,7 +35,7 @@ class DiskUsage(Metric[float]):
                  paths_to_monitor: Union[PathAlike, Sequence[PathAlike]] = None
                  ):
         """
-        Creates an instance of the disk usage metric.
+        Creates an instance of the standalone disk usage metric.
 
         The `result` method will return the sum of the size
         of the directories specified as the first parameter in KiloBytes.
@@ -104,7 +104,7 @@ class DiskUsage(Metric[float]):
 class MinibatchDiskUsage(PluginMetric[float]):
     """
     The minibatch Disk usage metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     At the end of each iteration, this metric logs the total
     size (in KB) of all the monitored paths.
@@ -151,7 +151,7 @@ class MinibatchDiskUsage(PluginMetric[float]):
 class EpochDiskUsage(PluginMetric[float]):
     """
     The Epoch Disk usage metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     At the end of each epoch, this metric logs the total
     size (in KB) of all the monitored paths.
@@ -194,7 +194,7 @@ class EpochDiskUsage(PluginMetric[float]):
 class ExperienceDiskUsage(PluginMetric[float]):
     """
     The average experience Disk usage metric.
-    This metric works only at eval time.
+    This plugin metric works only at eval time.
 
     At the end of each experience, this metric logs the total
     size (in KB) of all the monitored paths.
@@ -236,7 +236,7 @@ class ExperienceDiskUsage(PluginMetric[float]):
 class StreamDiskUsage(PluginMetric[float]):
     """
     The average stream Disk usage metric.
-    This metric works only at eval time.
+    This plugin metric works only at eval time.
 
     At the end of the eval stream, this metric logs the total
     size (in KB) of all the monitored paths.
@@ -284,7 +284,8 @@ def disk_usage_metrics(*, paths_to_monitor=None, minibatch=False, epoch=False,
                        experience=False, stream=False) \
         -> List[PluginMetric]:
     """
-    Helper method that can be used to obtain the desired set of metric.
+    Helper method that can be used to obtain the desired set of
+    standalone metrics.
 
     :param minibatch: If True, will return a metric able to log the minibatch
         Disk usage

--- a/avalanche/evaluation/metrics/forgetting.py
+++ b/avalanche/evaluation/metrics/forgetting.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 class Forgetting(Metric[Union[float, None, Dict[int, float]]]):
     """
-    The Forgetting metric.
+    The standalone Forgetting metric.
     This metric returns the forgetting relative to a specific key.
     Alternatively, this metric returns a dict in which each key is associated
     to the forgetting.
@@ -35,7 +35,7 @@ class Forgetting(Metric[Union[float, None, Dict[int, float]]]):
 
     def __init__(self):
         """
-        Creates an instance of the Forgetting metric
+        Creates an instance of the standalone Forgetting metric
         """
 
         super().__init__()
@@ -107,7 +107,7 @@ class ExperienceForgetting(PluginMetric[Dict[int, float]]):
     The ExperienceForgetting metric, describing the accuracy loss
     detected for a certain experience.
 
-    This metric, computed separately for each experience,
+    This plugin metric, computed separately for each experience,
     is the difference between the accuracy result obtained after
     first training on a experience and the accuracy result obtained
     on the same experience at the end of successive experiences.

--- a/avalanche/evaluation/metrics/gpu_usage.py
+++ b/avalanche/evaluation/metrics/gpu_usage.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 class MaxGPU(Metric[float]):
     """
-    The GPU usage metric.
+    The standalone GPU usage metric.
     Important: this metric approximates the real maximum GPU percentage
      usage since it sample at discrete amount of time the GPU values.
 
@@ -129,7 +129,7 @@ class MaxGPU(Metric[float]):
 class MinibatchMaxGPU(PluginMetric[float]):
     """
     The Minibatch Max GPU metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
     """
 
     def __init__(self, gpu_id, every=0.5):
@@ -180,7 +180,7 @@ class MinibatchMaxGPU(PluginMetric[float]):
 class EpochMaxGPU(PluginMetric[float]):
     """
     The Epoch Max GPU metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
     """
 
     def __init__(self, gpu_id, every=0.5):
@@ -231,7 +231,7 @@ class EpochMaxGPU(PluginMetric[float]):
 class ExperienceMaxGPU(PluginMetric[float]):
     """
     The Experience Max GPU metric.
-    This metric only works at eval time.
+    This plugin metric only works at eval time.
     """
 
     def __init__(self, gpu_id, every=0.5):
@@ -282,7 +282,7 @@ class ExperienceMaxGPU(PluginMetric[float]):
 class StreamMaxGPU(PluginMetric[float]):
     """
     The Stream Max GPU metric.
-    This metric only works at eval time.
+    This plugin metric only works at eval time.
     """
 
     def __init__(self, gpu_id, every=0.5):
@@ -334,7 +334,8 @@ class StreamMaxGPU(PluginMetric[float]):
 def gpu_usage_metrics(gpu_id, every=0.5, minibatch=False, epoch=False,
                       experience=False, stream=False) -> List[PluginMetric]:
     """
-    Helper method that can be used to obtain the desired set of metric.
+    Helper method that can be used to obtain the desired set of
+    plugin metrics.
 
     :param gpu_id: GPU device ID.
     :param every: seconds after which update the maximum GPU

--- a/avalanche/evaluation/metrics/loss.py
+++ b/avalanche/evaluation/metrics/loss.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 class Loss(Metric[float]):
     """
-    The Loss metric. This is a general metric
+    The standalone Loss metric. This is a general metric
     used to compute more specific ones.
 
     Instances of this metric keeps the running average loss
@@ -84,7 +84,7 @@ class Loss(Metric[float]):
 class MinibatchLoss(PluginMetric[float]):
     """
     The minibatch loss metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     This metric computes the average loss over patterns
     from a single minibatch.
@@ -130,7 +130,7 @@ class MinibatchLoss(PluginMetric[float]):
 class EpochLoss(PluginMetric[float]):
     """
     The average loss over a single training epoch.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     The loss will be logged after each training epoch by computing
     the loss on the predicted patterns during the epoch divided by
@@ -178,7 +178,7 @@ class RunningEpochLoss(EpochLoss):
     """
     The average loss across all minibatches up to the current
     epoch iteration.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     At each iteration, this metric logs the loss averaged over all patterns
     seen so far in the current epoch.
@@ -218,7 +218,7 @@ class ExperienceLoss(PluginMetric[float]):
     """
     At the end of each experience, this metric reports
     the average loss over all patterns seen in that experience.
-    This metric only works at eval time.
+    This plugin metric only works at eval time.
     """
 
     def __init__(self):
@@ -263,7 +263,7 @@ class StreamLoss(PluginMetric[float]):
     """
     At the end of the entire stream of experiences, this metric reports the
     average loss over all patterns seen in all experiences.
-    This metric only works at eval time.
+    This plugin metric only works at eval time.
     """
 
     def __init__(self):
@@ -312,7 +312,8 @@ class StreamLoss(PluginMetric[float]):
 def loss_metrics(*, minibatch=False, epoch=False, epoch_running=False,
                  experience=False, stream=False) -> List[PluginMetric]:
     """
-    Helper method that can be used to obtain the desired set of metric.
+    Helper method that can be used to obtain the desired set of
+    plugin metrics.
 
     :param minibatch: If True, will return a metric able to log
         the minibatch loss at training time.

--- a/avalanche/evaluation/metrics/mac.py
+++ b/avalanche/evaluation/metrics/mac.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 class MAC(Metric[int]):
     """
-    Multiply-and-accumulate metric. Provides a lower bound of the
+    Standalone Multiply-and-accumulate metric. Provides a lower bound of the
     computational cost of a model in a hardware-independent way by
     computing the number of multiplications. Currently supports only
     Linear or Conv2d modules. Other operations are ignored.
@@ -88,7 +88,7 @@ class MAC(Metric[int]):
 class MinibatchMAC(PluginMetric[float]):
     """
     The minibatch MAC metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     This metric computes the MAC over 1 pattern
     from a single minibatch.
@@ -135,7 +135,7 @@ class EpochMAC(PluginMetric[float]):
     """
     The MAC at the end of each epoch computed on a
     single pattern.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     The MAC will be logged after each training epoch.
     """
@@ -176,7 +176,7 @@ class ExperienceMAC(PluginMetric[float]):
     """
     At the end of each experience, this metric reports the
     MAC computed on a single pattern.
-    This metric only works at eval time.
+    This plugin metric only works at eval time.
     """
 
     def __init__(self):
@@ -216,7 +216,8 @@ class ExperienceMAC(PluginMetric[float]):
 def MAC_metrics(*, minibatch=False, epoch=False, experience=False) \
         -> List[PluginMetric]:
     """
-    Helper method that can be used to obtain the desired set of metric.
+    Helper method that can be used to obtain the desired set of
+    plugin metrics.
 
     :param minibatch: If True, will return a metric able to log
         the MAC after each iteration at training time.

--- a/avalanche/evaluation/metrics/mean.py
+++ b/avalanche/evaluation/metrics/mean.py
@@ -16,7 +16,7 @@ from avalanche.evaluation import Metric
 
 class Mean(Metric[float]):
     """
-    The mean metric.
+    The standalone mean metric.
 
     This utility metric is a general purpose metric that can be used to keep
     track of the mean of a sequence of values.
@@ -73,7 +73,7 @@ class Mean(Metric[float]):
 
 class Sum(Metric[float]):
     """
-    The sum metric.
+    The standalone sum metric.
 
     This utility metric is a general purpose metric that can be used to keep
     track of the sum of a sequence of values.

--- a/avalanche/evaluation/metrics/ram_usage.py
+++ b/avalanche/evaluation/metrics/ram_usage.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 class MaxRAM(Metric[float]):
     """
-    The RAM usage metric.
+    The standalone RAM usage metric.
     Important: this metric approximates the real maximum RAM usage since
     it sample at discrete amount of time the RAM values.
 
@@ -119,7 +119,7 @@ class MaxRAM(Metric[float]):
 class MinibatchMaxRAM(PluginMetric[float]):
     """
     The Minibatch Max RAM metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
     """
 
     def __init__(self, every=1):
@@ -167,7 +167,7 @@ class MinibatchMaxRAM(PluginMetric[float]):
 class EpochMaxRAM(PluginMetric[float]):
     """
     The Epoch Max RAM metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
     """
 
     def __init__(self, every=1):
@@ -215,7 +215,7 @@ class EpochMaxRAM(PluginMetric[float]):
 class ExperienceMaxRAM(PluginMetric[float]):
     """
     The Experience Max RAM metric.
-    This metric only works at eval time.
+    This plugin metric only works at eval time.
     """
 
     def __init__(self, every=1):
@@ -263,7 +263,7 @@ class ExperienceMaxRAM(PluginMetric[float]):
 class StreamMaxRAM(PluginMetric[float]):
     """
     The Stream Max RAM metric.
-    This metric only works at eval time.
+    This plugin metric only works at eval time.
     """
 
     def __init__(self, every=1):
@@ -312,7 +312,8 @@ class StreamMaxRAM(PluginMetric[float]):
 def ram_usage_metrics(*, every=1, minibatch=False, epoch=False,
                       experience=False, stream=False) -> List[PluginMetric]:
     """
-    Helper method that can be used to obtain the desired set of metric.
+    Helper method that can be used to obtain the desired set of
+    plugin metrics.
 
     :param every: seconds after which update the maximum RAM
         usage

--- a/avalanche/evaluation/metrics/timing.py
+++ b/avalanche/evaluation/metrics/timing.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 class ElapsedTime(Metric[float]):
     """
-    The elapsed time metric.
+    The standalone Elapsed Time metric.
 
     Instances of this metric keep track of the time elapsed between calls to the
     `update` method. The starting time is set when the `update` method is called
@@ -89,7 +89,7 @@ class ElapsedTime(Metric[float]):
 class MinibatchTime(PluginMetric[float]):
     """
     The minibatch time metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     This metric "logs" the elapsed time for each iteration.
 
@@ -135,7 +135,7 @@ class MinibatchTime(PluginMetric[float]):
 class EpochTime(PluginMetric[float]):
     """
     The epoch elapsed time metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     The elapsed time will be logged after each epoch.
     """
@@ -179,7 +179,7 @@ class EpochTime(PluginMetric[float]):
 class RunningEpochTime(PluginMetric[float]):
     """
     The running epoch time metric.
-    This metric only works at training time.
+    This plugin metric only works at training time.
 
     For each iteration, this metric logs the average time
     between the start of the
@@ -233,7 +233,7 @@ class RunningEpochTime(PluginMetric[float]):
 class ExperienceTime(PluginMetric[float]):
     """
     The experience time metric.
-    This metric only works at eval time.
+    This plugin metric only works at eval time.
 
     After each experience, this metric emits the average time of that
     experience.
@@ -279,7 +279,7 @@ class StreamTime(PluginMetric[float]):
     This metric only works at eval time.
 
     After the entire evaluation stream,
-    this metric emits the average time of that stream.
+    this plugin metric emits the average time of that stream.
     """
 
     def __init__(self):
@@ -319,7 +319,8 @@ class StreamTime(PluginMetric[float]):
 def timing_metrics(*, minibatch=False, epoch=False, epoch_running=False,
                    experience=False, stream=False) -> List[PluginMetric]:
     """
-    Helper method that can be used to obtain the desired set of metric.
+    Helper method that can be used to obtain the desired set of
+    plugin metrics.
 
     :param minibatch: If True, will return a metric able to log the train
         minibatch elapsed time.


### PR DESCRIPTION
This closes #418 
I also updated FZTH tutorial. 

The names of metric types are now `Standalone` metrics (subclass `Metric`) and `Plugin` metrics (subclass `PluginMetric`).