### PR TITLE
Fix wrong normalization statistics for Fashion MNIST

### DIFF
--- a/avalanche/benchmarks/classic/cfashion_mnist.py
+++ b/avalanche/benchmarks/classic/cfashion_mnist.py
@@ -22,12 +22,12 @@ from avalanche.benchmarks.utils import train_eval_avalanche_datasets
 
 _default_fmnist_train_transform = transforms.Compose([
     transforms.ToTensor(),
-    transforms.Normalize((0.2190,), (0.3318,))
+    transforms.Normalize((0.2860,), (0.3530,))
 ])
 
 _default_fmnist_eval_transform = transforms.Compose([
     transforms.ToTensor(),
-    transforms.Normalize((0.2190,), (0.3318,))
+    transforms.Normalize((0.2860,), (0.3530,))
 ])
 
 


### PR DESCRIPTION
Fashion MNIST normalization stats are wrong in the current implementation.  

Source for calculating stats: https://gist.github.com/weiaicunzai/e623931921efefd4c331622c344d8151