### PR TITLE
Core Module Docstring Updated

### DIFF
--- a/avalanche/core.py
+++ b/avalanche/core.py
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021. ContinualAI. All rights reserved.                        #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 5-5-2021                                                               #
+# Author: Antonio Carta, Vincenzo Lomonaco                                     #
+# E-mail: contact@continualai.org                                              #
+# Website: continualai.org                                                     #
+################################################################################
+
+"""
+The core module offers fundamental utilities (classes and data structures) that
+can be used by inner Avalanche modules. As for now, it contains only the
+Strategy Callbacks definition that can be used by the :py:mod:`training`
+module for defining new continual learning strategies and by the
+:py:mod:`evaluation` module for defining new evaluation plugin metrics.
+"""
+
 from abc import ABC
 from typing import Generic, TypeVar
 


### PR DESCRIPTION
This closes #548. The module cannot be moved into the training module due to circular dep. I just added a bit of doc. We will keep it here as a "sub-module" for now. It may be upgraded in a "sub-package" later on as we add functionalities.