### PR TITLE
pytorchcv wrapper

### DIFF
--- a/avalanche/models/pytorchcv_wrapper.py
+++ b/avalanche/models/pytorchcv_wrapper.py
@@ -1,0 +1,99 @@
+################################################################################
+# Copyright (c) 2021 ContinualAI.                                              #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 1-05-2020                                                              #
+# Author(s): Eli Verwimp                                       #
+# E-mail: contact@continualai.org                                              #
+# Website: www.continualai.org                                                 #
+################################################################################
+
+"""
+This module wraps pytorchcv models, with some convient wrappers.
+"""
+
+from pytorchcv.model_provider import get_model as ptcv_get_model
+from torch.nn import Module
+
+
+def vgg(depth: int, batch_normalization=False, pretrained=False) -> Module:
+    """
+    Wrapper for VGG net of verious depths availble in pytorchcv. Only availabe for imagenet.
+    :param depth: Depth of the model, one of (11, 13, 16, 19)
+    :param batch_normalization: include batch normalizaion layers
+    :param pretrained: loads model pretrained on imagnet
+    """
+    available_depths = [11, 13, 16, 19]
+    if depth not in available_depths:
+        raise ValueError(f"Depth {depth} not available, availble depths are {available_depths}")
+
+    name = f"vgg_{depth}"
+    if batch_normalization:
+        name = f"bn_{name}"
+
+    return ptcv_get_model(name, pretrained=pretrained)
+
+
+def resnet(dataset: str, depth: int, pretrained=False) -> Module:
+    """
+    Loader for (basic) renset available in the pytorchcv package. More variants are availble through
+    the general wrapper.
+    :param dataset: One of cifar10, cifar100, svhn, imagenet.
+    :param depth: depth of the architecture, one of (10, 12, 14, 16, 18, 26, 34, 50, 101, 152, 200) for
+                  imagenet, (20, 56, 110, 1001, 1202) for the other datasets.
+    :param pretrained: loads model pretrained on `dataset`.
+    """
+
+    if dataset in ["cifar10", "cifar100", "svhn"]:
+        available_depths = [20, 56, 110, 1001, 1202]
+        model_name = f"resnet{depth}_{dataset}"
+    elif dataset == "imagenet":
+        available_depths = [10, 12, 14, 16, 18, 26, 34, 50, 101, 152, 200]
+        model_name = f"resnet{depth}"
+    else:
+        raise ValueError(f"Unrecognized dataset {dataset}")
+
+    if depth not in available_depths:
+        raise ValueError(f"Depth {depth} not available for dataset {dataset}, "
+                         f"availble depths are {available_depths}")
+
+    model = ptcv_get_model(model_name, pretrained=pretrained)
+    return model
+
+
+def densenet(dataset: str, depth: int,  pretrained=False) -> Module:
+    """
+    Loader for densenets available in the pytorchcv package.
+    :param dataset: One of cifar10, cifar100, svhn, imagenet.
+    :param depth: The depth of the densnet. For imagenet depths (121, 161, 169, 201) are supported.
+                  The other datasets support dephts (40, 100, 190, 250).
+    :param pretrained: load model pretrained on `dataset`..
+    """
+    if dataset in ["cifar10", "cifar100", "svhn"]:
+        available_depths = [40, 100, 190, 250]
+        # other growth rates are available through the general method.
+        growth_rate = 40 if depth == 190 else 24
+        model_name = f"resnet{depth}_k{growth_rate}_{dataset}"
+    elif dataset == "imagenet":
+        available_depths = [121, 161, 169, 201]
+        model_name = f"resnet{depth}"
+    else:
+        raise ValueError(f"Unrecognized dataset {dataset}")
+
+    if depth not in available_depths:
+        raise ValueError(f"Depth {depth} not available for dataset {dataset}, "
+                         f"availble depths are {available_depths}")
+
+    model = ptcv_get_model(model_name, pretrained=pretrained)
+    return model
+
+
+def get_model(name: str, pretrained=False):
+    """
+    This a direct wrapper to the model getter of `pytorchcv`. For available models see:
+     https://github.com/osmr/imgclsmob
+    """
+    return ptcv_get_model(name, pretrained=pretrained)
+
+

