### PR TITLE
num_workers=0 for all the examples and notebooks

### DIFF
--- a/examples/ar1.py
+++ b/examples/ar1.py
@@ -62,11 +62,11 @@ def main(args):
         print("Start of experience: ", experience.current_experience)
         print("Current Classes: ", experience.classes_in_this_experience)
 
-        cl_strategy.train(experience, num_workers=4)
+        cl_strategy.train(experience, num_workers=0)
         print('Training completed')
 
         print('Computing accuracy on the whole test set')
-        results.append(cl_strategy.eval(scenario.test_stream, num_workers=4))
+        results.append(cl_strategy.eval(scenario.test_stream, num_workers=0))
 
 
 if __name__ == '__main__':

--- a/examples/lwf_mnist.py
+++ b/examples/lwf_mnist.py
@@ -57,7 +57,7 @@ def main(args):
         print("Start training on experience ",
               train_batch_info.current_experience)
 
-        strategy.train(train_batch_info, num_workers=4)
+        strategy.train(train_batch_info, num_workers=0)
         print("End training on experience ",
               train_batch_info.current_experience)
         print('Computing accuracy on the test set')

--- a/examples/task_incremental.py
+++ b/examples/task_incremental.py
@@ -53,7 +53,7 @@ def main(args):
 
     # train and test loop
     for train_task in train_stream:
-        strategy.train(train_task, num_workers=4)
+        strategy.train(train_task, num_workers=0)
         strategy.eval(test_stream)
 
 


### PR DESCRIPTION
This PR simply sets num_workers=0 for all the examples and notebooks to avoid bugs on Windows.

Solves #510.