### PR TITLE
Add histogram and figure logging, fixed confusion matrix bug

### DIFF
--- a/avalanche/evaluation/metrics/confusion_matrix.py
+++ b/avalanche/evaluation/metrics/confusion_matrix.py
@@ -180,7 +180,7 @@ class ConfusionMatrix(Metric[Tensor]):
             return torch.zeros(matrix_shape, dtype=torch.long)
         if self.normalize is not None:
             return ConfusionMatrix._normalize_cm(self._cm_tensor,
-                                                 self._normalize)
+                                                 self.normalize)
         return self._cm_tensor
 
     def reset(self) -> None:

--- a/avalanche/training/plugins/evaluation.py
+++ b/avalanche/training/plugins/evaluation.py
@@ -1,7 +1,6 @@
 import warnings
 from collections import defaultdict
 from typing import Union, Sequence, TYPE_CHECKING
-from copy import deepcopy
 from avalanche.training.plugins.strategy_plugin import StrategyPlugin
 
 if TYPE_CHECKING:
@@ -102,7 +101,7 @@ class EvaluationPlugin(StrategyPlugin):
         :return: a dictionary with full metric
             names as keys and last metric value as value.
         """
-        return deepcopy(self.last_metric_results)
+        return self.last_metric_results
 
     def get_all_metrics(self):
         """
@@ -118,7 +117,7 @@ class EvaluationPlugin(StrategyPlugin):
             is False return an empty dictionary
         """
         if self.collect_all:
-            return deepcopy(self.all_metric_results)
+            return self.all_metric_results
         else:
             return {}
 

--- a/avalanche/training/plugins/evaluation.py
+++ b/avalanche/training/plugins/evaluation.py
@@ -1,4 +1,5 @@
 import warnings
+from copy import copy
 from collections import defaultdict
 from typing import Union, Sequence, TYPE_CHECKING
 from avalanche.training.plugins.strategy_plugin import StrategyPlugin
@@ -95,18 +96,18 @@ class EvaluationPlugin(StrategyPlugin):
 
     def get_last_metrics(self):
         """
-        Return dictionary with metric names as keys and last metrics
-        value as values.
+        Return a shallow copy of dictionary with metric names
+        as keys and last metrics value as values.
 
         :return: a dictionary with full metric
             names as keys and last metric value as value.
         """
-        return self.last_metric_results
+        return copy(self.last_metric_results)
 
     def get_all_metrics(self):
         """
-        Return all collected metrics. This method should be called
-        only when `collect_all` is set to True.
+        Return the dictionary of all collected metrics.
+        This method should be called only when `collect_all` is set to True.
 
         :return: if `collect_all` is True, returns a dictionary
             with full metric names as keys and a tuple of two lists


### PR DESCRIPTION
This PR brings the following changes:

1. WandbLogger and Tensorboard logger now logs also matplotlib Figure and histogram
2. Confusion matrix is logged as a figure, not image. By default, the confusion matrix does not show numbers in the cell, to accommodate for medium / large number of classes. 
3. Confusion matrix now uses `num_classes` to fix the size of the confusion matrix for all the training and evaluation. This value is strict. The class documentation has been updated to explain the change.
4. The evaluation logger returns the plain metric dictionary instead of a copy. This is because matplotlib Figures cannot be deepcopied. This should not be a problem because loggers logs metrics instantly.


This closes #513 