### PR TITLE
Fix for #593

### DIFF
--- a/avalanche/benchmarks/scenarios/generic_cl_scenario.py
+++ b/avalanche/benchmarks/scenarios/generic_cl_scenario.py
@@ -239,18 +239,22 @@ class GenericCLScenario(Generic[TExperience]):
 
         return LazyStreamClassesInExps(self)
 
-    def get_classes_timeline(self, current_experience: int):
+    def get_classes_timeline(self, current_experience: int,
+                             stream: str = 'train'):
         """
-        Returns the classes timeline given the ID of a training experience.
+        Returns the classes timeline given the ID of a experience.
 
-        Given a experience ID, this method returns the classes in that training
+        Given a experience ID, this method returns the classes in that
         experience, previously seen classes, the cumulative class list and a
-        list of classes that will be encountered in next training experiences.
+        list of classes that will be encountered in next experiences of the
+        same stream.
 
-        Beware that this will obtain the timeline of an experience of the
-        **training** stream.
+        Beware that by default this will obtain the timeline of an experience
+        of the **training** stream. Use the stream parameter to select another
+        stream.
 
-        :param current_experience: The reference training experience ID.
+        :param current_experience: The reference experience ID.
+        :param stream: The stream name.
         :return: A tuple composed of four lists: the first list contains the
             IDs of classes in this experience, the second contains IDs of
             classes seen in previous experiences, the third returns a cumulative
@@ -258,26 +262,26 @@ class GenericCLScenario(Generic[TExperience]):
             last one returns a list of classes that will be encountered in next
             experiences.
         """
-        train_exps_patterns_assignment: Sequence[Sequence[int]]
 
         class_set_current_exp = \
-            self.classes_in_experience['train'][current_experience]
+            self.classes_in_experience[stream][current_experience]
 
         classes_in_this_exp = list(class_set_current_exp)
 
         class_set_prev_exps = set()
         for exp_id in range(0, current_experience):
             class_set_prev_exps.update(
-                self.classes_in_experience['train'][exp_id])
+                self.classes_in_experience[stream][exp_id])
         previous_classes = list(class_set_prev_exps)
 
         classes_seen_so_far = \
             list(class_set_current_exp.union(class_set_prev_exps))
 
         class_set_future_exps = set()
