### PR TITLE
Docker image with pre-downloaded datasets used in test

### DIFF
--- a/.github/workflows/test-coverage-coveralls.yml
+++ b/.github/workflows/test-coverage-coveralls.yml
@@ -72,7 +72,9 @@ jobs:
           conda activate avalanche-env
           FAST_TEST=True USE_GPU=False coverage run -m unittest
       - name: Upload coverage data to coveralls.io
-        run: coveralls --service=github
+        run: |
+          conda activate avalanche-env
+          coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: ${{ matrix.python-version }}

--- a/.github/workflows/test-coverage-coveralls.yml
+++ b/.github/workflows/test-coverage-coveralls.yml
@@ -32,6 +32,8 @@ jobs:
     if: github.repository == 'ContinualAI/avalanche'
     name: unit test
     runs-on: ubuntu-latest
+    container:
+      image: ggraffieti/avalanche-ds:latest
     strategy:
       fail-fast: false
       matrix:
@@ -43,28 +45,31 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: avalanche-env
-          python-version: ${{ matrix.python-version }}
-          auto-activate-base: false
+      - name: copy dataset in correct folder
+        run: cp -r /~/.avalanche /github/home
       - name: install conda environment < 3.9
         if: matrix.python-version != '3.9'
         run: |
+          conda create -n avalanche-env python=${{ matrix.python-version }} -c conda-forge
+          conda activate avalanche-env
           conda install pytorch torchvision cpuonly -c pytorch -y
           conda env update --file environment.yml
       - name: install conda environment = 3.9
         if: matrix.python-version == '3.9'
         run: |
+          conda create -n avalanche-env python=${{ matrix.python-version }} -c conda-forge
+          conda activate avalanche-env
           conda install pytorch torchvision cpuonly -c pytorch -c=conda-forge -y
           conda env update --file environment.yml
       - name: install coverage.py and coverralls
         run: |
+          conda activate avalanche-env
           pip install coverage
           pip install coveralls
       - name: python unit test
         id: unittest
         run: |
+          conda activate avalanche-env
           FAST_TEST=True USE_GPU=False coverage run -m unittest
       - name: Upload coverage data to coveralls.io
         run: coveralls --service=github

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,6 +31,8 @@ jobs:
   unit-test:
     name: unit test
     runs-on: ubuntu-latest
+    container:
+      image: ggraffieti/avalanche-ds:latest
     strategy:
       fail-fast: false
       matrix:
@@ -42,24 +44,26 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: avalanche-env
-          python-version: ${{ matrix.python-version }}
-          auto-activate-base: false
+      - name: copy dataset in correct folder
+        run: cp -r /~/.avalanche /github/home
       - name: install conda environment < 3.9
         if: matrix.python-version != '3.9'
         run: |
+          conda create -n avalanche-env python=${{ matrix.python-version }} -c conda-forge
+          conda activate avalanche-env
           conda install pytorch torchvision cpuonly -c pytorch -y
           conda env update --file environment.yml
       - name: install conda environment = 3.9
         if: matrix.python-version == '3.9'
         run: |
+          conda create -n avalanche-env python=${{ matrix.python-version }} -c conda-forge
+          conda activate avalanche-env
           conda install pytorch torchvision cpuonly -c pytorch -c=conda-forge -y
           conda env update --file environment.yml
       - name: python unit test
         id: unittest
         run: |
+          conda activate avalanche-env
           FAST_TEST=True USE_GPU=False python -m unittest
       - name: clone reports repository
         if: always() && github.event_name == 'push' && github.repository == 'ContinualAI/avalanche'

--- a/examples/wandb_logger.py
+++ b/examples/wandb_logger.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from os.path import expanduser
+
 import argparse
 import torch
 from torch.nn import CrossEntropyLoss
@@ -57,9 +59,11 @@ def main(args):
     # ---------
 
     # --- SCENARIO CREATION
