### PR TITLE
Update cub200.py

### DIFF
--- a/avalanche/benchmarks/datasets/cub200/cub200.py
+++ b/avalanche/benchmarks/datasets/cub200/cub200.py
@@ -82,10 +82,10 @@ class CUB200(Dataset):
     def __getitem__(self, idx):
 
         sample = self.data_paths[idx]
-        path = os.path.join(self.root, self.basefolder, sample)
+        path = os.path.join(self.root, self.basefolder, sample).strip()
         # Targets start at 1 by default, so shift to 0
         target = self.targets[idx] - 1
-        img = self.loader(path[:-1])
+        img = self.loader(path)
 
         if self.transform is not None:
             img = self.transform(img)

--- a/avalanche/benchmarks/datasets/cub200/cub200.py
+++ b/avalanche/benchmarks/datasets/cub200/cub200.py
@@ -85,7 +85,7 @@ class CUB200(Dataset):
         path = os.path.join(self.root, self.basefolder, sample)
         # Targets start at 1 by default, so shift to 0
         target = self.targets[idx] - 1
-        img = self.loader(path)
+        img = self.loader(path[:-1])
 
         if self.transform is not None:
             img = self.transform(img)


### PR DESCRIPTION
We used classic benchmarks SplitCUB200.
On running the below line for training CUB200 dataset with Class Incremental Learning, we get the following error and this basically occurs due to reading line from the train.txt in the lists.tgz file for getting the path of the image. 

cl_strategy.train(experience)

FileNotFoundError: [Errno 2] No such file or directory: '/content/drive/MyDrive/CUB/images/066.Western_Gull/Western_Gull_0002_259335622.jpg\n'