### PR TITLE
Fixed bug before SimpleCNN classifier

### DIFF
--- a/avalanche/models/simple_cnn.py
+++ b/avalanche/models/simple_cnn.py
@@ -45,7 +45,7 @@ class SimpleCNN(nn.Module):
 
     def forward(self, x):
         x = self.features(x)
-        x = x.squeeze()
+        x = x.view(x.size(0), -1)
         x = self.classifier(x)
         return x
 


### PR DESCRIPTION
The `SimpleCNN` previously removes all the dimensions with size 1. This removed also batch size, which was instead needed.

This closes #524 