### PR TITLE
Added correct reference to the SI paper

### DIFF
--- a/avalanche/training/plugins/synaptic_intelligence.py
+++ b/avalanche/training/plugins/synaptic_intelligence.py
@@ -23,8 +23,13 @@ class SynapticIntelligencePlugin(StrategyPlugin):
     The Synaptic Intelligence plugin.
 
     This is the Synaptic Intelligence PyTorch implementation of the
-    algorithm described in the paper "Continual Learning Through Synaptic
-    Intelligence" (https://arxiv.org/abs/1703.04200).
+    algorithm described in the paper
+    "Continuous Learning in Single-Incremental-Task Scenarios"
+    (https://arxiv.org/abs/1806.08568)
+
+    The original implementation has been proposed in the paper
+    "Continual Learning Through Synaptic Intelligence"
+    (https://arxiv.org/abs/1703.04200).
 
     This plugin can be attached to existing strategies to achieve a
     regularization effect.

--- a/avalanche/training/strategies/strategy_wrappers.py
+++ b/avalanche/training/strategies/strategy_wrappers.py
@@ -397,8 +397,13 @@ class SynapticIntelligence(BaseStrategy):
     The Synaptic Intelligence strategy.
 
     This is the Synaptic Intelligence PyTorch implementation of the
-    algorithm described in the paper "Continual Learning Through Synaptic
-    Intelligence" (https://arxiv.org/abs/1703.04200).
+    algorithm described in the paper
+    "Continuous Learning in Single-Incremental-Task Scenarios"
+    (https://arxiv.org/abs/1806.08568)
+
+    The original implementation has been proposed in the paper
+    "Continual Learning Through Synaptic Intelligence"
+    (https://arxiv.org/abs/1703.04200).
 
     The Synaptic Intelligence regularization can also be used in a different
     strategy by applying the :class:`SynapticIntelligencePlugin` plugin.


### PR DESCRIPTION
The Synaptic Intelligence implementation refers to a different paper than the original one. I clarified this fact in the plugin and strategy doc.

This closes #106 