### PR TITLE
update dataloader to use AvalancheDataset

### DIFF
--- a/avalanche/benchmarks/utils/avalanche_dataset.py
+++ b/avalanche/benchmarks/utils/avalanche_dataset.py
@@ -158,7 +158,6 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
         """
         super().__init__()
 
-        self.targets = targets
         if transform_groups is not None and (
                 transform is not None or target_transform is not None):
             raise ValueError('transform_groups can\'t be used with transform'

--- a/avalanche/benchmarks/utils/avalanche_dataset.py
+++ b/avalanche/benchmarks/utils/avalanche_dataset.py
@@ -158,6 +158,7 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
         """
         super().__init__()
 
+        self.targets = targets
         if transform_groups is not None and (
                 transform is not None or target_transform is not None):
             raise ValueError('transform_groups can\'t be used with transform'

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -17,7 +17,8 @@ from avalanche.benchmarks.utils import AvalancheDataset
 
 
 class MultiTaskDataLoader:
-    def __init__(self, data: AvalancheDataset, oversample_small_tasks: bool = False,
+    def __init__(self, data: AvalancheDataset,
+                 oversample_small_tasks: bool = False,
                  **kwargs):
         """ Custom data loader for Avalanche's datasets.
 
@@ -76,7 +77,8 @@ class MultiTaskDataLoader:
 
 
 class MultiTaskMultiBatchDataLoader:
-    def __init__(self, data: AvalancheDataset, oversample_small_tasks: bool = False,
+    def __init__(self, data: AvalancheDataset,
+                 oversample_small_tasks: bool = False,
                  **kwargs):
         """ Custom data loader for task-balanced multi-task training.
 
@@ -173,15 +175,15 @@ class MultiTaskJoinedBatchDataLoader:
         # print('batch size: ' + str(single_exp_batch_size))
         # print('resto: ' + str(remaining_example))
         self.loader_data, remaining_example = self._create_dataloaders(
-                                data, single_exp_batch_size,
-                                remaining_example, **kwargs)
+            data, single_exp_batch_size,
+            remaining_example, **kwargs)
         self.loader_memory, remaining_example = self._create_dataloaders(
-                                memory, single_exp_batch_size,
-                                remaining_example, **kwargs)
+            memory, single_exp_batch_size,
+            remaining_example, **kwargs)
         self.max_len = max([len(d) for d in chain(
             self.loader_data.values(), self.loader_memory.values())]
-            )
-    
+                           )
+
     def __iter__(self):
         iter_data_dataloaders = {}
         iter_buffer_dataloaders = {}
@@ -191,8 +193,8 @@ class MultiTaskJoinedBatchDataLoader:
         for t in self.loader_memory.keys():
             iter_buffer_dataloaders[t] = iter(self.loader_memory[t])
 
-        max_len = max([len(d) for d in chain(iter_data_dataloaders.values(), 
-                       iter_buffer_dataloaders.values())])
+        max_len = max([len(d) for d in chain(iter_data_dataloaders.values(),
+                                             iter_buffer_dataloaders.values())])
         try:
             for it in range(max_len):
                 mb_x = mb_y = None
@@ -201,7 +203,7 @@ class MultiTaskJoinedBatchDataLoader:
                     self.data, iter_data_dataloaders,
                     self.loader_data, self.oversample_small_tasks,
                     mb_curr)
