### PR TITLE
Fix wrong normalization statistics for CIFAR-100

### DIFF
--- a/avalanche/benchmarks/classic/ccifar100.py
+++ b/avalanche/benchmarks/classic/ccifar100.py
@@ -24,14 +24,14 @@ _default_cifar100_train_transform = transforms.Compose([
     transforms.RandomCrop(32, padding=4),
     transforms.RandomHorizontalFlip(),
     transforms.ToTensor(),
-    transforms.Normalize((0.4914, 0.4822, 0.4465),
-                         (0.2023, 0.1994, 0.2010))
+    transforms.Normalize((0.5071, 0.4865, 0.4409),
+                         (0.2673, 0.2564, 0.2762))
 ])
 
 _default_cifar100_eval_transform = transforms.Compose([
     transforms.ToTensor(),
-    transforms.Normalize((0.4914, 0.4822, 0.4465),
-                         (0.2023, 0.1994, 0.2010))
+    transforms.Normalize((0.5071, 0.4865, 0.4409),
+                         (0.2673, 0.2564, 0.2762))
 ])
 
 


### PR DESCRIPTION
CIFAR-100 has different normalization stats than CIFAR-10. However, in the current implementation, the same stats were used for CIFAR-10 and CIFAR-100.
This commit fixes this issue.

Source for calculating stats: https://gist.github.com/weiaicunzai/e623931921efefd4c331622c344d8151