--- a/avalanche/models/pytorchcv_wrapper.py
+++ b/avalanche/models/pytorchcv_wrapper.py
@@ -4,13 +4,25 @@
 # See the accompanying LICENSE file for terms.                                 #
 #                                                                              #
 # Date: 1-05-2020                                                              #
-# Author(s): Eli Verwimp                                       #
+# Author(s): Eli Verwimp                                                       #
 # E-mail: contact@continualai.org                                              #
 # Website: www.continualai.org                                                 #
 ################################################################################
 
 """
-This module wraps pytorchcv models, with some convient wrappers.
+This module provides acces to pytorchcv models. A general wrapper is available
+through get_model. For VGG, Resnet, DenseNet and Pyramidnet direct wrappers are
+provided.
+
+Models pretrained on e.g. Imagenet don't necessairly have the same structure
+as those used typically used for smaller datasets like Cifar10. So be carefull
+when adapting pretrained models for different datasets.
+
+Not all options (e.g. growth rate for densenet, alpha in pyramidnet,
+bottlenecks...) are available through the direct wrappers. If a more specific
+models is required, it can be loaded through the general method.
+
+Currently this module only wraps to pytorchcv models.
 """
 
 from pytorchcv.model_provider import get_model as ptcv_get_model
@@ -131,7 +143,7 @@ def pyramidnet(dataset: str, depth: int, pretrained=False) -> Module:
 def get_model(name: str, pretrained=False):
     """
     This a direct wrapper to the model getter of `pytorchcv`. For available
-     models see: https://github.com/osmr/imgclsmob
+    models see: https://github.com/osmr/imgclsmob
     """
     return ptcv_get_model(name, pretrained=pretrained)
 

--- a/avalanche/models/pytorchcv_wrapper.py
+++ b/avalanche/models/pytorchcv_wrapper.py
@@ -19,16 +19,19 @@ from torch.nn import Module
 
 def vgg(depth: int, batch_normalization=False, pretrained=False) -> Module:
     """
-    Wrapper for VGG net of verious depths availble in pytorchcv. Only availabe for imagenet.
+    Wrapper for VGG net of verious depths availble in the pytorchcv package.
+    VGG is only availabe for imagenet.
+
     :param depth: Depth of the model, one of (11, 13, 16, 19)
     :param batch_normalization: include batch normalizaion layers
     :param pretrained: loads model pretrained on imagnet
     """
     available_depths = [11, 13, 16, 19]
     if depth not in available_depths:
-        raise ValueError(f"Depth {depth} not available, availble depths are {available_depths}")
+        raise ValueError(f"Depth {depth} not available, "
+                         f"availble depths are {available_depths}")
 
-    name = f"vgg_{depth}"
+    name = f"vgg{depth}"
     if batch_normalization:
         name = f"bn_{name}"
 
@@ -37,11 +40,13 @@ def vgg(depth: int, batch_normalization=False, pretrained=False) -> Module:
 
 def resnet(dataset: str, depth: int, pretrained=False) -> Module:
     """
-    Loader for (basic) renset available in the pytorchcv package. More variants are availble through
-    the general wrapper.
+    Wrapper for (basic) renset available in the pytorchcv package. More variants
+    are availble through the general wrapper.
+
     :param dataset: One of cifar10, cifar100, svhn, imagenet.
-    :param depth: depth of the architecture, one of (10, 12, 14, 16, 18, 26, 34, 50, 101, 152, 200) for
-                  imagenet, (20, 56, 110, 1001, 1202) for the other datasets.
+    :param depth: depth of the architecture, one of (10, 12, 14, 16, 18, 26, 34,
+                  50, 101, 152, 200) for imagenet,
+                  (20, 56, 110, 1001, 1202) for the other datasets.
     :param pretrained: loads model pretrained on `dataset`.
     """
 
@@ -62,22 +67,56 @@ def resnet(dataset: str, depth: int, pretrained=False) -> Module:
     return model
 
 