-                
+
                 self._get_mini_batch_from_data_dict(
                     self.memory, iter_buffer_dataloaders,
                     self.loader_memory, self.oversample_small_tasks,
@@ -213,7 +215,7 @@ class MultiTaskJoinedBatchDataLoader:
 
     def __len__(self):
         return self.max_len
-    
+
     def _get_mini_batch_from_data_dict(self, data, iter_dataloaders,
                                        loaders_dict, oversample_small_tasks,
                                        mb_curr):
@@ -233,14 +235,14 @@ class MultiTaskJoinedBatchDataLoader:
                 else:
                     del iter_dataloaders[t]
                     continue
-            if t in mb_curr: 
+            if t in mb_curr:
                 x_curr = torch.cat((mb_curr[t][0], x))
                 y_curr = torch.cat((mb_curr[t][1], y))
                 mb_curr[t] = x_curr, y_curr
             else:
                 mb_curr[t] = x, y
 
-    def _create_dataloaders(self, data_dict, single_exp_batch_size, 
+    def _create_dataloaders(self, data_dict, single_exp_batch_size,
                             remaining_example, **kwargs):
         loaders_dict: Dict[int, DataLoader] = {}
         for task_id in data_dict.task_set:

--- a/avalanche/core.py
+++ b/avalanche/core.py
@@ -54,7 +54,8 @@ class StrategyCallbacks(Generic[CallbackResult], ABC):
         """ Called before `train_exp` by the `BaseStrategy`. """
         pass
 
-    def before_train_dataset_adaptation(self, *args, **kwargs) -> CallbackResult:
+    def before_train_dataset_adaptation(self, *args,
+                                        **kwargs) -> CallbackResult:
         """ Called before `train_dataset_adapatation` by the `BaseStrategy`. """
         pass
 

--- a/avalanche/core.py
+++ b/avalanche/core.py
@@ -17,6 +17,14 @@ class StrategyCallbacks(Generic[CallbackResult], ABC):
     **Training loop**
     The training loop and its callbacks are organized as follows::
         train
+            for exp in stream:
+                data_adaptation
+                for epoch in range(n_epochs):
+                    for mbatch in dataloader:
+                        forward
+                        backward
+                        update
+
             before_training
             before_training_exp
             adapt_train_dataset
@@ -59,7 +67,10 @@ class StrategyCallbacks(Generic[CallbackResult], ABC):
     def before_training_exp(self, *args, **kwargs) -> CallbackResult:
         pass
 
-    def adapt_train_dataset(self, *args, **kwargs) -> CallbackResult:
+    def before_train_dataset_adaptation(self, *args, **kwargs) -> CallbackResult:
+        pass
+
+    def after_train_dataset_adaptation(self, *args, **kwargs) -> CallbackResult:
         pass
 
     def before_training_epoch(self, *args, **kwargs) -> CallbackResult:
@@ -101,7 +112,10 @@ class StrategyCallbacks(Generic[CallbackResult], ABC):
     def before_eval(self, *args, **kwargs) -> CallbackResult:
         pass
 
-    def adapt_eval_dataset(self, *args, **kwargs) -> CallbackResult:
+    def before_eval_dataset_adaptation(self, *args, **kwargs) -> CallbackResult:
+        pass
+
+    def after_eval_dataset_adaptation(self, *args, **kwargs) -> CallbackResult:
         pass
 
     def before_eval_exp(self, *args, **kwargs) -> CallbackResult:

--- a/avalanche/core.py
+++ b/avalanche/core.py
@@ -6,135 +6,150 @@ CallbackResult = TypeVar('CallbackResult')
 
 class StrategyCallbacks(Generic[CallbackResult], ABC):
     """
-    Base class for all classes dealing with strategy callbacks. Implements all
-    the callbacks of the BaseStrategy with an empty function.
-    Subclasses must override the desired callbacks.
+    Strategy callbacks provide access before/after each phase of the training
+    and evaluation loops. Subclasses can override the desired callbacks to
+    customize the loops. In Avalanche, callbacks are used by
+    :class:`StrategyPlugin` to implement continual strategies, and
+    :class:`StrategyLogger` for automatic logging.
 
-    The main two direct subclasses are :class:`StrategyPlugin`, which are used
-    to implement continual strategies, and :class:`StrategyLogger`, which are
-    used for logging.
+    For each method of the training and evaluation loops, `StrategyCallbacks`
+    provide two functions `before_{method}` and `after_{method}`, called
+    before and after the method, respectively.
+
+    As a reminder, `BaseStrategy` loops follow the structure shown below:
 
     **Training loop**
-    The training loop and its callbacks are organized as follows::
+    The training loop is organized as follows::
         train
-            for exp in stream:
-                data_adaptation
-                for epoch in range(n_epochs):
-                    for mbatch in dataloader:
-                        forward
-                        backward
-                        update
-
-            before_training
-            before_training_exp
-            adapt_train_dataset
-            make_train_dataloader
-            before_training_epoch
-                before_training_iteration
-                    before_forward
-                    after_forward
-                    before_backward
-                    after_backward
-                after_training_iteration
-                before_update
-                after_update
-            after_training_epoch
-            after_training_exp
-            after_training
+            train_exp  # for each experience
+                adapt_train_dataset
+                train_dataset_adaptation
+                make_train_dataloader
+                train_epoch  # for each epoch
+                    # forward
+                    # backward
+                    # model update
 
     **Evaluation loop**
-    The evaluation loop and its callbacks are organized as follows::
+    The evaluation loop is organized as follows::
         eval
-            before_eval
-            adapt_eval_dataset
-            make_eval_dataloader
-            before_eval_exp
-                eval_epoch
-                    before_eval_iteration
-                    before_eval_forward
-                    after_eval_forward
-                    after_eval_iteration
-            after_eval_exp
-            after_eval
+            eval_exp  # for each experience
+                adapt_eval_dataset
+                eval_dataset_adaptation
+                make_eval_dataloader
+                eval_epoch  # for each epoch
+                    # forward
+                    # backward
+                    # model update
     """
 
     def __init__(self):
         pass
 
     def before_training(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `train` by the `BaseStrategy`. """
         pass
 
     def before_training_exp(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `train_exp` by the `BaseStrategy`. """
         pass
 
     def before_train_dataset_adaptation(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `train_dataset_adapatation` by the `BaseStrategy`. """
         pass
 
     def after_train_dataset_adaptation(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `train_dataset_adapatation` by the `BaseStrategy`. """
         pass
 
     def before_training_epoch(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `train_epoch` by the `BaseStrategy`. """
         pass
 
     def before_training_iteration(self, *args, **kwargs) -> CallbackResult:
+        """ Called before the start of a training iteration by the
+        `BaseStrategy`. """
         pass
 
     def before_forward(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `model.forward()` by the `BaseStrategy`. """
         pass
 
     def after_forward(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `model.forward()` by the `BaseStrategy`. """
         pass
 
     def before_backward(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `criterion.backward()` by the `BaseStrategy`. """
         pass
 
     def after_backward(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `criterion.backward()` by the `BaseStrategy`. """
         pass
 
     def after_training_iteration(self, *args, **kwargs) -> CallbackResult:
+        """ Called after the end of a training iteration by the
+        `BaseStrategy`. """
         pass
 
     def before_update(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `optimizer.update()` by the `BaseStrategy`. """
         pass
 
     def after_update(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `optimizer.update()` by the `BaseStrategy`. """
         pass
 
     def after_training_epoch(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `train_epoch` by the `BaseStrategy`. """
         pass
 
     def after_training_exp(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `train_exp` by the `BaseStrategy`. """
         pass
 
     def after_training(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `train` by the `BaseStrategy`. """
         pass
 
     def before_eval(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `eval` by the `BaseStrategy`. """
         pass
 
     def before_eval_dataset_adaptation(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `eval_dataset_adaptation` by the `BaseStrategy`. """
         pass
 
     def after_eval_dataset_adaptation(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `eval_dataset_adaptation` by the `BaseStrategy`. """
         pass
 
     def before_eval_exp(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `eval_exp` by the `BaseStrategy`. """
         pass
 
     def after_eval_exp(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `eval_exp` by the `BaseStrategy`. """
         pass
 
     def after_eval(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `eval` by the `BaseStrategy`. """
         pass
 
     def before_eval_iteration(self, *args, **kwargs) -> CallbackResult:
+        """ Called before the start of a training iteration by the
+        `BaseStrategy`. """
         pass
 
     def before_eval_forward(self, *args, **kwargs) -> CallbackResult:
+        """ Called before `model.forward()` by the `BaseStrategy`. """
         pass
 
     def after_eval_forward(self, *args, **kwargs) -> CallbackResult:
+        """ Called after `model.forward()` by the `BaseStrategy`. """
         pass
 
     def after_eval_iteration(self, *args, **kwargs) -> CallbackResult:
+        """ Called after the end of an iteration by the
+        `BaseStrategy`. """
         pass

--- a/avalanche/evaluation/metric_definitions.py
+++ b/avalanche/evaluation/metric_definitions.py
@@ -105,7 +105,11 @@ class PluginMetric(Metric[TResult], StrategyCallbacks['MetricResult'], ABC):
             -> 'MetricResult':
         pass
 
-    def adapt_train_dataset(self, strategy: 'BaseStrategy') \
+    def before_train_dataset_adaptation(self, strategy: 'BaseStrategy') \
+            -> 'MetricResult':
+        pass
+
+    def after_train_dataset_adaptation(self, strategy: 'BaseStrategy') \
             -> 'MetricResult':
         pass
 
@@ -153,7 +157,11 @@ class PluginMetric(Metric[TResult], StrategyCallbacks['MetricResult'], ABC):
     def before_eval(self, strategy: 'BaseStrategy') -> 'MetricResult':
         pass
 
-    def adapt_eval_dataset(self, strategy: 'BaseStrategy') \
+    def before_eval_dataset_adaptation(self, strategy: 'BaseStrategy') \
+            -> 'MetricResult':
+        pass
+
+    def after_eval_dataset_adaptation(self, strategy: 'BaseStrategy') \
             -> 'MetricResult':
         pass
 

--- a/avalanche/logging/interactive_logging.py
+++ b/avalanche/logging/interactive_logging.py
@@ -55,7 +55,7 @@ class InteractiveLogger(TextLogger):
     def before_training_epoch(self, strategy: 'BaseStrategy',
                               metric_values: List['MetricValue'], **kwargs):
         super().before_training_epoch(strategy, metric_values, **kwargs)
-        self._progress.total = len(strategy.current_dataloader)
+        self._progress.total = len(strategy.dataloader)
 
     def after_training_epoch(self, strategy: 'BaseStrategy',
                              metric_values: List['MetricValue'], **kwargs):
@@ -65,7 +65,7 @@ class InteractiveLogger(TextLogger):
     def before_eval_exp(self, strategy: 'BaseStrategy',
                         metric_values: List['MetricValue'], **kwargs):
         super().before_eval_exp(strategy, metric_values, **kwargs)
-        self._progress.total = len(strategy.current_dataloader)
+        self._progress.total = len(strategy.dataloader)
 
     def after_eval_exp(self, strategy: 'BaseStrategy',
                        metric_values: List['MetricValue'], **kwargs):

--- a/avalanche/logging/strategy_logger.py
+++ b/avalanche/logging/strategy_logger.py
@@ -56,7 +56,8 @@ class StrategyLogger(StrategyCallbacks[None], ABC):
             self.log_metric(val, 'before_training_exp')
 
     def after_train_dataset_adaptation(self, strategy: 'BaseStrategy',
-                                       metric_values: List['MetricValue'], **kwargs):
+                                       metric_values: List['MetricValue'],
+                                       **kwargs):
         for val in metric_values:
             self.log_metric(val, 'adapt_train_dataset')
 
@@ -127,7 +128,8 @@ class StrategyLogger(StrategyCallbacks[None], ABC):
             self.log_metric(val, 'before_eval')
 
     def after_eval_dataset_adaptation(self, strategy: 'BaseStrategy',
-                                      metric_values: List['MetricValue'], **kwargs):
+                                      metric_values: List['MetricValue'],
+                                      **kwargs):
         for val in metric_values:
             self.log_metric(val, 'adapt_eval_dataset')
 

--- a/avalanche/logging/strategy_logger.py
+++ b/avalanche/logging/strategy_logger.py
@@ -55,8 +55,8 @@ class StrategyLogger(StrategyCallbacks[None], ABC):
         for val in metric_values:
             self.log_metric(val, 'before_training_exp')
 
-    def adapt_train_dataset(self, strategy: 'BaseStrategy',
-                            metric_values: List['MetricValue'], **kwargs):
+    def after_train_dataset_adaptation(self, strategy: 'BaseStrategy',
+                                       metric_values: List['MetricValue'], **kwargs):
         for val in metric_values:
             self.log_metric(val, 'adapt_train_dataset')
 
@@ -126,8 +126,8 @@ class StrategyLogger(StrategyCallbacks[None], ABC):
         for val in metric_values:
             self.log_metric(val, 'before_eval')
 
-    def adapt_eval_dataset(self, strategy: 'BaseStrategy',
-                           metric_values: List['MetricValue'], **kwargs):
+    def after_eval_dataset_adaptation(self, strategy: 'BaseStrategy',
+                                      metric_values: List['MetricValue'], **kwargs):
         for val in metric_values:
             self.log_metric(val, 'adapt_eval_dataset')
 

--- a/avalanche/training/plugins/agem.py
+++ b/avalanche/training/plugins/agem.py
@@ -75,7 +75,7 @@ class AGEMPlugin(StrategyPlugin):
         Save a copy of the model after each experience
         """
 
-        self.update_memory(strategy.current_dataloader)
+        self.update_memory(strategy.dataloader)
 
     def sample_from_memory(self, sample_size):
         """

--- a/avalanche/training/plugins/evaluation.py
+++ b/avalanche/training/plugins/evaluation.py
@@ -135,8 +135,11 @@ class EvaluationPlugin(StrategyPlugin):
     def before_training_exp(self, strategy: 'BaseStrategy', **kwargs):
         self._update_metrics(strategy, 'before_training_exp')
 
-    def adapt_train_dataset(self, strategy: 'BaseStrategy', **kwargs):
-        self._update_metrics(strategy, 'adapt_train_dataset')
+    def before_train_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+        self._update_metrics(strategy, 'before_train_dataset_adaptation')
+
+    def after_train_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+        self._update_metrics(strategy, 'after_train_dataset_adaptation')
 
     def before_training_epoch(self, strategy: 'BaseStrategy', **kwargs):
         self._update_metrics(strategy, 'before_training_epoch')
@@ -177,8 +180,11 @@ class EvaluationPlugin(StrategyPlugin):
     def before_eval(self, strategy: 'BaseStrategy', **kwargs):
         self._update_metrics(strategy, 'before_eval')
 
-    def adapt_eval_dataset(self, strategy: 'BaseStrategy', **kwargs):
-        self._update_metrics(strategy, 'adapt_eval_dataset')
+    def before_eval_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+        self._update_metrics(strategy, 'before_eval_dataset_adaptation')
+
+    def after_eval_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+        self._update_metrics(strategy, 'after_eval_dataset_adaptation')
 
     def before_eval_exp(self, strategy: 'BaseStrategy', **kwargs):
         self._update_metrics(strategy, 'before_eval_exp')

--- a/avalanche/training/plugins/evaluation.py
+++ b/avalanche/training/plugins/evaluation.py
@@ -135,10 +135,12 @@ class EvaluationPlugin(StrategyPlugin):
     def before_training_exp(self, strategy: 'BaseStrategy', **kwargs):
         self._update_metrics(strategy, 'before_training_exp')
 
-    def before_train_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+    def before_train_dataset_adaptation(self, strategy: 'BaseStrategy',
+                                        **kwargs):
         self._update_metrics(strategy, 'before_train_dataset_adaptation')
 
-    def after_train_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+    def after_train_dataset_adaptation(self, strategy: 'BaseStrategy',
+                                       **kwargs):
         self._update_metrics(strategy, 'after_train_dataset_adaptation')
 
     def before_training_epoch(self, strategy: 'BaseStrategy', **kwargs):
@@ -180,7 +182,8 @@ class EvaluationPlugin(StrategyPlugin):
     def before_eval(self, strategy: 'BaseStrategy', **kwargs):
         self._update_metrics(strategy, 'before_eval')
 
-    def before_eval_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+    def before_eval_dataset_adaptation(self, strategy: 'BaseStrategy',
+                                       **kwargs):
         self._update_metrics(strategy, 'before_eval_dataset_adaptation')
 
     def after_eval_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):

--- a/avalanche/training/plugins/gdumb.py
+++ b/avalanche/training/plugins/gdumb.py
@@ -29,7 +29,7 @@ class GDumbPlugin(StrategyPlugin):
         # count occurrences for each class
         self.counter = defaultdict(lambda: defaultdict(int))
 
-    def adapt_train_dataset(self, strategy, **kwargs):
+    def after_train_dataset_adaptation(self, strategy, **kwargs):
         """ Before training we make sure to organize the memory following
             GDumb approach and updating the dataset accordingly.
         """

--- a/avalanche/training/plugins/gdumb.py
+++ b/avalanche/training/plugins/gdumb.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import torch
 from torch.utils.data import TensorDataset
 
+from avalanche.benchmarks.utils import AvalancheConcatDataset
 from avalanche.training.plugins.strategy_plugin import StrategyPlugin
 
 
@@ -13,10 +14,8 @@ class GDumbPlugin(StrategyPlugin):
     The memory is updated at the end of each experience to add new classes or
     new examples of already encountered classes.
     In multitask scenarios, mem_size is the memory size for each task.
-
     This plugin can be combined with a Naive strategy to obtain the
     standard GDumb strategy.
-
     https://www.robots.ox.ac.uk/~tvg/publications/2020/gdumb.pdf
     """
 
@@ -29,7 +28,7 @@ class GDumbPlugin(StrategyPlugin):
         # count occurrences for each class
         self.counter = defaultdict(lambda: defaultdict(int))
 
-    def after_train_dataset_adaptation(self, strategy, **kwargs):
+    def adapt_train_dataset(self, strategy, **kwargs):
         """ Before training we make sure to organize the memory following
             GDumb approach and updating the dataset accordingly.
         """
@@ -82,4 +81,4 @@ class GDumbPlugin(StrategyPlugin):
                 current_counter[target_value] += 1
 
         self.ext_mem[strategy.experience.task_label] = current_mem
-        strategy.adapted_dataset = self.ext_mem
+        strategy.adapted_dataset = AvalancheConcatDataset(self.ext_mem)

--- a/avalanche/training/plugins/strategy_plugin.py
+++ b/avalanche/training/plugins/strategy_plugin.py
@@ -23,7 +23,10 @@ class StrategyPlugin(StrategyCallbacks[Any]):
     def before_training_exp(self, strategy: 'BaseStrategy', **kwargs):
         pass
 
-    def adapt_train_dataset(self, strategy: 'BaseStrategy', **kwargs):
+    def before_train_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+        pass
+
+    def after_train_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
         pass
 
     def before_training_epoch(self, strategy: 'BaseStrategy', **kwargs):
@@ -65,7 +68,10 @@ class StrategyPlugin(StrategyCallbacks[Any]):
     def before_eval(self, strategy: 'BaseStrategy', **kwargs):
         pass
 
-    def adapt_eval_dataset(self, strategy: 'BaseStrategy', **kwargs):
+    def before_eval_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+        pass
+
+    def after_eval_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
         pass
 
     def before_eval_exp(self, strategy: 'BaseStrategy', **kwargs):

--- a/avalanche/training/plugins/strategy_plugin.py
+++ b/avalanche/training/plugins/strategy_plugin.py
@@ -23,10 +23,12 @@ class StrategyPlugin(StrategyCallbacks[Any]):
     def before_training_exp(self, strategy: 'BaseStrategy', **kwargs):
         pass
 
-    def before_train_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+    def before_train_dataset_adaptation(self, strategy: 'BaseStrategy',
+                                        **kwargs):
         pass
 
-    def after_train_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+    def after_train_dataset_adaptation(self, strategy: 'BaseStrategy',
+                                       **kwargs):
         pass
 
     def before_training_epoch(self, strategy: 'BaseStrategy', **kwargs):
@@ -68,7 +70,8 @@ class StrategyPlugin(StrategyCallbacks[Any]):
     def before_eval(self, strategy: 'BaseStrategy', **kwargs):
         pass
 
-    def before_eval_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):
+    def before_eval_dataset_adaptation(self, strategy: 'BaseStrategy',
+                                       **kwargs):
         pass
 
     def after_eval_dataset_adaptation(self, strategy: 'BaseStrategy', **kwargs):

--- a/avalanche/training/strategies/ar1.py
+++ b/avalanche/training/strategies/ar1.py
@@ -207,15 +207,13 @@ class AR1(BaseStrategy):
         self.replay_mb_size = max(0, self.train_mb_size - current_batch_mb_size)
 
         # AR1 only supports SIT scenarios (no task labels).
-        assert len(self.adapted_dataset.keys()) == 1
-        curr_data = list(self.adapted_dataset.values())[0]
-        self.current_dataloader = DataLoader(
-            curr_data, num_workers=num_workers,
+        self.dataloader = DataLoader(
+            self.adapted_dataset, num_workers=num_workers,
             batch_size=current_batch_mb_size, shuffle=shuffle)
 
     def training_epoch(self, **kwargs):
         for self.mb_it, (self.mb_x, self.mb_y, _) in \
-                enumerate(self.current_dataloader):
+                enumerate(self.dataloader):
             self.before_training_iteration(**kwargs)
 
             self.optimizer.zero_grad()

--- a/avalanche/training/strategies/base_strategy.py
+++ b/avalanche/training/strategies/base_strategy.py
@@ -310,6 +310,7 @@ class BaseStrategy:
         self.model.train()
 
     def train_dataset_adaptation(self, **kwargs):
+        """ Initialize `self.adapted_dataset`. """
         self.adapted_dataset = self.experience.dataset
         self.adapted_dataset = self.adapted_dataset.train()
 
@@ -363,7 +364,7 @@ class BaseStrategy:
 
     def make_train_dataloader(self, num_workers=0, shuffle=True, **kwargs):
         """
-        Called after the dataset instantiation. Initialize the data loader.
+        Called after the dataset adaptation. Initializes the data loader.
         :param num_workers: number of thread workers for the data loading.
         :param shuffle: True if the data should be shuffled, False otherwise.
         """
@@ -376,7 +377,7 @@ class BaseStrategy:
 
     def make_eval_dataloader(self, num_workers=0, **kwargs):
         """
-        Initialize the eval data loader.
+        Initializes the eval data loader.
         :param num_workers:
         :param kwargs:
         :return:
@@ -390,7 +391,7 @@ class BaseStrategy:
 
     def after_train_dataset_adaptation(self, **kwargs):
         """
-        Called after the dataset initialization and before the
+        Called after the dataset adaptation and before the
         dataloader initialization. Allows to customize the dataset.
         :param kwargs:
         :return:
@@ -510,6 +511,7 @@ class BaseStrategy:
             p.before_eval_exp(self, **kwargs)
 
     def eval_dataset_adaptation(self, **kwargs):
+        """ Initialize `self.adapted_dataset`. """
         self.adapted_dataset = self.experience.dataset
         self.adapted_dataset = self.adapted_dataset.eval()
 

--- a/avalanche/training/strategies/cumulative.py
+++ b/avalanche/training/strategies/cumulative.py
@@ -47,9 +47,9 @@ class Cumulative(BaseStrategy):
 
         self.dataset = {}  # cumulative dataset
 
-    def adapt_train_dataset(self, **kwargs):
+    def after_train_dataset_adaptation(self, **kwargs):
 
-        super().adapt_train_dataset(**kwargs)
+        super().after_train_dataset_adaptation(**kwargs)
 
         curr_task_id = self.experience.task_label
         curr_data = self.experience.dataset

--- a/avalanche/training/strategies/joint_training.py
+++ b/avalanche/training/strategies/joint_training.py
@@ -16,6 +16,7 @@ from torch.optim import Optimizer
 from torch.utils.data import ConcatDataset
 
 from avalanche.benchmarks.scenarios import Experience
+from avalanche.benchmarks.utils import AvalancheConcatDataset
 from avalanche.training import default_logger
 from avalanche.training.strategies import BaseStrategy
 
@@ -56,63 +57,56 @@ class JointTraining(BaseStrategy):
                          train_epochs, eval_mb_size, device, plugins, evaluator)
 
     def train(self, experiences: Union[Experience, Sequence[Experience]],
+              eval_streams: Optional[Sequence[Union[Experience,
+                                                    Sequence[
+                                                        Experience]]]] = None,
               **kwargs):
         """ Training loop. if experiences is a single element trains on it.
         If it is a sequence, trains the model on each experience in order.
-        Joint training uses the entire stream and it is not a proper CL
-        strategy.
-        It returns a dictionary with last recorded value for each metric name.
+        This is different from joint training on the entire stream.
+        It returns a dictionary with last recorded value for each metric.
 
-        :param experiences: single IExperience or sequence.
+        :param experiences: single Experience or sequence.
+        :param eval_streams: list of streams for evaluation.
+            If None: use training experiences for evaluation.
+            Use [] if you do not want to evaluate during training.
 
         :return: dictionary containing last recorded value for
-            each metric name
+            each metric name.
         """
         self.is_training = True
         self.model.train()
         self.model.to(self.device)
 
+        # Normalize training and eval data.
         if isinstance(experiences, Experience):
             experiences = [experiences]
+        if eval_streams is None:
+            eval_streams = [experiences]
+        for i, exp in enumerate(eval_streams):
+            if isinstance(exp, Experience):
+                eval_streams[i] = [exp]
 
+        self._experiences = experiences
         self.before_training(**kwargs)
-
-        self.experience = experiences[0]
-        self.train_task_label = self.experience.task_label
-        self.model.train()
-        self.model.to(self.device)
-
-        self.adapted_dataset = experiences[0].dataset
-        self.adapted_dataset.train()
-        # DO NOT CALL adapt_train_dataset.
-        # JointTraining adapts its own data in a custom manner.
-        # TODO: support adapt_train_dataset
-        # waiting for https://github.com/vlomonaco/avalanche/issues/320
-        # self.adapt_train_dataset(**kwargs)
-        ext_mem = {}
         for exp in experiences:
-            if exp.task_label in ext_mem:
-                curr_task_data = ext_mem[exp.task_label]
-                cat_data = ConcatDataset([exp.dataset, curr_task_data])
-                ext_mem[exp.task_label] = cat_data
-            else:
-                ext_mem[exp.task_label] = exp.dataset
-        self.adapted_dataset = ext_mem
-
-        self.make_train_dataloader(**kwargs)
-        self.before_training_exp(**kwargs)
-        self.epoch = 0
-        for self.epoch in range(self.train_epochs):
-            self.before_training_epoch(**kwargs)
-            self.training_epoch(**kwargs)
-            self.after_training_epoch(**kwargs)
-        self.after_training_exp(**kwargs)
-
+            self.train_exp(exp, eval_streams, **kwargs)
+            # Joint training only needs a single step because
+            # it concatenates all the data at once.
+            break
         self.after_training(**kwargs)
 
         res = self.evaluator.get_last_metrics()
-
         return res
+
+    def train_dataset_adaptation(self, **kwargs):
+        """ Concatenates all the datastream. """
+        self.adapted_dataset = self._experiences[0].dataset
+        for exp in self._experiences:
+            cat_data = AvalancheConcatDataset([self.adapted_dataset,
+                                               exp.dataset])
+            self.adapted_dataset = cat_data
+        self.adapted_dataset = self.adapted_dataset.train()
 
 
 __all__ = ['JointTraining']

--- a/docs/gitbook/from-zero-to-hero-tutorial/3.-training.md
+++ b/docs/gitbook/from-zero-to-hero-tutorial/3.-training.md
@@ -250,7 +250,7 @@ class Cumulative(BaseStrategy):
         self.dataset = {}  # cumulative dataset
 
     def adapt_train_dataset(self, **kwargs):
-        super().adapt_train_dataset(**kwargs)
+        super().after_train_dataset_adaptation(**kwargs)
         curr_task_id = self.experience.task_label
         curr_data = self.experience.dataset
         if curr_task_id in self.dataset:

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -23,6 +23,7 @@ from torch.nn import CrossEntropyLoss
 from torch.utils.data import TensorDataset
 
 from avalanche.benchmarks.datasets import MNIST
+from avalanche.benchmarks.utils import AvalancheConcatDataset
 from avalanche.logging import TextLogger
 from avalanche.models import SimpleMLP
 from avalanche.training.plugins import EvaluationPlugin, ReplayPlugin
@@ -88,12 +89,10 @@ class DataLoaderTests(unittest.TestCase):
         )
 
         for step in scenario.train_stream:
-            
-            adapted_dataset = {step.task_label: step.dataset}
-
+            adapted_dataset = step.dataset
             dataloader = MultiTaskJoinedBatchDataLoader(
                     adapted_dataset,
-                    replayPlugin.ext_mem,
+                    AvalancheConcatDataset(replayPlugin.ext_mem.values()),
                     oversample_small_tasks=True,
                     num_workers=0,
                     batch_size=batch_size,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -30,7 +30,7 @@ class MockPlugin(StrategyPlugin):
     def before_training_exp(self, strategy, **kwargs):
         self.activated[0] = True
 
-    def adapt_train_dataset(self, strategy, **kwargs):
+    def after_train_dataset_adaptation(self, strategy, **kwargs):
         self.activated[1] = True
 
     def before_training_epoch(self, strategy, **kwargs):
@@ -69,7 +69,7 @@ class MockPlugin(StrategyPlugin):
     def before_eval(self, strategy, **kwargs):
         self.activated[13] = True
 
-    def adapt_eval_dataset(self, strategy, **kwargs):
+    def after_eval_dataset_adaptation(self, strategy, **kwargs):
         self.activated[14] = True
 
     def before_eval_exp(self, strategy, **kwargs):


### PR DESCRIPTION
PR to update strategies to support the new `AvalancheDataset`. There are also some changes to the data adaptation phase.
- Convert data loaders to accept `AvalancheDataset`.
- create explicit `dataset_adaptation` phase.
- Added docstring for callbacks.

regarding point (2), this removes the old callback `adapt_dataset` with `before/after_data_adaptation` callbacks.
- makes it easier to write data adaptation strategies (e.g. cumulative and joint training)
- makes it easier to explain/understand strategies and callbacks.

`BaseStrategy` loops become:
```
train
    train_exp  # for each experience
        adapt_train_dataset
        train_dataset_adaptation
        make_train_dataloader
        train_epoch  # for each epoch
            # forward
            # backward
            # model update
```

Closes #452 #382.