### PR TITLE
Fixed bug in global it counter

### DIFF
--- a/avalanche/evaluation/metric_definitions.py
+++ b/avalanche/evaluation/metric_definitions.py
@@ -73,8 +73,8 @@ class PluginMetric(Metric[TResult], StrategyCallbacks['MetricResult'], ABC):
     the `result`, `reset` and the desired callbacks to compute the specific
     metric.
 
-    Remember to call the `super()` method when overriding `after_train_iteration` or
-    `after_eval_iteration`.
+    Remember to call the `super()` method when overriding
+    `after_train_iteration` or `after_eval_iteration`.
 
     An instance of this class usually leverages a `Metric` instance to update,
     reset and emit metric results at appropriate times

--- a/avalanche/evaluation/metric_definitions.py
+++ b/avalanche/evaluation/metric_definitions.py
@@ -72,6 +72,10 @@ class PluginMetric(Metric[TResult], StrategyCallbacks['MetricResult'], ABC):
     invoked by the :class:`EvaluationPlugin`. Subclasses should implement
     the `result`, `reset` and the desired callbacks to compute the specific
     metric.
+
+    Remember to call the `super()` method when overriding `after_train_iteration` or
+    `after_eval_iteration`.
+
     An instance of this class usually leverages a `Metric` instance to update,
     reset and emit metric results at appropriate times
     (during specific callbacks).

--- a/avalanche/evaluation/metrics/accuracy.py
+++ b/avalanche/evaluation/metrics/accuracy.py
@@ -137,6 +137,7 @@ class MinibatchAccuracy(PluginMetric[float]):
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> MetricResult:
+        super().after_training_iteration(strategy)
         self.reset()  # Because this metric computes the accuracy of a single mb
         self._minibatch_accuracy.update(strategy.mb_y,
                                         strategy.logits)
@@ -179,6 +180,7 @@ class EpochAccuracy(PluginMetric[float]):
         return self._accuracy_metric.result()
 
     def after_training_iteration(self, strategy: 'BaseStrategy') -> None:
+        super().after_training_iteration(strategy)
         self._accuracy_metric.update(strategy.mb_y,
                                      strategy.logits)
 
@@ -266,6 +268,7 @@ class ExperienceAccuracy(PluginMetric[float]):
         self.reset()
 
     def after_eval_iteration(self, strategy: 'BaseStrategy') -> None:
+        super().after_eval_iteration(strategy)
         self._accuracy_metric.update(strategy.mb_y,
                                      strategy.logits)
 
@@ -312,6 +315,7 @@ class StreamAccuracy(PluginMetric[float]):
         self.reset()
 
     def after_eval_iteration(self, strategy: 'BaseStrategy') -> None:
+        super().after_eval_iteration(strategy)
         self._accuracy_metric.update(strategy.mb_y,
                                      strategy.logits)
 

--- a/avalanche/evaluation/metrics/confusion_matrix.py
+++ b/avalanche/evaluation/metrics/confusion_matrix.py
@@ -296,6 +296,7 @@ class StreamConfusionMatrix(PluginMetric[Tensor]):
         self.reset()
 
     def after_eval_iteration(self, strategy: 'BaseStrategy') -> None:
+        super().after_eval_iteration(strategy)
         self.update(strategy.mb_y,
                     strategy.logits)
 

--- a/avalanche/evaluation/metrics/cpu_usage.py
+++ b/avalanche/evaluation/metrics/cpu_usage.py
@@ -150,6 +150,7 @@ class MinibatchCPUUsage(PluginMetric[float]):
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> MetricResult:
+        super().after_training_iteration(strategy)
         self._minibatch_cpu.update()
         return self._package_result(strategy)
 
@@ -236,6 +237,7 @@ class RunningEpochCPUUsage(PluginMetric[float]):
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> None:
+        super().after_training_iteration(strategy)
         self._epoch_cpu.update()
         self._cpu_mean.update(self._epoch_cpu.result())
         self._epoch_cpu.reset()

--- a/avalanche/evaluation/metrics/disk_usage.py
+++ b/avalanche/evaluation/metrics/disk_usage.py
@@ -132,6 +132,7 @@ class MinibatchDiskUsage(PluginMetric[float]):
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> MetricResult:
+        super().after_training_iteration(strategy)
         self._minibatch_disk.update()
         return self._package_result(strategy)
 

