### PR TITLE
Better handling of transformations in ni/nc_benchmark

### DIFF
--- a/avalanche/benchmarks/classic/ccifar10.py
+++ b/avalanche/benchmarks/classic/ccifar10.py
@@ -15,7 +15,6 @@ from torchvision.datasets import CIFAR10
 from torchvision import transforms
 
 from avalanche.benchmarks import nc_benchmark, NCScenario
-from avalanche.benchmarks.utils import train_eval_avalanche_datasets
 
 
 _default_cifar10_train_transform = transforms.Compose([
@@ -98,8 +97,7 @@ def SplitCIFAR10(n_experiences: int,
 
     :returns: A properly initialized :class:`NCScenario` instance.
     """
-    cifar_train, cifar_test = _get_cifar10_dataset(
-        train_transform, eval_transform)
+    cifar_train, cifar_test = _get_cifar10_dataset()
 
     if return_task_id:
         return nc_benchmark(
@@ -110,7 +108,9 @@ def SplitCIFAR10(n_experiences: int,
             seed=seed,
             fixed_class_order=fixed_class_order,
             per_exp_classes={0: 5} if first_exp_with_half_classes else None,
-            class_ids_from_zero_in_each_exp=True)
+            class_ids_from_zero_in_each_exp=True,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
     else:
         return nc_benchmark(
             train_dataset=cifar_train,
@@ -119,18 +119,19 @@ def SplitCIFAR10(n_experiences: int,
             task_labels=False,
             seed=seed,
             fixed_class_order=fixed_class_order,
-            per_exp_classes={0: 5} if first_exp_with_half_classes else None)
+            per_exp_classes={0: 5} if first_exp_with_half_classes else None,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
 
 
-def _get_cifar10_dataset(train_transformation, eval_transformation):
+def _get_cifar10_dataset():
     train_set = CIFAR10(expanduser("~") + "/.avalanche/data/cifar10/",
                         train=True, download=True)
 
     test_set = CIFAR10(expanduser("~") + "/.avalanche/data/cifar10/",
                        train=False, download=True)
 
-    return train_eval_avalanche_datasets(
-        train_set, test_set, train_transformation, eval_transformation)
+    return train_set, test_set
 
 
 __all__ = [

--- a/avalanche/benchmarks/classic/ccifar100.py
+++ b/avalanche/benchmarks/classic/ccifar100.py
@@ -17,7 +17,7 @@ from torchvision import transforms
 
 from avalanche.benchmarks.datasets import CIFAR10
 from avalanche.benchmarks.utils.avalanche_dataset import \
-    concat_datasets_sequentially, train_eval_avalanche_datasets
+    concat_datasets_sequentially
 from avalanche.benchmarks import nc_benchmark, NCScenario
 
 _default_cifar100_train_transform = transforms.Compose([
@@ -100,9 +100,7 @@ def SplitCIFAR100(n_experiences: int,
 
     :returns: A properly initialized :class:`NCScenario` instance.
     """
-    cifar_train, cifar_test = _get_cifar100_dataset(
-        train_transform, eval_transform
-    )
+    cifar_train, cifar_test = _get_cifar100_dataset()
 
     if return_task_id:
         return nc_benchmark(
@@ -113,7 +111,9 @@ def SplitCIFAR100(n_experiences: int,
             seed=seed,
             fixed_class_order=fixed_class_order,
             per_exp_classes={0: 50} if first_exp_with_half_classes else None,
-            class_ids_from_zero_in_each_exp=True)
+            class_ids_from_zero_in_each_exp=True,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
     else:
         return nc_benchmark(
             train_dataset=cifar_train,
@@ -122,7 +122,9 @@ def SplitCIFAR100(n_experiences: int,
             task_labels=False,
             seed=seed,
             fixed_class_order=fixed_class_order,
-            per_exp_classes={0: 50} if first_exp_with_half_classes else None)
+            per_exp_classes={0: 50} if first_exp_with_half_classes else None,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
 
 
 def SplitCIFAR110(
@@ -186,11 +188,8 @@ def SplitCIFAR110(
     :returns: A properly initialized :class:`NCScenario` instance.
     """
 
-    cifar10_train, cifar10_test = _get_cifar10_dataset(
-        train_transform, eval_transform)
-
-    cifar100_train, cifar100_test = _get_cifar100_dataset(
-        train_transform, eval_transform)
+    cifar10_train, cifar10_test = _get_cifar10_dataset()
+    cifar100_train, cifar100_test = _get_cifar100_dataset()
 
     cifar_10_100_train, cifar_10_100_test, _ = concat_datasets_sequentially(
         [cifar10_train, cifar100_train], [cifar10_test, cifar100_test]
@@ -215,29 +214,29 @@ def SplitCIFAR110(
         shuffle=False,
         seed=None,
         fixed_class_order=class_order,
-        per_exp_classes={0: 10})
+        per_exp_classes={0: 10},
+        train_transform=train_transform,
+        eval_transform=eval_transform)
 
 
-def _get_cifar10_dataset(train_transformation, eval_transformation):
+def _get_cifar10_dataset():
     train_set = CIFAR10(expanduser("~") + "/.avalanche/data/cifar10/",
                         train=True, download=True)
 
     test_set = CIFAR10(expanduser("~") + "/.avalanche/data/cifar10/",
                        train=False, download=True)
 
-    return train_eval_avalanche_datasets(
-        train_set, test_set, train_transformation, eval_transformation)
+    return train_set, test_set
 
 
-def _get_cifar100_dataset(train_transformation, eval_transformation):
+def _get_cifar100_dataset():
     train_set = CIFAR100(expanduser("~") + "/.avalanche/data/cifar100/",
                          train=True, download=True)
 
     test_set = CIFAR100(expanduser("~") + "/.avalanche/data/cifar100/",
                         train=False, download=True)
 
-    return train_eval_avalanche_datasets(
-        train_set, test_set, train_transformation, eval_transformation)
+    return train_set, test_set
 
 
 __all__ = [

--- a/avalanche/benchmarks/classic/ccub200.py
+++ b/avalanche/benchmarks/classic/ccub200.py
@@ -14,7 +14,6 @@ from avalanche.benchmarks import nc_benchmark
 
 from torchvision import transforms
 
-from avalanche.benchmarks.utils import train_eval_avalanche_datasets
 
 _default_train_transform = transforms.Compose([
         transforms.RandomHorizontalFlip(),
@@ -96,8 +95,7 @@ def SplitCUB200(root,
     :returns: A properly initialized :class:`NCScenario` instance.
     """
 
-    train_set, test_set = _get_cub200_dataset(
-        root, train_transform, eval_transform)
+    train_set, test_set = _get_cub200_dataset(root)
 
     if classes_first_batch is not None:
         per_exp_classes = {0: classes_first_batch}
@@ -114,7 +112,9 @@ def SplitCUB200(root,
             seed=seed,
             fixed_class_order=fixed_class_order,
             shuffle=shuffle,
-            one_dataset_per_exp=True)
+            one_dataset_per_exp=True,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
     else:
         return nc_benchmark(
             train_dataset=train_set,
@@ -124,15 +124,16 @@ def SplitCUB200(root,
             per_exp_classes=per_exp_classes,
             seed=seed,
             fixed_class_order=fixed_class_order,
-            shuffle=shuffle)
+            shuffle=shuffle,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
 
 
-def _get_cub200_dataset(root, train_transformation, eval_transformation):
+def _get_cub200_dataset(root):
     train_set = CUB200(root, train=True)
     test_set = CUB200(root, train=False)
 
-    return train_eval_avalanche_datasets(
-        train_set, test_set, train_transformation, eval_transformation)
+    return train_set, test_set
 
 
 __all__ = [

--- a/avalanche/benchmarks/classic/cfashion_mnist.py
+++ b/avalanche/benchmarks/classic/cfashion_mnist.py
@@ -18,7 +18,6 @@ from torchvision.datasets import FashionMNIST
 from torchvision import transforms
 
 from avalanche.benchmarks import nc_benchmark
-from avalanche.benchmarks.utils import train_eval_avalanche_datasets
 
 _default_fmnist_train_transform = transforms.Compose([
     transforms.ToTensor(),
@@ -100,8 +99,7 @@ def SplitFMNIST(n_experiences: int,
     :returns: A properly initialized :class:`NCScenario` instance.
     """
 
-    fmnist_train, fmnist_test = _get_fmnist_dataset(
-        train_transform, eval_transform)
+    fmnist_train, fmnist_test = _get_fmnist_dataset()
 
     if return_task_id:
         return nc_benchmark(
@@ -111,7 +109,9 @@ def SplitFMNIST(n_experiences: int,
             task_labels=True,
             seed=seed,
             fixed_class_order=fixed_class_order,
-            per_exp_classes={0: 5} if first_batch_with_half_classes else None)
+            per_exp_classes={0: 5} if first_batch_with_half_classes else None,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
     else:
         return nc_benchmark(
             train_dataset=fmnist_train,
@@ -120,16 +120,17 @@ def SplitFMNIST(n_experiences: int,
             task_labels=False,
             seed=seed,
             fixed_class_order=fixed_class_order,
-            per_exp_classes={0: 5} if first_batch_with_half_classes else None)
+            per_exp_classes={0: 5} if first_batch_with_half_classes else None,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
 
 
-def _get_fmnist_dataset(train_transformation, eval_transformation):
+def _get_fmnist_dataset():
     train_set = FashionMNIST(expanduser("~") + "/.avalanche/data/fashionmnist/",
                              train=True, download=True)
     test_set = FashionMNIST(expanduser("~") + "/.avalanche/data/fashionmnist/",
                             train=False, download=True)
-    return train_eval_avalanche_datasets(
-        train_set, test_set, train_transformation, eval_transformation)
+    return train_set, test_set
 
 
 __all__ = [

--- a/avalanche/benchmarks/classic/cimagenet.py
+++ b/avalanche/benchmarks/classic/cimagenet.py
@@ -15,8 +15,6 @@ from avalanche.benchmarks import nc_benchmark
 
 from torchvision import transforms
 
-from avalanche.benchmarks.utils import train_eval_avalanche_datasets
-
 normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                  std=[0.229, 0.224, 0.225])
 
@@ -106,8 +104,7 @@ def SplitImageNet(root,
     :returns: A properly initialized :class:`NCScenario` instance.
     """
 
-    train_set, test_set = _get_imagenet_dataset(
-        root, train_transform, eval_transform)
+    train_set, test_set = _get_imagenet_dataset(root)
 
     if return_task_id:
         return nc_benchmark(
@@ -118,7 +115,9 @@ def SplitImageNet(root,
             per_exp_classes=per_exp_classes,
             seed=seed,
             fixed_class_order=fixed_class_order,
-            class_ids_from_zero_in_each_exp=True)
+            class_ids_from_zero_in_each_exp=True,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
     else:
         return nc_benchmark(
             train_dataset=train_set,
@@ -127,16 +126,17 @@ def SplitImageNet(root,
             task_labels=False,
             per_exp_classes=per_exp_classes,
             seed=seed,
-            fixed_class_order=fixed_class_order)
+            fixed_class_order=fixed_class_order,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
 
 
-def _get_imagenet_dataset(root, train_transformation, eval_transformation):
+def _get_imagenet_dataset(root):
     train_set = ImageNet(root, split="train")
 
     test_set = ImageNet(root, split="val")
 
-    return train_eval_avalanche_datasets(
-        train_set, test_set, train_transformation, eval_transformation)
+    return train_set, test_set
 
 
 __all__ = [

--- a/avalanche/benchmarks/classic/ctiny_imagenet.py
+++ b/avalanche/benchmarks/classic/ctiny_imagenet.py
@@ -12,7 +12,7 @@
 from torchvision import transforms
 from avalanche.benchmarks.datasets import TinyImagenet
 from avalanche.benchmarks.generators import nc_benchmark
-from avalanche.benchmarks.utils import train_eval_avalanche_datasets
+
 
 _default_train_transform = transforms.Compose([
         transforms.RandomHorizontalFlip(),
@@ -83,8 +83,7 @@ def SplitTinyImageNet(n_experiences=10, return_task_id=False, seed=0,
     :returns: A properly initialized :class:`NCScenario` instance.
     """
 
-    train_set, test_set = _get_tiny_imagenet_dataset(
-        train_transform, eval_transform)
+    train_set, test_set = _get_tiny_imagenet_dataset()
 
     if return_task_id:
         return nc_benchmark(
@@ -94,7 +93,9 @@ def SplitTinyImageNet(n_experiences=10, return_task_id=False, seed=0,
             task_labels=True,
             seed=seed,
             fixed_class_order=fixed_class_order,
-            class_ids_from_zero_in_each_exp=True)
+            class_ids_from_zero_in_each_exp=True,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
     else:
         return nc_benchmark(
             train_dataset=train_set,
@@ -102,16 +103,17 @@ def SplitTinyImageNet(n_experiences=10, return_task_id=False, seed=0,
             n_experiences=n_experiences,
             task_labels=False,
             seed=seed,
-            fixed_class_order=fixed_class_order)
+            fixed_class_order=fixed_class_order,
+            train_transform=train_transform,
+            eval_transform=eval_transform)
 
 
-def _get_tiny_imagenet_dataset(train_transformation, eval_transformation):
+def _get_tiny_imagenet_dataset():
     train_set = TinyImagenet(train=True)
 
     test_set = TinyImagenet(train=False)
 
-    return train_eval_avalanche_datasets(
-        train_set, test_set, train_transformation, eval_transformation)
+    return train_set, test_set
 
 
 __all__ = [

--- a/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
@@ -363,15 +363,16 @@ class NCScenario(GenericCLScenario['NCExperience']):
             train_exps_patterns_assignment.append(selected_indexes_train)
             test_exps_patterns_assignment.append(selected_indexes_test)
 
-        transform_groups = train_eval_transforms(train_dataset, test_dataset)
-
-        train_dataset = train_dataset\
-            .replace_transforms(*transform_groups['train'], group='train') \
-            .replace_transforms(*transform_groups['eval'], group='eval')
-
-        test_dataset = test_dataset \
-            .replace_transforms(*transform_groups['train'], group='train') \
-            .replace_transforms(*transform_groups['eval'], group='eval')
+        # Good idea, but doesn't work
+        # transform_groups = train_eval_transforms(train_dataset, test_dataset)
+        #
+        # train_dataset = train_dataset\
+        #     .replace_transforms(*transform_groups['train'], group='train') \
+        #     .replace_transforms(*transform_groups['eval'], group='eval')
+        #
+        # test_dataset = test_dataset \
+        #     .replace_transforms(*transform_groups['train'], group='train') \
+        #     .replace_transforms(*transform_groups['eval'], group='eval')
 
         train_dataset = AvalancheSubset(
             train_dataset, class_mapping=self.class_mapping,

--- a/avalanche/benchmarks/scenarios/new_instances/ni_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_instances/ni_scenario.py
@@ -115,15 +115,16 @@ class NIScenario(GenericCLScenario['NIExperience']):
             raise ValueError('Invalid min_class_patterns_in_exp parameter: '
                              'must be greater than or equal to 0')
 
-        transform_groups = train_eval_transforms(train_dataset, test_dataset)
-
-        train_dataset = train_dataset \
-            .replace_transforms(*transform_groups['train'], group='train') \
-            .replace_transforms(*transform_groups['eval'], group='eval')
-
-        test_dataset = test_dataset \
-            .replace_transforms(*transform_groups['train'], group='train') \
-            .replace_transforms(*transform_groups['eval'], group='eval')
+        # # Good idea, but doesn't work
+        # transform_groups = train_eval_transforms(train_dataset, test_dataset)
+        #
+        # train_dataset = train_dataset \
+        #     .replace_transforms(*transform_groups['train'], group='train') \
+        #     .replace_transforms(*transform_groups['eval'], group='eval')
+        #
+        # test_dataset = test_dataset \
+        #     .replace_transforms(*transform_groups['train'], group='train') \
+        #     .replace_transforms(*transform_groups['eval'], group='eval')
 
         unique_targets, unique_count = torch.unique(
             torch.as_tensor(train_dataset.targets), return_counts=True)

--- a/tests/test_cifar100_benchmarks.py
+++ b/tests/test_cifar100_benchmarks.py
@@ -3,7 +3,7 @@ import unittest
 from torch.utils.data.dataloader import DataLoader
 
 from avalanche.benchmarks import Experience, SplitCIFAR100, SplitCIFAR110
-from unit_tests_utils import load_experience_train_eval
+from tests.unit_tests_utils import load_experience_train_eval
 
 CIFAR10_DOWNLOADS = 0
 CIFAR10_DOWNLOAD_METHOD = None

--- a/tests/test_cifar100_benchmarks.py
+++ b/tests/test_cifar100_benchmarks.py
@@ -1,0 +1,120 @@
+import unittest
+
+from torch.utils.data.dataloader import DataLoader
+
+from avalanche.benchmarks import Experience, SplitCIFAR100, SplitCIFAR110
+from unit_tests_utils import load_experience_train_eval
+
+CIFAR10_DOWNLOADS = 0
+CIFAR10_DOWNLOAD_METHOD = None
+CIFAR100_DOWNLOADS = 0
+CIFAR100_DOWNLOAD_METHOD = None
+
+
+class CIFAR100BenchmarksTests(unittest.TestCase):
+    def setUp(self):
+        import avalanche.benchmarks.classic.ccifar100 as ccifar100
+        global CIFAR10_DOWNLOAD_METHOD, CIFAR100_DOWNLOAD_METHOD
+        CIFAR10_DOWNLOAD_METHOD = ccifar100._get_cifar10_dataset
+        CIFAR100_DOWNLOAD_METHOD = ccifar100._get_cifar100_dataset
+
+        def count_downloads_c10(*args, **kwargs):
+            global CIFAR10_DOWNLOADS
+            CIFAR10_DOWNLOADS += 1
+            return CIFAR10_DOWNLOAD_METHOD(*args, **kwargs)
+
+        def count_downloads_c100(*args, **kwargs):
+            global CIFAR100_DOWNLOADS
+            CIFAR100_DOWNLOADS += 1
+            return CIFAR100_DOWNLOAD_METHOD(*args, **kwargs)
+
+        ccifar100._get_cifar10_dataset = count_downloads_c10
+        ccifar100._get_cifar100_dataset = count_downloads_c100
+
+    def tearDown(self):
+        global CIFAR10_DOWNLOAD_METHOD, CIFAR100_DOWNLOAD_METHOD
+        if CIFAR10_DOWNLOAD_METHOD is not None:
+            import avalanche.benchmarks.classic.ccifar100 as ccifar100
+            ccifar100._get_cifar10_dataset = CIFAR10_DOWNLOAD_METHOD
+            CIFAR10_DOWNLOAD_METHOD = None
+
+        if CIFAR100_DOWNLOAD_METHOD is not None:
+            import avalanche.benchmarks.classic.ccifar100 as ccifar100
+            ccifar100._get_cifar100_dataset = CIFAR100_DOWNLOAD_METHOD
+            CIFAR100_DOWNLOAD_METHOD = None
+
+    def test_SplitCifar100_scenario(self):
+        scenario = SplitCIFAR100(5)
+        self.assertEqual(5, len(scenario.train_stream))
+        self.assertEqual(5, len(scenario.test_stream))
+
+        train_sz = 0
+        for experience in scenario.train_stream:
+            self.assertIsInstance(experience, Experience)
+            train_sz += len(experience.dataset)
+
+            # Regression test for 575
+            load_experience_train_eval(experience)
+
+        self.assertEqual(50000, train_sz)
+
+        test_sz = 0
+        for experience in scenario.test_stream:
+            self.assertIsInstance(experience, Experience)
+            test_sz += len(experience.dataset)
+
+            # Regression test for 575
+            load_experience_train_eval(experience)
+
+        self.assertEqual(10000, test_sz)
+
+    def test_SplitCifar110_scenario(self):
+        scenario = SplitCIFAR110(6)
+        self.assertEqual(6, len(scenario.train_stream))
+        self.assertEqual(6, len(scenario.test_stream))
+
+        train_sz = 0
+        for experience in scenario.train_stream:
+            self.assertIsInstance(experience, Experience)
+            train_sz += len(experience.dataset)
+
+            load_experience_train_eval(experience)
+
+        self.assertEqual(50000 * 2, train_sz)
+
+        test_sz = 0
+        for experience in scenario.test_stream:
+            self.assertIsInstance(experience, Experience)
+            test_sz += len(experience.dataset)
+
+            load_experience_train_eval(experience)
+
+        self.assertEqual(10000 * 2, test_sz)
+
+    def test_SplitCifar100_scenario_download_once(self):
+        global CIFAR100_DOWNLOADS, CIFAR10_DOWNLOADS
+        CIFAR100_DOWNLOADS = 0
+        CIFAR10_DOWNLOADS = 0
+
+        scenario = SplitCIFAR100(5)
+        self.assertEqual(5, len(scenario.train_stream))
+        self.assertEqual(5, len(scenario.test_stream))
+
+        self.assertEqual(1, CIFAR100_DOWNLOADS)
+        self.assertEqual(0, CIFAR10_DOWNLOADS)
+
+    def test_SplitCifar110_scenario_download_once(self):
+        global CIFAR100_DOWNLOADS, CIFAR10_DOWNLOADS
+        CIFAR100_DOWNLOADS = 0
+        CIFAR10_DOWNLOADS = 0
+
+        scenario = SplitCIFAR110(6)
+        self.assertEqual(6, len(scenario.train_stream))
+        self.assertEqual(6, len(scenario.test_stream))
+
+        self.assertEqual(1, CIFAR100_DOWNLOADS)
+        self.assertEqual(1, CIFAR10_DOWNLOADS)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cifar10_benchmarks.py
+++ b/tests/test_cifar10_benchmarks.py
@@ -1,7 +1,7 @@
 import unittest
 
 from avalanche.benchmarks import Experience, SplitCIFAR10
-from unit_tests_utils import load_experience_train_eval
+from tests.unit_tests_utils import load_experience_train_eval
 
 CIFAR10_DOWNLOADS = 0
 CIFAR10_DOWNLOAD_METHOD = None

--- a/tests/test_cifar10_benchmarks.py
+++ b/tests/test_cifar10_benchmarks.py
@@ -1,8 +1,7 @@
 import unittest
 
-from torch.utils.data.dataloader import DataLoader
-
 from avalanche.benchmarks import Experience, SplitCIFAR10
+from unit_tests_utils import load_experience_train_eval
 
 CIFAR10_DOWNLOADS = 0
 CIFAR10_DOWNLOAD_METHOD = None
@@ -38,13 +37,8 @@ class CIFAR10BenchmarksTests(unittest.TestCase):
             self.assertIsInstance(experience, Experience)
             train_sz += len(experience.dataset)
 
-            for x, y, t in DataLoader(experience.dataset, batch_size=32):
-                break
-
             # Regression test for 575
-            for x, y, t in DataLoader(experience.dataset.eval(),
-                                      batch_size=32):
-                break
+            load_experience_train_eval(experience)
 
         self.assertEqual(50000, train_sz)
 
@@ -53,13 +47,8 @@ class CIFAR10BenchmarksTests(unittest.TestCase):
             self.assertIsInstance(experience, Experience)
             test_sz += len(experience.dataset)
 
-            for x, y, t in DataLoader(experience.dataset, batch_size=32):
-                break
-
             # Regression test for 575
-            for x, y, t in DataLoader(experience.dataset.train(),
-                                      batch_size=32):
-                break
+            load_experience_train_eval(experience)
 
         self.assertEqual(10000, test_sz)
 

--- a/tests/test_cifar10_benchmarks.py
+++ b/tests/test_cifar10_benchmarks.py
@@ -1,0 +1,78 @@
+import unittest
+
+from torch.utils.data.dataloader import DataLoader
+
+from avalanche.benchmarks import Experience, SplitCIFAR10
+
+CIFAR10_DOWNLOADS = 0
+CIFAR10_DOWNLOAD_METHOD = None
+
+
+class CIFAR10BenchmarksTests(unittest.TestCase):
+    def setUp(self):
+        import avalanche.benchmarks.classic.ccifar10 as ccifar10
+        global CIFAR10_DOWNLOAD_METHOD
+        CIFAR10_DOWNLOAD_METHOD = ccifar10._get_cifar10_dataset
+
+        def count_downloads(*args, **kwargs):
+            global CIFAR10_DOWNLOADS
+            CIFAR10_DOWNLOADS += 1
+            return CIFAR10_DOWNLOAD_METHOD(*args, **kwargs)
+
+        ccifar10._get_cifar10_dataset = count_downloads
+
+    def tearDown(self):
+        global CIFAR10_DOWNLOAD_METHOD
+        if CIFAR10_DOWNLOAD_METHOD is not None:
+            import avalanche.benchmarks.classic.ccifar10 as ccifar10
+            ccifar10._get_cifar10_dataset = CIFAR10_DOWNLOAD_METHOD
+            CIFAR10_DOWNLOAD_METHOD = None
+
+    def test_SplitCifar10_scenario(self):
+        scenario = SplitCIFAR10(5)
+        self.assertEqual(5, len(scenario.train_stream))
+        self.assertEqual(5, len(scenario.test_stream))
+
+        train_sz = 0
+        for experience in scenario.train_stream:
+            self.assertIsInstance(experience, Experience)
+            train_sz += len(experience.dataset)
+
+            for x, y, t in DataLoader(experience.dataset, batch_size=32):
+                break
+
+            # Regression test for 575
+            for x, y, t in DataLoader(experience.dataset.eval(),
+                                      batch_size=32):
+                break
+
+        self.assertEqual(50000, train_sz)
+
+        test_sz = 0
+        for experience in scenario.test_stream:
+            self.assertIsInstance(experience, Experience)
+            test_sz += len(experience.dataset)
+
+            for x, y, t in DataLoader(experience.dataset, batch_size=32):
+                break
+
+            # Regression test for 575
+            for x, y, t in DataLoader(experience.dataset.train(),
+                                      batch_size=32):
+                break
+
+        self.assertEqual(10000, test_sz)
+
+    def test_SplitCifar10_scenario_download_once(self):
+        global CIFAR10_DOWNLOADS
+        CIFAR10_DOWNLOADS = 0
+
+        scenario = SplitCIFAR10(5)
+        self.assertEqual(5, len(scenario.train_stream))
+        self.assertEqual(5, len(scenario.test_stream))
+
+        self.assertEqual(1, CIFAR10_DOWNLOADS)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_fmnist_benckmarks.py
+++ b/tests/test_fmnist_benckmarks.py
@@ -1,0 +1,55 @@
+import unittest
+
+from avalanche.benchmarks import Experience, SplitFMNIST
+from unit_tests_utils import load_experience_train_eval
+
+MNIST_DOWNLOADS = 0
+MNIST_DOWNLOAD_METHOD = None
+
+
+class FMNISTBenchmarksTests(unittest.TestCase):
+    def setUp(self):
+        import avalanche.benchmarks.classic.cfashion_mnist as cfashion_mnist
+        global MNIST_DOWNLOAD_METHOD
+        MNIST_DOWNLOAD_METHOD = cfashion_mnist._get_fmnist_dataset
+
+        def count_downloads(*args, **kwargs):
+            global MNIST_DOWNLOADS
+            MNIST_DOWNLOADS += 1
+            return MNIST_DOWNLOAD_METHOD(*args, **kwargs)
+
+        cfashion_mnist._get_fmnist_dataset = count_downloads
+
+    def tearDown(self):
+        global MNIST_DOWNLOAD_METHOD
+        if MNIST_DOWNLOAD_METHOD is not None:
+            import avalanche.benchmarks.classic.cfashion_mnist as cfashion_mnist
+            cfashion_mnist._get_fmnist_dataset = MNIST_DOWNLOAD_METHOD
+            MNIST_DOWNLOAD_METHOD = None
+
+    def test_SplitFMNIST_scenario(self):
+        scenario = SplitFMNIST(5)
+        self.assertEqual(5, len(scenario.train_stream))
+        self.assertEqual(5, len(scenario.test_stream))
+
+        train_sz = 0
+        for experience in scenario.train_stream:
+            self.assertIsInstance(experience, Experience)
+            train_sz += len(experience.dataset)
+
+            load_experience_train_eval(experience)
+
+        self.assertEqual(60000, train_sz)
+
+        test_sz = 0
+        for experience in scenario.test_stream:
+            self.assertIsInstance(experience, Experience)
+            test_sz += len(experience.dataset)
+
+            load_experience_train_eval(experience)
+
+        self.assertEqual(10000, test_sz)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_fmnist_benckmarks.py
+++ b/tests/test_fmnist_benckmarks.py
@@ -1,7 +1,7 @@
 import unittest
 
 from avalanche.benchmarks import Experience, SplitFMNIST
-from unit_tests_utils import load_experience_train_eval
+from tests.unit_tests_utils import load_experience_train_eval
 
 MNIST_DOWNLOADS = 0
 MNIST_DOWNLOAD_METHOD = None

--- a/tests/test_mnist_benckmarks.py
+++ b/tests/test_mnist_benckmarks.py
@@ -1,9 +1,8 @@
 import unittest
 
-from torch.utils.data import DataLoader
-
 from avalanche.benchmarks import PermutedMNIST, Experience, RotatedMNIST, \
     SplitMNIST
+from unit_tests_utils import load_experience_train_eval
 
 MNIST_DOWNLOADS = 0
 MNIST_DOWNLOAD_METHOD = None
@@ -39,13 +38,8 @@ class MNISTBenchmarksTests(unittest.TestCase):
             self.assertIsInstance(experience, Experience)
             train_sz += len(experience.dataset)
 
-            for x, y, t in DataLoader(experience.dataset, batch_size=32):
-                break
-
             # Regression test for 572
-            for x, y, t in DataLoader(experience.dataset.eval(),
-                                      batch_size=32):
-                break
+            load_experience_train_eval(experience)
 
         self.assertEqual(60000, train_sz)
 
@@ -54,13 +48,8 @@ class MNISTBenchmarksTests(unittest.TestCase):
             self.assertIsInstance(experience, Experience)
             test_sz += len(experience.dataset)
 
-            for x, y, t in DataLoader(experience.dataset, batch_size=32):
-                break
-
             # Regression test for 572
-            for x, y, t in DataLoader(experience.dataset.train(),
-                                      batch_size=32):
-                break
+            load_experience_train_eval(experience)
 
         self.assertEqual(10000, test_sz)
 
@@ -73,9 +62,30 @@ class MNISTBenchmarksTests(unittest.TestCase):
             self.assertIsInstance(experience, Experience)
             self.assertEqual(60000, len(experience.dataset))
 
+            load_experience_train_eval(experience)
+
         for experience in scenario.test_stream:
             self.assertIsInstance(experience, Experience)
             self.assertEqual(10000, len(experience.dataset))
+
+            load_experience_train_eval(experience)
+
+    def test_RotatedMNIST_scenario(self):
+        scenario = RotatedMNIST(3)
+        self.assertEqual(3, len(scenario.train_stream))
+        self.assertEqual(3, len(scenario.test_stream))
+
+        for experience in scenario.train_stream:
+            self.assertIsInstance(experience, Experience)
+            self.assertEqual(60000, len(experience.dataset))
+
+            load_experience_train_eval(experience)
+
+        for experience in scenario.test_stream:
+            self.assertIsInstance(experience, Experience)
+            self.assertEqual(10000, len(experience.dataset))
+
+            load_experience_train_eval(experience)
 
     def test_PermutedMNIST_scenario_download_once(self):
         global MNIST_DOWNLOADS

--- a/tests/test_mnist_benckmarks.py
+++ b/tests/test_mnist_benckmarks.py
@@ -2,7 +2,7 @@ import unittest
 
 from avalanche.benchmarks import PermutedMNIST, Experience, RotatedMNIST, \
     SplitMNIST
-from unit_tests_utils import load_experience_train_eval
+from tests.unit_tests_utils import load_experience_train_eval
 
 MNIST_DOWNLOADS = 0
 MNIST_DOWNLOAD_METHOD = None

--- a/tests/unit_tests_utils.py
+++ b/tests/unit_tests_utils.py
@@ -4,6 +4,7 @@ import torch
 from sklearn.datasets import make_classification
 from sklearn.model_selection import train_test_split
 from torch.utils.data import TensorDataset
+from torch.utils.data.dataloader import DataLoader
 
 from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, ToTensor
@@ -60,8 +61,19 @@ def get_fast_scenario(use_task_labels=False, shuffle=True):
     return my_nc_benchmark
 
 
+def load_experience_train_eval(experience, batch_size=32, num_workers=0):
+    for x, y, t in DataLoader(experience.dataset.train(), batch_size=batch_size,
+                              num_workers=num_workers):
+        break
+
+    for x, y, t in DataLoader(experience.dataset.eval(), batch_size=batch_size,
+                              num_workers=num_workers):
+        break
+
+
 __all__ = [
     'common_setups',
     'load_scenario',
-    'get_fast_scenario'
+    'get_fast_scenario',
+    'load_experience_train_eval'
 ]


### PR DESCRIPTION
This PR implements a better handling of train and eval transformations for `ni_benchmark` and `nc_benchmark` helpers. Train and eval transformations can now be defined by passing them to these helpers.

Adapted classic benchmarks.
Added unit tests for FMnist and CIFAR benchmarks.
Better unit tests for MNIST benchmarks.

Fixes #575
Fixes #577 