-    mnist_train = MNIST('./data/mnist', train=True,
+    mnist_train = MNIST(root=expanduser("~") + "/.avalanche/data/mnist/",
+                        train=True,
                         download=True, transform=train_transform)
-    mnist_test = MNIST('./data/mnist', train=False,
+    mnist_test = MNIST(root=expanduser("~") + "/.avalanche/data/mnist/",
+                       train=False,
                        download=True, transform=test_transform)
     scenario = nc_benchmark(
         mnist_train, mnist_test, 5, task_labels=False, seed=1234)

--- a/tests/test_high_level_generators.py
+++ b/tests/test_high_level_generators.py
@@ -1,6 +1,7 @@
 import unittest
 
 import os
+from os.path import expanduser
 
 import torch
 from torchvision.datasets import CIFAR10, MNIST
@@ -19,17 +20,21 @@ class HighLevelGeneratorTests(unittest.TestCase):
 
     def test_dataset_benchmark(self):
         train_MNIST = MNIST(
-            './data/mnist', train=True, download=True
+            root=expanduser("~") + "/.avalanche/data/mnist/",
+            train=True, download=True
         )
         test_MNIST = MNIST(
-            './data/mnist', train=False, download=True
+            root=expanduser("~") + "/.avalanche/data/mnist/",
+            train=False, download=True
         )
 
         train_cifar10 = CIFAR10(
-            './data/cifar10', train=True, download=True
+            root=expanduser("~") + "/.avalanche/data/cifar10/",
+            train=True, download=True
         )
         test_cifar10 = CIFAR10(
-            './data/cifar10', train=False, download=True
+            root=expanduser("~") + "/.avalanche/data/cifar10/",
+            train=False, download=True
         )
 
         generic_scenario = dataset_benchmark(
@@ -38,19 +43,23 @@ class HighLevelGeneratorTests(unittest.TestCase):
 
     def test_dataset_benchmark_avalanche_dataset(self):
         train_MNIST = AvalancheDataset(MNIST(
-            './data/mnist', train=True, download=True
+            root=expanduser("~") + "/.avalanche/data/mnist/",
+            train=True, download=True
         ), task_labels=0)
 
         test_MNIST = AvalancheDataset(MNIST(
-            './data/mnist', train=False, download=True
+            root=expanduser("~") + "/.avalanche/data/mnist/",
+            train=False, download=True
         ), task_labels=0)
 
         train_cifar10 = AvalancheDataset(CIFAR10(
-            './data/cifar10', train=True, download=True
+            root=expanduser("~") + "/.avalanche/data/cifar10/",
+            train=True, download=True
         ), task_labels=1)
 
         test_cifar10 = AvalancheDataset(CIFAR10(
-            './data/cifar10', train=False, download=True
+            root=expanduser("~") + "/.avalanche/data/cifar10/",
+            train=False, download=True
         ), task_labels=1)
 
         generic_scenario = dataset_benchmark(
@@ -65,13 +74,15 @@ class HighLevelGeneratorTests(unittest.TestCase):
     def test_filelist_benchmark(self):
         download_url(
             'https://storage.googleapis.com/mledu-datasets/'
-            'cats_and_dogs_filtered.zip', './data',
+            'cats_and_dogs_filtered.zip', expanduser("~") + "/.avalanche/data",
             'cats_and_dogs_filtered.zip')
         archive_name = os.path.join(
-            './data', 'cats_and_dogs_filtered.zip')
-        extract_archive(archive_name, to_path='./data/')
+            expanduser("~") + "/.avalanche/data", 'cats_and_dogs_filtered.zip')
+        extract_archive(archive_name,
+                        to_path=expanduser("~") + "/.avalanche/data/")
 
-        dirpath = "./data/cats_and_dogs_filtered/train"
+        dirpath = expanduser("~") + \
+            "/.avalanche/data/cats_and_dogs_filtered/train"
 
         for filelist, dir, label in zip(
                 ["train_filelist_00.txt", "train_filelist_01.txt"],
@@ -101,13 +112,15 @@ class HighLevelGeneratorTests(unittest.TestCase):
     def test_paths_benchmark(self):
         download_url(
             'https://storage.googleapis.com/mledu-datasets/'
-            'cats_and_dogs_filtered.zip', './data',
+            'cats_and_dogs_filtered.zip', expanduser("~") + "/.avalanche/data",
             'cats_and_dogs_filtered.zip')
         archive_name = os.path.join(
-            './data', 'cats_and_dogs_filtered.zip')
-        extract_archive(archive_name, to_path='./data/')
+            expanduser("~") + "/.avalanche/data", 'cats_and_dogs_filtered.zip')
+        extract_archive(archive_name,
+                        to_path=expanduser("~") + "/.avalanche/data/")
 
-        dirpath = "./data/cats_and_dogs_filtered/train"
+        dirpath = expanduser("~") + \
+            "/.avalanche/data/cats_and_dogs_filtered/train"
 
         train_experiences = []
         for rel_dir, label in zip(


### PR DESCRIPTION
This PR improves the automatic testing of the project: 
- Using a docker image with pre-downloaded datasets, data no longer has to be downloaded every time the software is tested. This solves download issues (broken links, servers down, slow connection..) making the testing procedure more reliable. 
- Using a docker image with only python + conda installed increase the validity of testing since the environment is minimal and does not contain any unnecessary package. 
- Conda is now runned directly in the shell without relying on any additional action. This seems to have solved the slow environment creation with python 3.6 
- Fix download location for the data used during tests.

Now in the docker image are only contained the MNIST and tiny imagenet, cifar10 and cats_and_dogs will be inserted in the docker image as soon as possible (in any case the insertion of the datasets only requires the upload of a new container on DockerHub, so it's totally independent from Avalance). 

This PR resolves #454 