--- a/avalanche/evaluation/metrics/forgetting.py
+++ b/avalanche/evaluation/metrics/forgetting.py
@@ -195,6 +195,7 @@ class ExperienceForgetting(PluginMetric[Dict[int, float]]):
         self._current_accuracy.reset()
 
     def after_eval_iteration(self, strategy: 'BaseStrategy') -> None:
+        super().after_eval_iteration(strategy)
         self.eval_exp_id = strategy.experience.current_experience
         self._current_accuracy.update(strategy.mb_y,
                                       strategy.logits)
@@ -343,6 +344,7 @@ class StreamForgetting(PluginMetric[Dict[int, float]]):
         self._current_accuracy.reset()
 
     def after_eval_iteration(self, strategy: 'BaseStrategy') -> None:
+        super().after_eval_iteration(strategy)
         self.eval_exp_id = strategy.experience.current_experience
         self._current_accuracy.update(strategy.mb_y,
                                       strategy.logits)

--- a/avalanche/evaluation/metrics/gpu_usage.py
+++ b/avalanche/evaluation/metrics/gpu_usage.py
@@ -154,6 +154,7 @@ class MinibatchMaxGPU(PluginMetric[float]):
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> MetricResult:
+        super().after_training_iteration(strategy)
         return self._package_result(strategy)
 
     def after_training(self, strategy: 'BaseStrategy') -> None:

--- a/avalanche/evaluation/metrics/loss.py
+++ b/avalanche/evaluation/metrics/loss.py
@@ -110,6 +110,7 @@ class MinibatchLoss(PluginMetric[float]):
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> MetricResult:
+        super().after_training_iteration(strategy)
         self.reset()  # Because this metric computes the loss of a single mb
         self._loss_metric.update(strategy.loss,
                                  patterns=len(strategy.mb_y))
@@ -150,6 +151,7 @@ class EpochLoss(PluginMetric[float]):
         self.reset()
 
     def after_training_iteration(self, strategy: 'BaseStrategy') -> None:
+        super().after_training_iteration(strategy)
         self._loss_metric.update(strategy.loss, len(strategy.mb_y))
 
     def after_training_epoch(self, strategy: 'BaseStrategy') \
@@ -239,6 +241,7 @@ class ExperienceLoss(PluginMetric[float]):
         self.reset()
 
     def after_eval_iteration(self, strategy: 'BaseStrategy') -> None:
+        super().after_eval_iteration(strategy)
         self._loss_metric.update(strategy.loss, len(strategy.mb_y))
 
     def after_eval_exp(self, strategy: 'BaseStrategy') -> \
@@ -284,6 +287,7 @@ class StreamLoss(PluginMetric[float]):
         self.reset()
 
     def after_eval_iteration(self, strategy: 'BaseStrategy') -> None:
+        super().after_eval_iteration(strategy)
         self._loss_metric.update(strategy.loss, len(strategy.mb_y))
 
     def after_eval(self, strategy: 'BaseStrategy') -> \

--- a/avalanche/evaluation/metrics/mac.py
+++ b/avalanche/evaluation/metrics/mac.py
@@ -114,6 +114,7 @@ class MinibatchMAC(PluginMetric[float]):
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> MetricResult:
+        super().after_training_iteration(strategy)
         self._minibatch_MAC.update(strategy.model,
                                    strategy.mb_x[0].unsqueeze(0))
         return self._package_result(strategy)

--- a/avalanche/evaluation/metrics/ram_usage.py
+++ b/avalanche/evaluation/metrics/ram_usage.py
@@ -141,6 +141,7 @@ class MinibatchMaxRAM(PluginMetric[float]):
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> MetricResult:
+        super().after_training_iteration(strategy)
         return self._package_result(strategy)
 
     def after_training(self, strategy: 'BaseStrategy') -> None:

--- a/avalanche/evaluation/metrics/timing.py
+++ b/avalanche/evaluation/metrics/timing.py
@@ -117,6 +117,7 @@ class MinibatchTime(PluginMetric[float]):
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> MetricResult:
+        super().after_training_iteration(strategy)
         self._minibatch_time.update()
         return self._package_result(strategy)
 
@@ -205,6 +206,7 @@ class RunningEpochTime(PluginMetric[float]):
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> MetricResult:
+        super().after_training_iteration(strategy)
         self._epoch_time.update()
         self._time_mean.update(self._epoch_time.result())
         self._epoch_time.reset()


### PR DESCRIPTION
I added `super` calls to correctly update the global counter for metrics.

This is related to #550 