### PR TITLE
BaseStrategy support for arbitrary mini-batches

### DIFF
--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -8,7 +8,12 @@
 # E-mail: contact@continualai.org                                              #
 # Website: avalanche.continualai.org                                           #
 ################################################################################
-from copy import copy
+"""
+    Avalanche supports data loading using pytorch's dataloaders.
+    This module provides custom dataloaders for continual learning such as
+    support for balanced dataloading between different tasks or balancing
+    between the current data and the replay memory.
+"""
 from itertools import chain
 from typing import Dict, Sequence
 

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -202,8 +202,9 @@ class ReplayDataLoader:
         self.collate_mbatches = collate_mbatches
 
         num_keys = len(self.data.task_set) + len(self.memory.task_set)
-        assert batch_size >= num_keys, "Batch size must be greator or equal " \
-           "to the number of tasks in the memory and current data."
+        assert batch_size >= num_keys, "Batch size must be greator or equal "\
+                                       "to the number of tasks in the memory " \
+                                       "and current data."
 
         single_group_batch_size = batch_size // num_keys
         remaining_example = batch_size % num_keys

--- a/avalanche/training/plugins/agem.py
+++ b/avalanche/training/plugins/agem.py
@@ -99,24 +99,24 @@ class AGEMPlugin(StrategyPlugin):
         """
 
         tot = 0
-        for batches in dataloader:
-            for _, (x, y, _) in batches.items():
-                if tot + x.size(0) <= self.patterns_per_experience:
-                    if self.memory_x is None:
-                        self.memory_x = x.clone()
-                        self.memory_y = y.clone()
-                    else:
-                        self.memory_x = torch.cat((self.memory_x, x), dim=0)
-                        self.memory_y = torch.cat((self.memory_y, y), dim=0)
+        for mbatch in dataloader:
+            x, y, _ = mbatch
+            if tot + x.size(0) <= self.patterns_per_experience:
+                if self.memory_x is None:
+                    self.memory_x = x.clone()
+                    self.memory_y = y.clone()
                 else:
-                    diff = self.patterns_per_experience - tot
-                    if self.memory_x is None:
-                        self.memory_x = x[:diff].clone()
-                        self.memory_y = y[:diff].clone()
-                    else:
-                        self.memory_x = torch.cat((self.memory_x,
-                                                   x[:diff]), dim=0)
-                        self.memory_y = torch.cat((self.memory_y,
-                                                   y[:diff]), dim=0)
-                    break
-                tot += x.size(0)
+                    self.memory_x = torch.cat((self.memory_x, x), dim=0)
+                    self.memory_y = torch.cat((self.memory_y, y), dim=0)
+            else:
+                diff = self.patterns_per_experience - tot
+                if self.memory_x is None:
+                    self.memory_x = x[:diff].clone()
+                    self.memory_y = y[:diff].clone()
+                else:
+                    self.memory_x = torch.cat((self.memory_x,
+                                               x[:diff]), dim=0)
+                    self.memory_y = torch.cat((self.memory_y,
+                                               y[:diff]), dim=0)
+                break
+            tot += x.size(0)

--- a/avalanche/training/plugins/cope.py
+++ b/avalanche/training/plugins/cope.py
@@ -10,7 +10,7 @@ from avalanche.benchmarks.utils import AvalancheConcatDataset
 from avalanche.training.plugins.strategy_plugin import StrategyPlugin
 from avalanche.training.plugins.replay import ClassBalancedStoragePolicy
 from avalanche.benchmarks.utils.data_loader import \
-    MultiTaskJoinedBatchDataLoader
+    ReplayDataLoader
 
 
 class CoPEPlugin(StrategyPlugin):
@@ -82,7 +82,7 @@ class CoPEPlugin(StrategyPlugin):
         """
         if len(self.replay_mem) == 0:
             return
