### PR TITLE
Added Deep SLDA Model implementation

### DIFF
--- a/avalanche/training/strategies/deep_slda.py
+++ b/avalanche/training/strategies/deep_slda.py
@@ -1,0 +1,284 @@
+import warnings
+from typing import Optional, Sequence
+
+import os
+import torch
+from torch import nn
+import torchvision.models as models
+
+
+from avalanche.training import default_logger
+from avalanche.models import MobilenetV1
+from avalanche.models.batch_renorm import BatchRenorm2D
+from avalanche.training.plugins import StrategyPlugin, EvaluationPlugin, \
+    SynapticIntelligencePlugin, CWRStarPlugin
+from avalanche.training.strategies import BaseStrategy
+from avalanche.training.utils import replace_bn_with_brn, get_last_fc_layer, \
+    freeze_up_to, change_brn_pars, examples_per_class, LayerAndParameter
+
+
+class ModelWrapper(nn.Module):
+    def __init__(self, model, output_layer_names, return_single=False):
+        super(ModelWrapper, self).__init__()
+        self.model = model
+        self.output_layer_names = output_layer_names
+        self.outputs = {}
+        self.return_single = return_single
+        self.add_hooks(self.model, self.outputs, self.output_layer_names)
+
+    def forward(self, x):
+        self.model(x)
+        output_vals = [self.outputs[output_layer_name] for output_layer_name in self.output_layer_names]
+        if self.return_single:
+            return output_vals[0]
+        else:
+            return output_vals
+
+    def get_name_to_module(self, model):
+        name_to_module = {}
+        for m in model.named_modules():
+            name_to_module[m[0]] = m[1]
+        return name_to_module
+
+    def get_activation(self, all_outputs, name):
+        def hook(model, input, output):
+            all_outputs[name] = output.detach()
+
+        return hook
+
+    def add_hooks(self, model, outputs, output_layer_names):
+        """
+        :param model:
+        :param outputs: Outputs from layers specified in `output_layer_names` will be stored in `output` variable
+        :param output_layer_names:
+        :return:
+        """
+        name_to_module = self.get_name_to_module(model)
+        for output_layer_name in output_layer_names:
+            name_to_module[output_layer_name].register_forward_hook(self.get_activation(outputs, output_layer_name))
+
+
+class StreamingLDA(nn.Module):
+    """
+    This is an implementation of the Deep Streaming Linear Discriminant
+    Analysis algorithm for streaming learning.
+    """
+
+    def __init__(self, input_shape, num_classes, test_batch_size=1024,
+                 shrinkage_param=1e-4, streaming_update_sigma=True, arch='resnet18', imagenet_pretrained=True,
+                 device='cuda'):
+        """
+        Init function for the SLDA model.
+        :param input_shape: feature dimension
+        :param num_classes: number of total classes in stream
+        :param test_batch_size: batch size for inference
+        :param shrinkage_param: value of the shrinkage parameter
+        :param streaming_update_sigma: True if sigma is plastic else False
+        :param arch: backbone architecture (default is resnet-18, but others can be used by modifying layer for
+        feature extraction in `self.feature_extraction_wrapper'
+        :param imagenet_pretrained: True if initializing backbone with imagenet pre-trained weights else False
+        :param imagenet_pretrained: device to use for experiment (default is cuda)
+        """
+
+        super(StreamingLDA, self).__init__()
+
+        # SLDA parameters
+        self.device = device
+        self.input_shape = input_shape
+        self.num_classes = num_classes
+        self.test_batch_size = test_batch_size
+        self.shrinkage_param = shrinkage_param
+        self.streaming_update_sigma = streaming_update_sigma
+
+        # setup weights for SLDA
+        self.muK = torch.zeros((num_classes, input_shape)).to(self.device)
+        self.cK = torch.zeros(num_classes).to(self.device)
+        self.Sigma = torch.ones((input_shape, input_shape)).to(self.device)
+        self.num_updates = 0
+        self.Lambda = torch.zeros_like(self.Sigma).to(self.device)
+        self.prev_num_updates = -1
+
+        # setup feature extraction model pre-trained on imagenet
+        feature_extraction_model = self.get_feature_extraction_model(arch=arch, imagenet_pretrained=imagenet_pretrained)
+        # layer 4.1 is the final layer in resnet18 (need to change this code
+        # for other architectures)
+        self.feature_extraction_wrapper = ModelWrapper(
+            feature_extraction_model.eval().to(self.device),
+            ['layer4.1'], return_single=True).eval()
+
+    def get_feature_extraction_model(self, arch, imagenet_pretrained):
+        feature_extraction_model = models.__dict__[arch](
+            pretrained=imagenet_pretrained)
+        return feature_extraction_model
+
+    def fit(self, x, y):
+        """
+        Fit the SLDA model to a new sample (x,y).
+        :param x: a torch tensor of the input data (must be a vector)
+        :param y: a torch tensor of the input label
+        :return: None
+        """
+        x = x.to(self.device)
+        y = y.long().to(self.device)
+
+        # make sure things are the right shape
+        if len(x.shape) < 2:
+            x = x.unsqueeze(0)
+        if len(y.shape) == 0:
+            y = y.unsqueeze(0)
+
+        with torch.no_grad():
+
+            # covariance updates
+            if self.streaming_update_sigma:
+                x_minus_mu = (x - self.muK[y])
+                mult = torch.matmul(x_minus_mu.transpose(1, 0), x_minus_mu)
+                delta = mult * self.num_updates / (self.num_updates + 1)
+                self.Sigma = (self.num_updates * self.Sigma + delta) / (
+                        self.num_updates + 1)
+
+            # update class means
+            self.muK[y, :] += (x - self.muK[y, :]) / (self.cK[y] + 1).unsqueeze(
+                1)
+            self.cK[y] += 1
+            self.num_updates += 1
+
+    def predict(self, X, return_probas=False):
+        """
+        Make predictions on test data X.
+        :param X: a torch tensor that contains N data samples (N x d)
+        :param return_probas: True if the user would like probabilities instead
+        of predictions returned
+        :return: the test predictions or probabilities
+        """
+        X = X.to(self.device)
+
+        with torch.no_grad():
+            # initialize parameters for testing
+            num_samples = X.shape[0]
+            scores = torch.empty((num_samples, self.num_classes))
+            mb = min(self.test_batch_size, num_samples)
+
+            # compute/load Lambda matrix
+            if self.prev_num_updates != self.num_updates:
+                # there have been updates to the model, compute Lambda
+                Lambda = torch.pinverse(
+                    (
+                            1 - self.shrinkage_param) * self.Sigma +
+                    self.shrinkage_param * torch.eye(
+                        self.input_shape).to(
+                        self.device))
+                self.Lambda = Lambda
+                self.prev_num_updates = self.num_updates
+            else:
+                Lambda = self.Lambda
+
+            # parameters for predictions
+            M = self.muK.transpose(1, 0)
+            W = torch.matmul(Lambda, M)
+            c = 0.5 * torch.sum(M * W, dim=0)
+
+            # loop in mini-batches over test samples
+            for i in range(0, num_samples, mb):
+                start = min(i, num_samples - mb)
+                end = i + mb
+                x = X[start:end]
+                scores[start:end, :] = torch.matmul(x, W) - c
+
+            # return predictions or probabilities
+            if not return_probas:
+                return scores.cpu()
+            else:
+                return torch.softmax(scores, dim=1).cpu()
+
+    def fit_base(self, X, y):
+        """
+        Fit the SLDA model to the base data.
+        :param X: an Nxd torch tensor of base initialization data
+        :param y: an Nx1-dimensional torch tensor of the associated labels for X
+        :return: None
+        """
+        print('\nFitting Base...')
+        X = X.to(self.device)
+        y = y.squeeze().long()
+
+        # update class means
+        for k in torch.unique(y):
+            self.muK[k] = X[y == k].mean(0)
+            self.cK[k] = X[y == k].shape[0]
+        self.num_updates = X.shape[0]
+
+        print('\nEstimating initial covariance matrix...')
+        from sklearn.covariance import OAS
+        cov_estimator = OAS(assume_centered=True)
+        cov_estimator.fit((X - self.muK[y]).cpu().numpy())
+        self.Sigma = torch.from_numpy(cov_estimator.covariance_).float().to(
+            self.device)
+
+    def pool_feat(self, features):
+        feat_size = features.shape[-1]
+        num_channels = features.shape[1]
+        features2 = features.permute(0, 2, 3,
+                                     1)  # 1 x feat_size x feat_size x num_channels
+        features3 = torch.reshape(features2, (
+            features.shape[0], feat_size * feat_size, num_channels))
+        feat = features3.mean(1)  # mb x num_channels
+        return feat
+
+    def train_model(self, train_loader):
+
+        for train_x, train_y, _ in train_loader:
+            batch_x_feat = self.feature_extraction_wrapper(train_x.to(self.device))
+            batch_x_feat = self.pool_feat(batch_x_feat)
+
+            # train one sample at a time
+            for x_pt, y_pt in zip(batch_x_feat, train_y):
+                self.fit(x_pt.cpu(), y_pt.view(1, ))
+
+    def evaluate_model(self, test_loader):
+        preds = []
+        correct = 0
+
+        for it, (test_x, test_y, _) in enumerate(test_loader):
+            batch_x_feat = self.feature_extraction_wrapper(test_x.to(self.device))
+            batch_x_feat = self.pool_feat(batch_x_feat)
+
+            logits = self.predict(batch_x_feat, return_probas=True)
+
+            _, pred_label = torch.max(logits, 1)
+            correct += (pred_label == test_y).sum()
+            preds += list(pred_label.numpy())
+
+        acc = correct.item() / len(test_loader.dataset)
+        return acc, preds
+
+    def save_model(self, save_path, save_name):
+        """
+        Save the model parameters to a torch file.
+        :param save_path: the path where the model will be saved
+        :param save_name: the name for the saved file
+        :return:
+        """
+        # grab parameters for saving
+        d = dict()
+        d['muK'] = self.muK.cpu()
+        d['cK'] = self.cK.cpu()
+        d['Sigma'] = self.Sigma.cpu()
+        d['num_updates'] = self.num_updates
+
+        # save model out
+        torch.save(d, os.path.join(save_path, save_name + '.pth'))
+
+    def load_model(self, save_path, save_name):
+        """
+        Load the model parameters into StreamingLDA object.
+        :param save_path: the path where the model is saved
+        :param save_name: the name of the saved file
+        :return:
+        """
+        # load parameters
+        d = torch.load(os.path.join(save_path, save_name + '.pth'))
+        self.muK = d['muK'].to(self.device)
+        self.cK = d['cK'].to(self.device)
+        self.Sigma = d['Sigma'].to(self.device)
+        self.num_updates = d['num_updates']