-def densenet(dataset: str, depth: int,  pretrained=False) -> Module:
+def densenet(dataset: str, depth: int, pretrained=False) -> Module:
     """
-    Loader for densenets available in the pytorchcv package.
+    Wrapper for densenet available in the pytorchcv package.
+
     :param dataset: One of cifar10, cifar100, svhn, imagenet.
-    :param depth: The depth of the densnet. For imagenet depths (121, 161, 169, 201) are supported.
-                  The other datasets support dephts (40, 100, 190, 250).
+    :param depth: The depth of the densnet. For imagenet depths
+                  (121, 161, 169, 201) are supported. The other datasets
+                   support dephts (40, 100).
     :param pretrained: load model pretrained on `dataset`..
     """
     if dataset in ["cifar10", "cifar100", "svhn"]:
-        available_depths = [40, 100, 190, 250]
+        available_depths = [40, 100]
         # other growth rates are available through the general method.
-        growth_rate = 40 if depth == 190 else 24
-        model_name = f"resnet{depth}_k{growth_rate}_{dataset}"
+        growth_rate = 12
+        model_name = f"densenet{depth}_k{growth_rate}_{dataset}"
     elif dataset == "imagenet":
         available_depths = [121, 161, 169, 201]
-        model_name = f"resnet{depth}"
+        model_name = f"densenet{depth}"
+    else:
+        raise ValueError(f"Unrecognized dataset {dataset}")
+
+    if depth not in available_depths:
+        raise ValueError(f"Depth {depth} not available for dataset {dataset}, "
+                         f"availble depths are {available_depths}")
+
+    model = ptcv_get_model(model_name, pretrained=pretrained)
+    return model
+
+
+def pyramidnet(dataset: str, depth: int, pretrained=False) -> Module:
+    """
+    Wrapper for pyramidnet available in the pytorchcv package.
+
+    :param dataset: One of cifar10, cifar100, svhn, imagenet.
+    :param depth: The depth of the pyramidnet. For imagenet 101 is supported.
+                  The other datasets support dephts (110, 164, 200, 236, 272).
+    :param pretrained: load model pretrained on `dataset`..
+    """
+    if dataset in ["cifar10", "cifar100", "svhn"]:
+        available_depths = [110, 164, 200, 236, 272]
+        alpha = {110: 48, 164: 270, 200: 240, 236: 220, 272: 200}.get(depth)
+        if depth < 200:
+            model_name = f"pyramidnet{depth}_a{alpha}_{dataset}"
+        else:
+            # These models have batch normalization
+            model_name = f"pyramidnet{depth}_a{alpha}_bn_{dataset}"
+    elif dataset == "imagenet":
+        available_depths = [101]
+        alpha = 360
+        model_name = f"pyramidnet{depth}_a{alpha}"
     else:
         raise ValueError(f"Unrecognized dataset {dataset}")
 
@@ -91,9 +130,16 @@ def densenet(dataset: str, depth: int,  pretrained=False) -> Module:
 
 def get_model(name: str, pretrained=False):
     """
-    This a direct wrapper to the model getter of `pytorchcv`. For available models see:
-     https://github.com/osmr/imgclsmob
+    This a direct wrapper to the model getter of `pytorchcv`. For available
+     models see: https://github.com/osmr/imgclsmob
     """
     return ptcv_get_model(name, pretrained=pretrained)
 
 
+__all__ = [
+    'get_model',
+    'resnet',
+    'densenet',
+    'vgg',
+    'pyramidnet'
+]