-        for exp_id in range(current_experience, self.n_experiences):
+        stream_n_exps = len(self.stream_definitions[stream].exps_data)
+        for exp_id in range(current_experience, stream_n_exps):
             class_set_prev_exps.update(
-                self.classes_in_experience['train'][exp_id])
+                self.classes_in_experience[stream][exp_id])
         future_classes = list(class_set_future_exps)
 
         return (classes_in_this_exp, previous_classes, classes_seen_so_far,
@@ -634,7 +638,7 @@ class GenericExperience(AbstractExperience[TGenericCLScenario,
 
         (classes_in_this_exp, previous_classes, classes_seen_so_far,
          future_classes) = origin_stream.scenario.get_classes_timeline(
-            current_experience)
+            current_experience, stream=origin_stream.name)
 
         super(GenericExperience, self).__init__(
             origin_stream, current_experience, classes_in_this_exp,

--- a/avalanche/benchmarks/scenarios/generic_cl_scenario.py
+++ b/avalanche/benchmarks/scenarios/generic_cl_scenario.py
@@ -2,8 +2,7 @@ import copy
 import re
 from abc import ABC
 from typing import Generic, TypeVar, Union, Sequence, Callable, Optional, \
-    Dict, Any, Iterable, List, Set, Iterator, Tuple, NamedTuple, Mapping, \
-    overload
+    Dict, Any, Iterable, List, Set, Iterator, Tuple, NamedTuple, Mapping
 
 import warnings
 from torch.utils.data.dataset import Dataset

--- a/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
@@ -9,13 +9,13 @@
 # Website: avalanche.continualai.org                                           #
 ################################################################################
 
-import torch
 from typing import Sequence, List, Optional, Dict, Any, Set
 
-from avalanche.benchmarks.scenarios.scenario_utils import train_eval_transforms
-from avalanche.benchmarks.utils import AvalancheSubset, AvalancheDataset
+import torch
+
 from avalanche.benchmarks.scenarios.generic_cl_scenario import \
     GenericCLScenario, GenericScenarioStream, GenericExperience
+from avalanche.benchmarks.utils import AvalancheSubset, AvalancheDataset
 from avalanche.benchmarks.utils.dataset_utils import ConstantSequence
 
 
@@ -149,11 +149,12 @@ class NCScenario(GenericCLScenario['NCExperience']):
 
         self._classes_in_exp: List[Set[int]] = []
 
-        # TODO: same for classes_in_exp
         self.original_classes_in_exp: List[Set[int]] = []
-        """ A list that, for each experience (identified by its index/ID),
-            stores a list of the original IDs of classes assigned 
-            to that experience. """
+        """
+        A list that, for each experience (identified by its index/ID), stores a 
+        set of the original IDs of classes assigned to that experience. 
+        This field applies to both train and test streams.
+        """
 
         self.class_ids_from_zero_from_first_exp: bool = \
             class_ids_from_zero_from_first_exp
@@ -424,11 +425,6 @@ class NCScenario(GenericCLScenario['NCExperience']):
                 'test': (test_experiences, test_task_labels, test_dataset)
             },
             experience_factory=NCExperience)
-
-    # TODO: remove
-    # @property
-    # def classes_in_experience(self) -> Sequence[Set[int]]:
-    #     return self._classes_in_exp
 
     def get_reproducibility_data(self):
         reproducibility_data = {

--- a/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
@@ -149,6 +149,7 @@ class NCScenario(GenericCLScenario['NCExperience']):
 
         self._classes_in_exp: List[Set[int]] = []
 
+        # TODO: same for classes_in_exp
         self.original_classes_in_exp: List[Set[int]] = []
         """ A list that, for each experience (identified by its index/ID),
             stores a list of the original IDs of classes assigned 
@@ -424,9 +425,10 @@ class NCScenario(GenericCLScenario['NCExperience']):
             },
             experience_factory=NCExperience)
 
-    @property
-    def classes_in_experience(self) -> Sequence[Set[int]]:
-        return self._classes_in_exp
+    # TODO: remove
+    # @property
+    # def classes_in_experience(self) -> Sequence[Set[int]]:
+    #     return self._classes_in_exp
 
     def get_reproducibility_data(self):
         reproducibility_data = {

--- a/avalanche/benchmarks/scenarios/new_instances/ni_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_instances/ni_scenario.py
@@ -404,17 +404,18 @@ class NIScenario(GenericCLScenario['NIExperience']):
             complete_test_set_only=True,
             experience_factory=NIExperience)
 
-    @property
-    def classes_in_experience(self) -> Sequence[Set[int]]:
-        if self._classes_in_exp is None:
-            self._classes_in_exp = []
-            for exp_id in range(self.n_experiences):
-                self._classes_in_exp.append(set())
-                exp_s = self.exp_structure[exp_id]
-                for class_id, n_patterns_of_class in enumerate(exp_s):
-                    if n_patterns_of_class > 0:
-                        self._classes_in_exp[exp_id].add(class_id)
-        return self._classes_in_exp
+    # TODO: remove
+    # @property
+    # def classes_in_experience(self) -> Sequence[Set[int]]:
+    #     if self._classes_in_exp is None:
+    #         self._classes_in_exp = []
+    #         for exp_id in range(self.n_experiences):
+    #             self._classes_in_exp.append(set())
+    #             exp_s = self.exp_structure[exp_id]
+    #             for class_id, n_patterns_of_class in enumerate(exp_s):
+    #                 if n_patterns_of_class > 0:
+    #                     self._classes_in_exp[exp_id].add(class_id)
+    #     return self._classes_in_exp
 
     def get_reproducibility_data(self) -> Dict[str, Any]:
         reproducibility_data = {

--- a/avalanche/benchmarks/scenarios/new_instances/ni_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_instances/ni_scenario.py
@@ -9,16 +9,15 @@
 # Website: avalanche.continualai.org                                           #
 ################################################################################
 
-from typing import Optional, List, Sequence, Dict, Any, Set
+from typing import Optional, List, Sequence, Dict, Any
 
 import torch
 
-from avalanche.benchmarks.scenarios.new_instances.ni_utils import \
-    _exp_structure_from_assignment
-from avalanche.benchmarks.scenarios.scenario_utils import train_eval_transforms
-from avalanche.benchmarks.utils import AvalancheSubset, AvalancheDataset
 from avalanche.benchmarks.scenarios.generic_cl_scenario import \
     GenericCLScenario, GenericScenarioStream, GenericExperience
+from avalanche.benchmarks.scenarios.new_instances.ni_utils import \
+    _exp_structure_from_assignment
+from avalanche.benchmarks.utils import AvalancheSubset, AvalancheDataset
 from avalanche.benchmarks.utils.dataset_utils import ConstantSequence
 
 

--- a/tests/test_core50.py
+++ b/tests/test_core50.py
@@ -14,7 +14,6 @@
 import unittest
 
 from avalanche.benchmarks.classic import CORe50
-from avalanche.benchmarks.scenarios.generic_definitions import Experience
 
 
 class CORe50Test(unittest.TestCase):

--- a/tests/test_core50.py
+++ b/tests/test_core50.py
@@ -28,6 +28,17 @@ class CORe50Test(unittest.TestCase):
         # for task_info in scenario:
         #     self.assertIsInstance(task_info, IExperience)
 
+    def test_core50_nc_scenario(self):
+        benchmark_instance = CORe50(scenario='nc')
+
+        self.assertEqual(1, len(benchmark_instance.test_stream))
+
+        classes_in_test = benchmark_instance.\
+            classes_in_experience['test'][0]
+        self.assertSetEqual(
+            set(range(50)),
+            set(classes_in_test))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_generic_cl_scenario.py
+++ b/tests/test_generic_cl_scenario.py
@@ -2,7 +2,8 @@ import unittest
 
 import torch
 
-from avalanche.benchmarks import dataset_benchmark
+from avalanche.benchmarks import dataset_benchmark, Experience, \
+    GenericExperience
 from avalanche.benchmarks.utils import AvalancheTensorDataset
 
 
@@ -72,6 +73,67 @@ class GenericCLScenarioTests(unittest.TestCase):
         self.assertLess(test_0_classes_max, 200)
 
         other_0_classes = benchmark_instance.classes_in_experience['other'][0]
+        other_0_classes_min = min(other_0_classes)
+        other_0_classes_max = max(other_0_classes)
+        self.assertGreaterEqual(other_0_classes_min, 400)
+        self.assertLess(other_0_classes_max, 600)
+
+    def test_classes_in_this_experience(self):
+        train_exps = []
+
+        tensor_x = torch.rand(200, 3, 28, 28)
+        tensor_y = torch.randint(0, 70, (200,))
+        tensor_t = torch.randint(0, 5, (200,))
+        train_exps.append(AvalancheTensorDataset(
+            tensor_x, tensor_y, task_labels=tensor_t))
+
+        tensor_x = torch.rand(200, 3, 28, 28)
+        tensor_y = torch.randint(0, 100, (200,))
+        tensor_t = torch.randint(0, 5, (200,))
+        train_exps.append(AvalancheTensorDataset(
+            tensor_x, tensor_y, task_labels=tensor_t))
+
+        test_exps = []
+        test_x = torch.rand(200, 3, 28, 28)
+        test_y = torch.randint(100, 200, (200,))
+        test_t = torch.randint(0, 5, (200,))
+        test_exps.append(AvalancheTensorDataset(
+            test_x, test_y, task_labels=test_t))
+
+        other_stream_exps = []
+        other_x = torch.rand(200, 3, 28, 28)
+        other_y = torch.randint(400, 600, (200,))
+        other_t = torch.randint(0, 5, (200,))
+        other_stream_exps.append(AvalancheTensorDataset(
+            other_x, other_y, task_labels=other_t))
+
+        benchmark_instance = dataset_benchmark(
+            train_datasets=train_exps,
+            test_datasets=test_exps,
+            other_streams_datasets={'other': other_stream_exps})
+
+        train_exp_0: GenericExperience = benchmark_instance.train_stream[0]
+        train_exp_1: GenericExperience = benchmark_instance.train_stream[1]
+        train_0_classes = train_exp_0.classes_in_this_experience
+        train_1_classes = train_exp_1.classes_in_this_experience
+        train_0_classes_min = min(train_0_classes)
+        train_1_classes_min = min(train_1_classes)
+        train_0_classes_max = max(train_0_classes)
+        train_1_classes_max = max(train_1_classes)
+        self.assertGreaterEqual(train_0_classes_min, 0)
+        self.assertLess(train_0_classes_max, 70)
+        self.assertGreaterEqual(train_1_classes_min, 0)
+        self.assertLess(train_1_classes_max, 100)
+
+        test_exp_0: GenericExperience = benchmark_instance.test_stream[0]
+        test_0_classes = test_exp_0.classes_in_this_experience
+        test_0_classes_min = min(test_0_classes)
+        test_0_classes_max = max(test_0_classes)
+        self.assertGreaterEqual(test_0_classes_min, 100)
+        self.assertLess(test_0_classes_max, 200)
+
+        other_exp_0: GenericExperience = benchmark_instance.other_stream[0]
+        other_0_classes = other_exp_0.classes_in_this_experience
         other_0_classes_min = min(other_0_classes)
         other_0_classes_max = max(other_0_classes)
         self.assertGreaterEqual(other_0_classes_min, 400)

--- a/tests/test_generic_cl_scenario.py
+++ b/tests/test_generic_cl_scenario.py
@@ -1,0 +1,82 @@
+import unittest
+
+import torch
+
+from avalanche.benchmarks import dataset_benchmark
+from avalanche.benchmarks.utils import AvalancheTensorDataset
+
+
+class GenericCLScenarioTests(unittest.TestCase):
+    def test_classes_in_exp(self):
+        train_exps = []
+
+        tensor_x = torch.rand(200, 3, 28, 28)
+        tensor_y = torch.randint(0, 70, (200,))
+        tensor_t = torch.randint(0, 5, (200,))
+        train_exps.append(AvalancheTensorDataset(
+            tensor_x, tensor_y, task_labels=tensor_t))
+
+        tensor_x = torch.rand(200, 3, 28, 28)
+        tensor_y = torch.randint(0, 100, (200,))
+        tensor_t = torch.randint(0, 5, (200,))
+        train_exps.append(AvalancheTensorDataset(
+            tensor_x, tensor_y, task_labels=tensor_t))
+
+        test_exps = []
+        test_x = torch.rand(200, 3, 28, 28)
+        test_y = torch.randint(100, 200, (200,))
+        test_t = torch.randint(0, 5, (200,))
+        test_exps.append(AvalancheTensorDataset(
+            test_x, test_y, task_labels=test_t))
+
+        other_stream_exps = []
+        other_x = torch.rand(200, 3, 28, 28)
+        other_y = torch.randint(400, 600, (200,))
+        other_t = torch.randint(0, 5, (200,))
+        other_stream_exps.append(AvalancheTensorDataset(
+            other_x, other_y, task_labels=other_t))
+
+        benchmark_instance = dataset_benchmark(
+            train_datasets=train_exps,
+            test_datasets=test_exps,
+            other_streams_datasets={'other': other_stream_exps})
+
+        train_0_classes = benchmark_instance.classes_in_experience['train'][0]
+        train_1_classes = benchmark_instance.classes_in_experience['train'][1]
+        train_0_classes_min = min(train_0_classes)
+        train_1_classes_min = min(train_1_classes)
+        train_0_classes_max = max(train_0_classes)
+        train_1_classes_max = max(train_1_classes)
+        self.assertGreaterEqual(train_0_classes_min, 0)
+        self.assertLess(train_0_classes_max, 70)
+        self.assertGreaterEqual(train_1_classes_min, 0)
+        self.assertLess(train_1_classes_max, 100)
+
+        # Test deprecated behavior
+        train_0_classes = benchmark_instance.classes_in_experience[0]
+        train_1_classes = benchmark_instance.classes_in_experience[1]
+        train_0_classes_min = min(train_0_classes)
+        train_1_classes_min = min(train_1_classes)
+        train_0_classes_max = max(train_0_classes)
+        train_1_classes_max = max(train_1_classes)
+        self.assertGreaterEqual(train_0_classes_min, 0)
+        self.assertLess(train_0_classes_max, 70)
+        self.assertGreaterEqual(train_1_classes_min, 0)
+        self.assertLess(train_1_classes_max, 100)
+        # End test deprecated behavior
+
+        test_0_classes = benchmark_instance.classes_in_experience['test'][0]
+        test_0_classes_min = min(test_0_classes)
+        test_0_classes_max = max(test_0_classes)
+        self.assertGreaterEqual(test_0_classes_min, 100)
+        self.assertLess(test_0_classes_max, 200)
+
+        other_0_classes = benchmark_instance.classes_in_experience['other'][0]
+        other_0_classes_min = min(other_0_classes)
+        other_0_classes_max = max(other_0_classes)
+        self.assertGreaterEqual(other_0_classes_min, 400)
+        self.assertLess(other_0_classes_max, 600)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_nc_mt_scenario.py
+++ b/tests/test_nc_mt_scenario.py
@@ -25,13 +25,14 @@ class MultiTaskTests(unittest.TestCase):
         self.assertEqual(10, my_nc_benchmark.n_classes)
         for task_id in range(5):
             self.assertEqual(
-                2, len(my_nc_benchmark.classes_in_experience[task_id])
+                2, len(my_nc_benchmark.classes_in_experience['train'][task_id])
             )
 
         all_classes = set()
         all_original_classes = set()
         for task_id in range(5):
-            all_classes.update(my_nc_benchmark.classes_in_experience[task_id])
+            all_classes.update(
+                my_nc_benchmark.classes_in_experience['train'][task_id])
             all_original_classes.update(
                 my_nc_benchmark.original_classes_in_exp[task_id])
 
@@ -51,12 +52,13 @@ class MultiTaskTests(unittest.TestCase):
         self.assertEqual(10, my_nc_benchmark.n_classes)
         for task_id in range(5):
             self.assertEqual(
-                2, len(my_nc_benchmark.classes_in_experience[task_id])
+                2, len(my_nc_benchmark.classes_in_experience['train'][task_id])
             )
 
         all_classes = set()
         for task_id in range(my_nc_benchmark.n_experiences):
-            all_classes.update(my_nc_benchmark.classes_in_experience[task_id])
+            all_classes.update(
+                my_nc_benchmark.classes_in_experience['train'][task_id])
 
         self.assertEqual(10, len(all_classes))
 
@@ -72,7 +74,8 @@ class MultiTaskTests(unittest.TestCase):
 
         all_classes = []
         for task_id in range(5):
-            all_classes.extend(my_nc_benchmark.classes_in_experience[task_id])
+            all_classes.extend(
+                my_nc_benchmark.classes_in_experience['train'][task_id])
 
         self.assertEqual(order, all_classes)
 
@@ -86,16 +89,18 @@ class MultiTaskTests(unittest.TestCase):
             mnist_train, mnist_test, 4, task_labels=True,
             fixed_class_order=order, class_ids_from_zero_in_each_exp=True)
 
-        self.assertEqual(4, len(my_nc_benchmark.classes_in_experience))
+        self.assertEqual(4, len(my_nc_benchmark.classes_in_experience['train']))
 
         all_classes = []
         for task_id in range(4):
             self.assertEqual(
-                2, len(my_nc_benchmark.classes_in_experience[task_id])
+                2, len(my_nc_benchmark.classes_in_experience['train'][task_id])
             )
-            self.assertEqual(set(order[task_id*2:(task_id+1)*2]),
-                             my_nc_benchmark.original_classes_in_exp[task_id])
-            all_classes.extend(my_nc_benchmark.classes_in_experience[task_id])
+            self.assertEqual(
+                set(order[task_id*2:(task_id+1)*2]),
+                my_nc_benchmark.original_classes_in_exp[task_id])
+            all_classes.extend(
+                my_nc_benchmark.classes_in_experience['train'][task_id])
 
         self.assertEqual([0, 1] * 4, all_classes)
 
@@ -109,16 +114,18 @@ class MultiTaskTests(unittest.TestCase):
             mnist_train, mnist_test, 2, task_labels=True,
             fixed_class_order=order, class_ids_from_zero_in_each_exp=False)
 
-        self.assertEqual(2, len(my_nc_benchmark.classes_in_experience))
+        self.assertEqual(2, len(my_nc_benchmark.classes_in_experience['train']))
 
         all_classes = set()
         for task_id in range(2):
             self.assertEqual(
-                4, len(my_nc_benchmark.classes_in_experience[task_id])
+                4, len(my_nc_benchmark.classes_in_experience['train'][task_id])
             )
-            self.assertEqual(set(order[task_id*4:(task_id+1)*4]),
-                             my_nc_benchmark.original_classes_in_exp[task_id])
-            all_classes.update(my_nc_benchmark.classes_in_experience[task_id])
+            self.assertEqual(
+                set(order[task_id*4:(task_id+1)*4]),
+                my_nc_benchmark.original_classes_in_exp[task_id])
+            all_classes.update(
+                my_nc_benchmark.classes_in_experience['train'][task_id])
 
         self.assertEqual(set(order), all_classes)
 
@@ -156,12 +163,16 @@ class MultiTaskTests(unittest.TestCase):
 
         all_classes = set()
         for task_id in range(3):
-            all_classes.update(my_nc_benchmark.classes_in_experience[task_id])
+            all_classes.update(
+                my_nc_benchmark.classes_in_experience['train'][task_id])
         self.assertEqual(5, len(all_classes))
 
-        self.assertEqual(5, len(my_nc_benchmark.classes_in_experience[0]))
-        self.assertEqual(3, len(my_nc_benchmark.classes_in_experience[1]))
-        self.assertEqual(2, len(my_nc_benchmark.classes_in_experience[2]))
+        self.assertEqual(
+            5,  len(my_nc_benchmark.classes_in_experience['train'][0]))
+        self.assertEqual(
+            3, len(my_nc_benchmark.classes_in_experience['train'][1]))
+        self.assertEqual(
+            2, len(my_nc_benchmark.classes_in_experience['train'][2]))
 
     def test_mt_multi_dataset_one_task_per_set(self):
         split_mapping = [0, 1, 2, 0, 1, 2, 3, 4, 5, 6]
@@ -203,7 +214,7 @@ class MultiTaskTests(unittest.TestCase):
         for task_id, task_info in enumerate(my_nc_benchmark.train_stream):
             self.assertLessEqual(task_id, 1)
             all_classes_train.update(
-                my_nc_benchmark.classes_in_experience[task_id]
+                my_nc_benchmark.classes_in_experience['train'][task_id]
             )
             exp_classes_train.append(task_info.classes_in_this_experience)
         self.assertEqual(7, len(all_classes_train))
@@ -211,16 +222,18 @@ class MultiTaskTests(unittest.TestCase):
         for task_id, task_info in enumerate(my_nc_benchmark.test_stream):
             self.assertLessEqual(task_id, 1)
             all_classes_test.update(
-                my_nc_benchmark.classes_in_experience[task_id]
+                my_nc_benchmark.classes_in_experience['test'][task_id]
             )
             exp_classes_test.append(task_info.classes_in_this_experience)
         self.assertEqual(7, len(all_classes_test))
 
         self.assertTrue(
-            (my_nc_benchmark.classes_in_experience[0] == {0, 1, 2} and
-             my_nc_benchmark.classes_in_experience[1] == set(range(0, 7))) or
-            (my_nc_benchmark.classes_in_experience[0] == set(range(0, 7)) and
-             my_nc_benchmark.classes_in_experience[1] == {0, 1, 2}))
+            (my_nc_benchmark.classes_in_experience['train'][0] == {0, 1, 2} and
+             my_nc_benchmark.classes_in_experience['train'][1] ==
+             set(range(0, 7))) or
+            (my_nc_benchmark.classes_in_experience['train'][0] ==
+             set(range(0, 7)) and
+             my_nc_benchmark.classes_in_experience['train'][1] == {0, 1, 2}))
 
         exp_classes_ref1 = [list(range(3)), list(range(7))]
         exp_classes_ref2 = [list(range(7)), list(range(3))]

--- a/tests/test_nc_mt_scenario.py
+++ b/tests/test_nc_mt_scenario.py
@@ -168,7 +168,7 @@ class MultiTaskTests(unittest.TestCase):
         self.assertEqual(5, len(all_classes))
 
         self.assertEqual(
-            5,  len(my_nc_benchmark.classes_in_experience['train'][0]))
+            5, len(my_nc_benchmark.classes_in_experience['train'][0]))
         self.assertEqual(
             3, len(my_nc_benchmark.classes_in_experience['train'][1]))
         self.assertEqual(

--- a/tests/test_nc_sit_scenario.py
+++ b/tests/test_nc_sit_scenario.py
@@ -194,7 +194,7 @@ class SITTests(unittest.TestCase):
         self.assertEqual(10, len(all_classes))
 
         self.assertEqual(
-            5,  len(my_nc_benchmark.classes_in_experience['train'][0]))
+            5, len(my_nc_benchmark.classes_in_experience['train'][0]))
         self.assertEqual(
             3, len(my_nc_benchmark.classes_in_experience['train'][1]))
         self.assertEqual(

--- a/tests/test_nc_sit_scenario.py
+++ b/tests/test_nc_sit_scenario.py
@@ -31,11 +31,13 @@ class SITTests(unittest.TestCase):
         self.assertEqual(10, my_nc_benchmark.n_classes)
         for batch_id in range(my_nc_benchmark.n_experiences):
             self.assertEqual(
-                2, len(my_nc_benchmark.classes_in_experience[batch_id]))
+                2,
+                len(my_nc_benchmark.classes_in_experience['train'][batch_id]))
 
         all_classes = set()
         for batch_id in range(5):
-            all_classes.update(my_nc_benchmark.classes_in_experience[batch_id])
+            all_classes.update(
+                my_nc_benchmark.classes_in_experience['train'][batch_id])
 
         self.assertEqual(10, len(all_classes))
 
@@ -51,7 +53,8 @@ class SITTests(unittest.TestCase):
 
         all_classes = []
         for batch_id in range(5):
-            all_classes.extend(my_nc_benchmark.classes_in_experience[batch_id])
+            all_classes.extend(
+                my_nc_benchmark.classes_in_experience['train'][batch_id])
 
         self.assertEqual(order, all_classes)
 
@@ -65,13 +68,15 @@ class SITTests(unittest.TestCase):
             mnist_train, mnist_test, 4, task_labels=False,
             fixed_class_order=order)
 
-        self.assertEqual(4, len(my_nc_benchmark.classes_in_experience))
+        self.assertEqual(4, len(my_nc_benchmark.classes_in_experience['train']))
 
         all_classes = set()
         for batch_id in range(4):
             self.assertEqual(
-                2, len(my_nc_benchmark.classes_in_experience[batch_id]))
-            all_classes.update(my_nc_benchmark.classes_in_experience[batch_id])
+                2,
+                len(my_nc_benchmark.classes_in_experience['train'][batch_id]))
+            all_classes.update(
+                my_nc_benchmark.classes_in_experience['train'][batch_id])
 
         self.assertEqual(set(order), all_classes)
 
@@ -85,13 +90,15 @@ class SITTests(unittest.TestCase):
             mnist_train, mnist_test, 4, task_labels=False,
             fixed_class_order=order, class_ids_from_zero_from_first_exp=True)
 
-        self.assertEqual(4, len(my_nc_benchmark.classes_in_experience))
+        self.assertEqual(4, len(my_nc_benchmark.classes_in_experience['train']))
 
         all_classes = []
         for batch_id in range(4):
             self.assertEqual(
-                2, len(my_nc_benchmark.classes_in_experience[batch_id]))
-            all_classes.extend(my_nc_benchmark.classes_in_experience[batch_id])
+                2,
+                len(my_nc_benchmark.classes_in_experience['train'][batch_id]))
+            all_classes.extend(
+                my_nc_benchmark.classes_in_experience['train'][batch_id])
         self.assertEqual(list(range(8)), all_classes)
 
         # Regression test for issue #258
@@ -126,13 +133,15 @@ class SITTests(unittest.TestCase):
             fixed_class_order=order,
             class_ids_from_zero_in_each_exp=True)
 
-        self.assertEqual(4, len(my_nc_benchmark.classes_in_experience))
+        self.assertEqual(4, len(my_nc_benchmark.classes_in_experience['train']))
 
         all_classes = []
         for batch_id in range(4):
             self.assertEqual(
-                2, len(my_nc_benchmark.classes_in_experience[batch_id]))
-            all_classes.extend(my_nc_benchmark.classes_in_experience[batch_id])
+                2,
+                len(my_nc_benchmark.classes_in_experience['train'][batch_id]))
+            all_classes.extend(
+                my_nc_benchmark.classes_in_experience['train'][batch_id])
         self.assertEqual(8, len(all_classes))
         self.assertListEqual([0, 1], sorted(set(all_classes)))
 
@@ -180,12 +189,16 @@ class SITTests(unittest.TestCase):
 
         all_classes = set()
         for batch_id in range(3):
-            all_classes.update(my_nc_benchmark.classes_in_experience[batch_id])
+            all_classes.update(
+                my_nc_benchmark.classes_in_experience['train'][batch_id])
         self.assertEqual(10, len(all_classes))
 
-        self.assertEqual(5, len(my_nc_benchmark.classes_in_experience[0]))
-        self.assertEqual(3, len(my_nc_benchmark.classes_in_experience[1]))
-        self.assertEqual(2, len(my_nc_benchmark.classes_in_experience[2]))
+        self.assertEqual(
+            5,  len(my_nc_benchmark.classes_in_experience['train'][0]))
+        self.assertEqual(
+            3, len(my_nc_benchmark.classes_in_experience['train'][1]))
+        self.assertEqual(
+            2, len(my_nc_benchmark.classes_in_experience['train'][2]))
 
     def test_sit_multi_dataset_one_batch_per_set(self):
         split_mapping = [0, 1, 2, 0, 1, 2, 3, 4, 5, 6]
@@ -217,15 +230,18 @@ class SITTests(unittest.TestCase):
 
         all_classes = set()
         for batch_id in range(2):
-            all_classes.update(my_nc_benchmark.classes_in_experience[batch_id])
+            all_classes.update(
+                my_nc_benchmark.classes_in_experience['train'][batch_id])
 
         self.assertEqual(10, len(all_classes))
 
         self.assertTrue(
-            (my_nc_benchmark.classes_in_experience[0] == {0, 1, 2} and
-             my_nc_benchmark.classes_in_experience[1] == set(range(3, 10))) or
-            (my_nc_benchmark.classes_in_experience[0] == set(range(3, 10)) and
-             my_nc_benchmark.classes_in_experience[1] == {0, 1, 2}))
+            (my_nc_benchmark.classes_in_experience['train'][0] == {0, 1, 2} and
+             my_nc_benchmark.classes_in_experience['train'][1] ==
+             set(range(3, 10))) or
+            (my_nc_benchmark.classes_in_experience['train'][0] ==
+             set(range(3, 10)) and
+             my_nc_benchmark.classes_in_experience['train'][1] == {0, 1, 2}))
 
     def test_sit_multi_dataset_merge(self):
         split_mapping = [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]
@@ -255,11 +271,13 @@ class SITTests(unittest.TestCase):
         self.assertEqual(10, my_nc_benchmark.n_classes)
         for batch_id in range(5):
             self.assertEqual(
-                2, len(my_nc_benchmark.classes_in_experience[batch_id]))
+                2,
+                len(my_nc_benchmark.classes_in_experience['train'][batch_id]))
 
         all_classes = set()
         for batch_id in range(5):
-            all_classes.update(my_nc_benchmark.classes_in_experience[batch_id])
+            all_classes.update(
+                my_nc_benchmark.classes_in_experience['train'][batch_id])
 
         self.assertEqual(10, len(all_classes))
 

--- a/tests/test_ni_sit_scenario.py
+++ b/tests/test_ni_sit_scenario.py
@@ -26,7 +26,8 @@ class NISITTests(unittest.TestCase):
         self.assertEqual(10, my_ni_benchmark.n_classes)
         for batch_id in range(5):
             self.assertEqual(
-                10, len(my_ni_benchmark.classes_in_experience[batch_id])
+                10,
+                len(my_ni_benchmark.classes_in_experience['train'][batch_id])
             )
 
         _, unique_count = torch.unique(torch.as_tensor(mnist_train.targets),
@@ -134,12 +135,13 @@ class NISITTests(unittest.TestCase):
         self.assertEqual(10, my_ni_benchmark.n_classes)
         for batch_id in range(5):
             self.assertEqual(
-                10, len(my_ni_benchmark.classes_in_experience[batch_id])
-            )
+                10,
+                len(my_ni_benchmark.classes_in_experience['train'][batch_id]))
 
         all_classes = set()
         for batch_id in range(5):
-            all_classes.update(my_ni_benchmark.classes_in_experience[batch_id])
+            all_classes.update(
+                my_ni_benchmark.classes_in_experience['train'][batch_id])
 
         self.assertEqual(10, len(all_classes))
 


### PR DESCRIPTION
The `classes_in_this_experience` field of `GenericCLScenario` by default returned the list linked to the training stream. This made it difficult to obtain the list of classes for non-training experiences.

This PR introduces another way to use that field, which can now be used as:

```python
benchmark_instance.classes_in_experience[stream_name][exp_id]
```

The previous way to use this field is deprecated. The following:

```python
benchmark_instance.classes_in_experience[exp_id]  # Deprecated
```

still works, but a warning will be printed to stdout.

Fixes #593