--- a/examples/deep_slda.py
+++ b/examples/deep_slda.py
@@ -48,7 +48,8 @@ def main(args):
     # --- SCENARIO CREATION
     scenario = CORe50(root=args.dataset_dir, scenario=args.scenario,
                       train_transform=transform, eval_transform=transform)
-    test_data_loader = DataLoader(scenario.test_dataset, batch_size=args.batch_size,
+    test_data_loader = DataLoader(scenario.test_dataset,
+                                  batch_size=args.batch_size,
                                   shuffle=False, num_workers=8)
     # ---------
 
@@ -98,12 +99,15 @@ if __name__ == '__main__':
 
     # deep slda model parameters
     parser.add_argument('--arch', type=str, default='resnet18', choices=[
-        'resnet18'])  # to change this, need to modify creation of `self.feature_extraction_wrapper'
-    # `avalanche.training.strategies.deep_slda import StreamingLDA'
+        'resnet18'])  # to change this, need to modify creation of
+    # `self.feature_extraction_wrapper' in
+    # `avalanche.training.strategies.deep_slda'
     parser.add_argument('--imagenet_pretrained', type=bool,
-                        default=True)  # initialize backbone with imagenet pre-trained weights
+                        default=True)  # initialize backbone with
+    # imagenet pre-trained weights
     parser.add_argument('--feature_size', type=int,
-                        default=512)  # feature size before output layer (512 for resnet-18)
+                        default=512)  # feature size before output layer
+    # (512 for resnet-18)
     parser.add_argument('--shrinkage', type=float,
                         default=1e-4)  # shrinkage value
     parser.add_argument('--plastic_cov', type=bool,

--- a/examples/deep_slda.py
+++ b/examples/deep_slda.py
@@ -1,0 +1,114 @@
+################################################################################
+# Copyright (c) 2021 ContinualAI.                                              #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 06-04-2021                                                             #
+# Author(s): Tyler Hayes                                                       #
+# E-mail: contact@continualai.org                                              #
+# Website: avalanche.continualai.org                                           #
+################################################################################
+
+"""
+This is a simple example on how to use the Deep SLDA strategy.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import torch
+from torchvision import transforms
+from torch.utils.data.dataloader import DataLoader
+
+from avalanche.benchmarks.classic import CORe50
+from avalanche.training.strategies.deep_slda import StreamingLDA
+
+
+def main(args):
+    # Device config
+    device = torch.device(f"cuda:{args.cuda}"
+                          if torch.cuda.is_available() and
+                             args.cuda >= 0 else "cpu")
+    print('device ', device)
+    # ---------
+
+    # --- TRANSFORMATIONS
+    _mu = [0.485, 0.456, 0.406]  # imagenet normalization
+    _std = [0.229, 0.224, 0.225]
+    transform = transforms.Compose([
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=_mu,
+                             std=_std)
+    ])
+    # ---------
+
+    # --- SCENARIO CREATION
+    scenario = CORe50(root=args.dataset_dir, scenario=args.scenario,
+                      train_transform=transform, eval_transform=transform)
+    test_data_loader = DataLoader(scenario.test_dataset, batch_size=args.batch_size,
+                                  shuffle=False, num_workers=8)
+    # ---------
+
+    # CREATE THE STRATEGY INSTANCE
+    cl_strategy = StreamingLDA(args.feature_size, args.n_classes,
+                               test_batch_size=args.batch_size,
+                               shrinkage_param=args.shrinkage,
+                               streaming_update_sigma=args.plastic_cov,
+                               arch=args.arch,
+                               imagenet_pretrained=args.imagenet_pretrained,
+                               device=device)
+
+    # TRAINING LOOP
+    print('Starting experiment...')
+    results = []
+    for i, batch in enumerate(scenario.train_stream):
+        print("\n----------- Batch {0}/{1} -------------".format(i + 1, len(
+            scenario.train_stream)))
+        train_loader = DataLoader(batch.dataset, batch_size=args.batch_size,
+                                  shuffle=False, num_workers=8)
+
+        # fit SLDA model to batch (one sample at a time)
+        cl_strategy.train_model(train_loader)
+
+        # evaluate model on test data
+        test_acc, preds = cl_strategy.evaluate_model(test_data_loader)
+
+        print("------------------------------------------")
+        print("Test Accuracy: %0.3f" % test_acc)
+        print("------------------------------------------")
+
+        # update results
+        results.append(test_acc)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser('SLDA Example with ResNet-18 on CORe50')
+    parser.add_argument('--cuda', type=int, default=0,
+                        help='Select zero-indexed cuda device. -1 to use CPU.')
+
+    parser.add_argument('--n_classes', type=int, default=50)
+    parser.add_argument('--scenario', type=str, default="nc",
+                        choices=['ni', 'nc', 'nic', 'nicv2_79', 'nicv2_196',
+                                 'nicv2_391'])
+    parser.add_argument('--dataset_dir', type=str,
+                        default='/media/tyler/Data/datasets/core50/')
+
+    # deep slda model parameters
+    parser.add_argument('--arch', type=str, default='resnet18', choices=[
+        'resnet18'])  # to change this, need to modify creation of `self.feature_extraction_wrapper'
+    # `avalanche.training.strategies.deep_slda import StreamingLDA'
+    parser.add_argument('--imagenet_pretrained', type=bool,
+                        default=True)  # initialize backbone with imagenet pre-trained weights
+    parser.add_argument('--feature_size', type=int,
+                        default=512)  # feature size before output layer (512 for resnet-18)
+    parser.add_argument('--shrinkage', type=float,
+                        default=1e-4)  # shrinkage value
+    parser.add_argument('--plastic_cov', type=bool,
+                        default=True)  # plastic covariance matrix
+    parser.add_argument('--batch_size', type=int, default=512)
+
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
I added `deep_slda` to `training/strategies` and an example script to run it on CORe50 in `examples/deep_slda`

The model works as expected, however I am a bit unsure about how to integrate the avalanche metrics and logging features into these scripts. Deep SLDA does not perform gradient descent, so it trains a bit differently than the default `BaseStrategy`

Would someone be able to set some time up to discuss this implementation with me so I can get Deep SLDA integrated with the Avalanche loggers and metrics? Thank you in advance!

@AntonioCarta