--- a/examples/pytorchcv_models.py
+++ b/examples/pytorchcv_models.py
@@ -1,0 +1,107 @@
+################################################################################
+# Copyright (c) 2021 ContinualAI.                                              #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 12-10-2020                                                             #
+# Author(s): Eli Verwimp                                                       #
+# E-mail: contact@continualai.org                                              #
+# Website: avalanche.continualai.org                                           #
+################################################################################
+
+"""
+This example shows how to train models provided by pytorchcv with the rehearsal
+strategy.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from os.path import expanduser
+
+import argparse
+import torch
+from torch.nn import CrossEntropyLoss
+from torchvision import transforms
+from torchvision.datasets import CIFAR10
+from torchvision.transforms import ToTensor, RandomCrop
+import torch.optim.lr_scheduler
+from avalanche.benchmarks import nc_benchmark
+from avalanche.models import pytorchcv_wrapper
+from avalanche.training.strategies import Naive
+from avalanche.training.plugins import ReplayPlugin
+from avalanche.evaluation.metrics import forgetting_metrics, \
+    accuracy_metrics, loss_metrics
+from avalanche.logging import InteractiveLogger
+from avalanche.training.plugins import EvaluationPlugin
+
+
+def main(args):
+
+    # Model getter: specify dataset and depth of the network.
+    model = pytorchcv_wrapper.resnet('cifar10', depth=20, pretrained=False)
+
+    # Or get a more specific model. E.g. wide resnet, with depth 40 and growth
+    # factor 8 for Cifar 10.
+    # model = pytorchcv_wrapper.get_model("wrn40_8_cifar10", pretrained=False)
+
+    # --- CONFIG
+    device = torch.device(f"cuda:{args.cuda}"
+                          if torch.cuda.is_available() and
+                          args.cuda >= 0 else "cpu")
+
+    device = "cpu"
+
+    # --- TRANSFORMATIONS
+    transform = transforms.Compose([
+        ToTensor(),
+        transforms.Normalize((0.491, 0.482, 0.446), (0.247, 0.243, 0.261))
+    ])
+
+    # --- SCENARIO CREATION
+    cifar_train = CIFAR10(root=expanduser("~") + "/.avalanche/data/cifar10/",
+                          train=True, download=True, transform=transform)
+    cifar_test = CIFAR10(root=expanduser("~") + "/.avalanche/data/cifar10/",
+                         train=False, download=True, transform=transform)
+    scenario = nc_benchmark(
+        cifar_train, cifar_test, 5, task_labels=False, seed=1234,
+        fixed_class_order=[i for i in range(10)])
+
+    # choose some metrics and evaluation method
+    interactive_logger = InteractiveLogger()
+
+    eval_plugin = EvaluationPlugin(
+        accuracy_metrics(
+            minibatch=True, epoch=True, experience=True, stream=True),
+        loss_metrics(minibatch=True, epoch=True, experience=True, stream=True),
+        forgetting_metrics(experience=True),
+        loggers=[interactive_logger])
+
+    # CREATE THE STRATEGY INSTANCE (Naive, with Replay)
+    cl_strategy = Naive(model, torch.optim.SGD(model.parameters(), lr=0.01),
+                        CrossEntropyLoss(),
+                        train_mb_size=100, train_epochs=1, eval_mb_size=100,
+                        device=device,
+                        plugins=[ReplayPlugin(mem_size=1000)],
+                        evaluator=eval_plugin
+                        )
+
+    # TRAINING LOOP
+    print('Starting experiment...')
+    results = []
+    for experience in scenario.train_stream:
+        print("Start of experience ", experience.current_experience)
+        cl_strategy.train(experience)
+        print('Training completed')
+
+        print('Computing accuracy on the whole test set')
+        results.append(cl_strategy.eval(scenario.test_stream))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--cuda', type=int, default=0,
+                        help='Select zero-indexed cuda device. -1 to use CPU.')
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
Hi,

Closes #430 . This PR implement a pytorchcv wrapper to load various models. A general wrapper is available through `get_model`. For VGG, Resnet, DenseNet and Pyramidnet direct wrappers are provided.

A bit of explanation for the design choices:
- Initially I wanted to make sure that imagenet pre-trained models could be easily used for Cifar etc. However, this isn't as simple as changing input and output layers. Eg in Resnet, the structure of the convolutional layers also change because of the smaller input size. Since there is no straight-forward way, I would leave it up to the user to change models if required, such that no unexpected behavior is introduced.
- The choice of the networks (vgg, densenet, pryamidnet..)  is mostly based on the nets available for cifar10/100. 
- Not all options (eg growth rate for densenet, alpha in pyramidnet, bottlenecks...) are available through the direct wrappers. I don't think this is necessary, as those wrappers should be convenient and quick. If someone wants a very specific model, it's probably quicker to use the general wrapper anyway.
- As mentioned in the issue #430 discussion,  a slimmed down Resnet18 is a often used net, but not available in `pytorchcv`. In the future I would either expand these functions to also load our own implemented networks, which includes a slimmed down resent.