-        strategy.dataloader = MultiTaskJoinedBatchDataLoader(
+        strategy.dataloader = ReplayDataLoader(
             strategy.adapted_dataset,
             AvalancheConcatDataset(self.replay_mem.values()),
             oversample_small_tasks=True,

--- a/avalanche/training/plugins/replay.py
+++ b/avalanche/training/plugins/replay.py
@@ -7,7 +7,7 @@ from avalanche.benchmarks.utils import AvalancheConcatDataset, \
     AvalancheDataset, AvalancheSubset
 from avalanche.training.plugins.strategy_plugin import StrategyPlugin
 from avalanche.benchmarks.utils.data_loader import \
-    MultiTaskJoinedBatchDataLoader
+    ReplayDataLoader
 
 
 class ReplayPlugin(StrategyPlugin):
@@ -53,7 +53,7 @@ class ReplayPlugin(StrategyPlugin):
         """
         if len(self.ext_mem) == 0:
             return
-        strategy.dataloader = MultiTaskJoinedBatchDataLoader(
+        strategy.dataloader = ReplayDataLoader(
             strategy.adapted_dataset,
             AvalancheConcatDataset(self.ext_mem.values()),
             oversample_small_tasks=True,

--- a/avalanche/training/strategies/base_strategy.py
+++ b/avalanche/training/strategies/base_strategy.py
@@ -9,6 +9,8 @@
 # Website: avalanche.continualai.org                                           #
 ################################################################################
 from collections import defaultdict
+
+import torch
 from typing import Optional, Sequence, Union
 
 from torch.nn import Module
@@ -247,8 +249,8 @@ class BaseStrategy:
         for self.epoch in range(self.train_epochs):
             self.before_training_epoch(**kwargs)
             self.training_epoch(**kwargs)
-            self._periodic_eval(eval_streams, do_final=False)
             self.after_training_epoch(**kwargs)
+            self._periodic_eval(eval_streams, do_final=False)
 
         # Final evaluation
         self._periodic_eval(eval_streams, do_final=True)
@@ -284,6 +286,7 @@ class BaseStrategy:
         self.adapted_dataset = self.experience.dataset
         self.adapted_dataset = self.adapted_dataset.train()
 
+    @torch.no_grad()
     def eval(self,
              exp_list: Union[Experience, Sequence[Experience]],
              **kwargs):

--- a/avalanche/training/strategies/base_strategy.py
+++ b/avalanche/training/strategies/base_strategy.py
@@ -214,8 +214,8 @@ class BaseStrategy:
                 eval_streams[i] = [exp]
 
         self.before_training(**kwargs)
-        for exp in experiences:
-            self.train_exp(exp, eval_streams, **kwargs)
+        for self.experience in experiences:
+            self.train_exp(self.experience, eval_streams, **kwargs)
         self.after_training(**kwargs)
 
         res = self.evaluator.get_last_metrics()
@@ -307,9 +307,7 @@ class BaseStrategy:
             exp_list = [exp_list]
 
         self.before_eval(**kwargs)
-        for exp in exp_list:
-            self.experience = exp
-
+        for self.experience in exp_list:
             # Data Adaptation
             self.before_eval_dataset_adaptation(**kwargs)
             self.eval_dataset_adaptation(**kwargs)

--- a/examples/dataloader.py
+++ b/examples/dataloader.py
@@ -1,0 +1,43 @@
+from torch.nn import CrossEntropyLoss
+from torch.optim import SGD
+
+from avalanche.benchmarks import SplitMNIST
+from avalanche.benchmarks.utils.data_loader import TaskBalancedDataLoader
+from avalanche.models import SimpleMLP
+from avalanche.training.strategies import Naive, Cumulative
+
+
+class MyCumulativeStrategy(Cumulative):
+    def make_train_dataloader(self, shuffle=True, **kwargs):
+        # you can override make_train_dataloader to change the
+        # strategy's dataloader
+        # remember to iterate over self.adapted_dataset
+        self.dataloader = TaskBalancedDataLoader(
+            self.adapted_dataset,
+            batch_size=self.train_mb_size)
+
+
+if __name__ == '__main__':
+    benchmark = SplitMNIST(n_experiences=5)
+
+    model = SimpleMLP(input_size=784, hidden_size=10)
+    opt = SGD(model.parameters(), lr=0.001, momentum=0.9, weight_decay=0.001)
+
+    # we use our custom strategy to change the dataloading policy.
+    cl_strategy = MyCumulativeStrategy(
+        model, opt, CrossEntropyLoss(), train_epochs=1,
+        train_mb_size=512, eval_mb_size=512)
+
+    for step in benchmark.train_stream:
+        cl_strategy.train(step)
+        cl_strategy.eval(step)
+
+    # If you don't use avalanche's strategies you can also use the dataloader
+    # directly to iterate the data
+    data = step.dataset
+    dl = TaskBalancedDataLoader(data)
+    for x, y, t in dl:
+        # by default minibatches in Avalanche have the form <x, y, ..., t>
+        # with arbitrary additional tensors between y and t.
+        print(x, y, t)
+        break


### PR DESCRIPTION
This PR updates dataloaders. Now BaseStrategy supports pytorch dataloaders. Custom dataloaders are provided for CL-specific features:
- TaskBalancedDataLoader
- GroupBalancedDataLoader
- ReplayDataLoader

BaseStrategy (and dataloaders) now supports arbitrary mini-batches of the form `<x, y, ..., t>`.

Closes #539.