### PR TITLE
StreamForgetting

### DIFF
--- a/avalanche/evaluation/metrics/forgetting.py
+++ b/avalanche/evaluation/metrics/forgetting.py
@@ -9,7 +9,7 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from typing import Dict, TYPE_CHECKING, Union
+from typing import Dict, TYPE_CHECKING, Union, List
 
 from avalanche.evaluation.metric_definitions import Metric, PluginMetric
 from avalanche.evaluation.metric_results import MetricValue, MetricResult
@@ -237,10 +237,10 @@ class ExperienceForgetting(PluginMetric[Dict[int, float]]):
 
 class StreamForgetting(PluginMetric[Dict[int, float]]):
     """
-    The StreamForgetting metric, describing the average accuracy loss
-    detected over all observed experiences.
+    The StreamForgetting metric, describing the average evaluation accuracy loss
+    detected over all experiences observed during training.
 
-    This plugin metric, computed over all experiences,
+    This plugin metric, computed over all observed experiences during training,
     is the average over the difference between the accuracy result obtained after
     first training on a experience and the accuracy result obtained
     on the same experience at the end of successive experiences.
@@ -378,6 +378,31 @@ class StreamForgetting(PluginMetric[Dict[int, float]]):
     def __str__(self):
         return "StreamForgetting"
 
+
+def forgetting_metrics(*, experience=False, stream=False) \
+        -> List[PluginMetric]:
+    """
+    Helper method that can be used to obtain the desired set of
+    plugin metrics.
+
+    :param experience: If True, will return a metric able to log
+        the forgetting on each evaluation experience.
+    :param stream: If True, will return a metric able to log
+        the forgetting averaged over the evaluation stream experiences,
+        which have been observed during training.
+
+    :return: A list of plugin metrics.
+    """
+
+    metrics = []
+
+    if experience:
+        metrics.append(ExperienceForgetting())
+
+    if stream:
+        metrics.append(StreamForgetting())
+
+    return metrics
 
 __all__ = [
     'Forgetting',

--- a/avalanche/evaluation/metrics/forgetting.py
+++ b/avalanche/evaluation/metrics/forgetting.py
@@ -404,8 +404,10 @@ def forgetting_metrics(*, experience=False, stream=False) \
 
     return metrics
 
+
 __all__ = [
     'Forgetting',
     'ExperienceForgetting',
-    'StreamForgetting'
+    'StreamForgetting',
+    'forgetting_metrics'
 ]

--- a/avalanche/evaluation/metrics/forgetting.py
+++ b/avalanche/evaluation/metrics/forgetting.py
@@ -241,8 +241,8 @@ class StreamForgetting(PluginMetric[Dict[int, float]]):
     detected over all experiences observed during training.
 
     This plugin metric, computed over all observed experiences during training,
-    is the average over the difference between the accuracy result obtained after
-    first training on a experience and the accuracy result obtained
+    is the average over the difference between the accuracy result obtained
+    after first training on a experience and the accuracy result obtained
     on the same experience at the end of successive experiences.
 
     This metric is computed during the eval phase only.
@@ -366,7 +366,7 @@ class StreamForgetting(PluginMetric[Dict[int, float]]):
         # If not, forgetting should not be returned.
         if self.exp_result(k=self.eval_exp_id) is not None:
             exp_forgetting = self.exp_result(k=self.eval_exp_id)
-            self.stream_forgetting.update(exp_forgetting, weight=1)  # Equal weight per experience
+            self.stream_forgetting.update(exp_forgetting, weight=1)
 
     def after_eval(self, strategy: 'BaseStrategy') -> \
             'MetricResult':

--- a/examples/eval_plugin.py
+++ b/examples/eval_plugin.py
@@ -26,7 +26,7 @@ from torchvision.datasets import MNIST
 from torchvision.transforms import ToTensor, RandomCrop
 
 from avalanche.benchmarks import nc_scenario
-from avalanche.evaluation.metrics import ExperienceForgetting, \
+from avalanche.evaluation.metrics import forgetting_metrics, \
     accuracy_metrics, loss_metrics, cpu_usage_metrics, timing_metrics, \
     gpu_usage_metrics, ram_usage_metrics, disk_usage_metrics, MAC_metrics
 from avalanche.models import SimpleMLP
@@ -39,7 +39,7 @@ def main(args):
     # --- CONFIG
     device = torch.device(f"cuda:{args.cuda}"
                           if torch.cuda.is_available() and
-                          args.cuda >= 0 else "cpu")
+                             args.cuda >= 0 else "cpu")
     # ---------
 
     # --- TRANSFORMATIONS
@@ -82,7 +82,7 @@ def main(args):
         accuracy_metrics(
             minibatch=True, epoch=True, experience=True, stream=True),
         loss_metrics(minibatch=True, epoch=True, experience=True, stream=True),
-        ExperienceForgetting(),
+        forgetting_metrics(experience=True, stream=True),
         cpu_usage_metrics(
             minibatch=True, epoch=True, experience=True, stream=True),
         timing_metrics(
@@ -99,7 +99,6 @@ def main(args):
             minibatch=True, epoch=True, experience=True),
         loggers=[interactive_logger, text_logger],
         collect_all=True)  # collect all metrics (set to True by default)
-
 
     # CREATE THE STRATEGY INSTANCE (NAIVE)
     cl_strategy = Naive(


### PR DESCRIPTION
The StreamForgetting is implemented as the average of the forgetting over all experiences. A forgetting_metrics helper method is implemented to create both the StreamForgetting and ExperienceForgetting metrics. The use is exemplified in the examples/eval_plugin.py