### PR TITLE
Validation stream creation helper

### DIFF
--- a/avalanche/benchmarks/generators/benchmark_generators.py
+++ b/avalanche/benchmarks/generators/benchmark_generators.py
@@ -16,7 +16,8 @@ the generic ones: filelist_benchmark, tensors_benchmark, dataset_benchmark
 and paths_benchmark.
 """
 from functools import partial
-from typing import Sequence, Optional, Dict, Union, Any, List, Callable, Set
+from typing import Sequence, Optional, Dict, Union, Any, List, Callable, Set, \
+    Tuple
 
 import torch
 
@@ -385,7 +386,7 @@ def fixed_size_experience_split_strategy(
     parameter: the experience. Consider wrapping your custom splitting strategy
     with `partial` if more parameters are needed.
 
-    Also consider that the stream name of the experience can be obtaines by
+    Also consider that the stream name of the experience can be obtained by
     using `experience.origin_stream.name`.
 
     :param experience_size: The experience size (number of instances).
@@ -446,8 +447,7 @@ def data_incremental_benchmark(
     streams (like the test one) if needed.
 
     The `custom_split_strategy` parameter can be used if a more specific
-    splitting is required (or even if a custom class for the final experience
-    is needed).
+    splitting is required.
 
     Beware that experience splitting is NOT executed in a lazy way. This
     means that the splitting process takes place immediately. Consider
@@ -526,6 +526,178 @@ def data_incremental_benchmark(
                              experience_factory=experience_factory)
 
 
+def random_validation_split_strategy(
+        validation_size: Union[int, float], shuffle: bool,
+        experience: Experience):
+    """
+    The default splitting strategy used by
+    :func:`benchmark_with_validation_stream`.
+
+    This splitting strategy simply splits the experience in two experiences (
+    train and validation) of size `validation_size`.
+
+    When taking inspiration for your custom splitting strategy, please consider
+    that all parameters preceding `experience` are filled by
+    :func:`benchmark_with_validation_stream` by using `partial` from the
+    `functools` standard library. A custom splitting strategy must have only
+    a single parameter: the experience. Consider wrapping your custom
+    splitting strategy with `partial` if more parameters are needed.
+
+    Also consider that the stream name of the experience can be obtained by
+    using `experience.origin_stream.name`.
+
+    :param validation_size: The number of instances to allocate to the
+    validation experience. Can be an int value or a float between 0 and 1.
+    :param shuffle: If True, instances will be shuffled before splitting.
+        Otherwise, the first instances will be allocated to the training
+        dataset by leaving the last ones to the validation dataset.
+    :param experience: The experience to split.
+    :return: A tuple containing 2 elements: the new training and validation
+        datasets.
+    """
+
+    exp_dataset = experience.dataset
+    exp_indices = list(range(len(exp_dataset)))
+
+    if shuffle:
+        exp_indices = \
+            torch.as_tensor(exp_indices)[
+                torch.randperm(len(exp_indices))
+            ].tolist()
+
+    if 0.0 <= validation_size <= 1.0:
+        valid_n_instances = int(validation_size * len(exp_dataset))
+    else:
+        valid_n_instances = int(validation_size)
+        if valid_n_instances > len(exp_dataset):
+            raise ValueError(
+                f'Can\'t create the validation experience: nott enough '
+                f'instances. Required {valid_n_instances}, got only'
+                f'{len(exp_dataset)}')
+
+    train_n_instances = len(exp_dataset) - valid_n_instances
+
+    result_train_dataset = AvalancheSubset(
+        exp_dataset, indices=exp_indices[:train_n_instances])
+    result_valid_dataset = AvalancheSubset(
+        exp_dataset, indices=exp_indices[train_n_instances:])
+
+    return result_train_dataset, result_valid_dataset
+
+
+def benchmark_with_validation_stream(
+        benchmark_instance: GenericCLScenario,
+        validation_size: Union[int, float],
+        shuffle: bool = False,
+        input_stream: str = 'train',
+        output_stream: str = 'valid',
+        custom_split_strategy: Callable[[Experience],
+                                        Tuple[AvalancheDataset,
+                                              AvalancheDataset]] = None,
+        experience_factory: Callable[[GenericScenarioStream, int],
+                                     Experience] = None):
+    """
+    Helper that can be used to obtain a benchmark with a validation stream.
+
+    This generator accepts an existing benchmark instance and returns a version
+    of it in which a validation stream has been added.
+
+    In its base form this generator will split train experiences to extract
+    validation experiences of a fixed (by number of instances or relative
+    size), configurable, size. The split can be also performed on other
+    streams if needed and the name of the resulting validation stream can
+    be configured too.
+
+    Each validation experience will be extracted directly from a single training
+    experience. Patterns selected for the validation experience will be removed
+    from the training one.
+
+    If shuffle is True, the validation stream will be created randomly.
+    Beware that no kind of class balancing is done.
+
+    The `custom_split_strategy` parameter can be used if a more specific
+    splitting is required.
+
+    Beware that experience splitting is NOT executed in a lazy way. This
+    means that the splitting process takes place immediately. This is usually
+    fast even for streams with many experiences.
+
+    Please note that the resulting experiences will have a task  labels field
+    equal to the one of the originating experience.
+
+    :param benchmark_instance: The benchmark to split.
+    :param validation_size: The size of the validation experience, as an int
+        or a float between 0 and 1. Ignored if `custom_split_strategy` is used.
+    :param shuffle: If True, patterns will be allocated to the validation
+        stream randomly. This will use the default PyTorch random number
+        generator at its current state. Defaults to False. Ignored if
+        `custom_split_strategy` is used. If False, the first instances will be
+        allocated to the training  dataset by leaving the last ones to the
+        validation dataset.
+    :param input_stream: The name of the input stream. Defaults to 'train'.
+    :param output_stream: The name of the output stream. Defaults to 'valid'.
+    :param custom_split_strategy: A function that implements a custom splitting
+        strategy. The function must accept an experience and return a tuple
+        containing the new train and validation dataset. Defaults to None,
+        which means that the standard splitting strategy will be used (which
+        creates experiences according to `validation_size` and `shuffle`).
+        A good starting to understand the mechanism is to look at the
+        implementation of the standard splitting function
+        :func:`random_validation_split_strategy`.
+    :param experience_factory: The experience factory. Defaults to
+        :class:`GenericExperience`.
+    :return: A benchmark instance in which the validation stream has been added.
+    """
+
+    split_strategy = custom_split_strategy
+    if split_strategy is None:
+        split_strategy = partial(
+            random_validation_split_strategy, validation_size,
+            shuffle)
+
+    stream_definitions: TStreamsDict = dict(
+        benchmark_instance.stream_definitions)
+    streams = benchmark_instance.streams
+
+    if input_stream not in streams:
+        raise ValueError(f'Stream {input_stream} could not be found in the '
+                         f'benchmark instance')
+
+    if output_stream in streams:
+        raise ValueError(f'Stream {output_stream} already exists in the '
+                         f'benchmark instance')
+
+    stream = streams[input_stream]
+
+    split_train_datasets: List[AvalancheDataset] = []
+    split_valid_datasets: List[AvalancheDataset] = []
+    split_task_labels: List[Set[int]] = []
+
+    exp: Experience
+    for exp in stream:
+        train_exp, valid_exp = split_strategy(exp)
+        split_train_datasets.append(train_exp)
+        split_valid_datasets.append(valid_exp)
+        split_task_labels.append(set(exp.task_labels))
+
+    train_stream_def = \
+        StreamDef(split_train_datasets, split_task_labels,
+                  stream_definitions[input_stream].origin_dataset)
+
+    valid_stream_def = \
+        StreamDef(split_valid_datasets, split_task_labels,
+                  stream_definitions[input_stream].origin_dataset)
+
+    stream_definitions[input_stream] = train_stream_def
+    stream_definitions[output_stream] = valid_stream_def
+
+    complete_test_set_only = benchmark_instance.complete_test_set_only
+
+    return GenericCLScenario(stream_definitions=stream_definitions,
+                             complete_test_set_only=complete_test_set_only,
+                             experience_factory=experience_factory)
+
+
 __all__ = [
     'nc_benchmark',
     'ni_benchmark',
@@ -533,5 +705,6 @@ __all__ = [
     'filelist_benchmark',
     'paths_benchmark',
     'tensors_benchmark',
-    'data_incremental_benchmark'
+    'data_incremental_benchmark',
+    'benchmark_with_validation_stream'
 ]

--- a/tests/test_high_level_generators.py
+++ b/tests/test_high_level_generators.py
@@ -9,7 +9,8 @@ from torchvision.datasets.utils import download_url, extract_archive
 from torchvision.transforms import ToTensor
 
 from avalanche.benchmarks import dataset_benchmark, filelist_benchmark, \
-    tensors_benchmark, paths_benchmark, data_incremental_benchmark
+    tensors_benchmark, paths_benchmark, data_incremental_benchmark, \
+    benchmark_with_validation_stream
 from avalanche.benchmarks.utils import AvalancheDataset
 from tests.unit_tests_utils import common_setups
 
@@ -235,3 +236,183 @@ class HighLevelGeneratorTests(unittest.TestCase):
             self.assertTrue(torch.equal(test_x[tensor_idx], x))
             self.assertTrue(torch.equal(test_y[tensor_idx], y))
             tensor_idx += 1
+
+    def test_benchmark_with_validation_stream_fixed_size(self):
+        pattern_shape = (3, 32, 32)
+
+        # Definition of training experiences
+        # Experience 1
+        experience_1_x = torch.zeros(100, *pattern_shape)
+        experience_1_y = torch.zeros(100, dtype=torch.long)
+
+        # Experience 2
+        experience_2_x = torch.zeros(80, *pattern_shape)
+        experience_2_y = torch.ones(80, dtype=torch.long)
+
+        # Test experience
+        test_x = torch.zeros(50, *pattern_shape)
+        test_y = torch.zeros(50, dtype=torch.long)
+
+        initial_benchmark_instance = tensors_benchmark(
+            train_tensors=[(experience_1_x, experience_1_y),
+                           (experience_2_x, experience_2_y)],
+            test_tensors=[(test_x, test_y)],
+            task_labels=[0, 0],  # Task label of each train exp
+            complete_test_set_only=True)
+
+        valid_benchmark = benchmark_with_validation_stream(
+            initial_benchmark_instance, 20, shuffle=False)
+
+        self.assertEqual(2, len(valid_benchmark.train_stream))
+        self.assertEqual(2, len(valid_benchmark.valid_stream))
+        self.assertEqual(1, len(valid_benchmark.test_stream))
+        self.assertTrue(valid_benchmark.complete_test_set_only)
+
+        self.assertEqual(80, len(valid_benchmark.train_stream[0].dataset))
+        self.assertEqual(60, len(valid_benchmark.train_stream[1].dataset))
+        self.assertEqual(20, len(valid_benchmark.valid_stream[0].dataset))
+        self.assertEqual(20, len(valid_benchmark.valid_stream[1].dataset))
+
+        self.assertTrue(
+            torch.equal(
+                experience_1_x[:80],
+                valid_benchmark.train_stream[0].dataset[:][0]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_2_x[:60],
+                valid_benchmark.train_stream[1].dataset[:][0]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_1_y[:80],
+                valid_benchmark.train_stream[0].dataset[:][1]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_2_y[:60],
+                valid_benchmark.train_stream[1].dataset[:][1]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_1_x[80:],
+                valid_benchmark.valid_stream[0].dataset[:][0]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_2_x[60:],
+                valid_benchmark.valid_stream[1].dataset[:][0]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_1_y[80:],
+                valid_benchmark.valid_stream[0].dataset[:][1]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_2_y[60:],
+                valid_benchmark.valid_stream[1].dataset[:][1]))
+
+        self.assertTrue(
+            torch.equal(
+                test_x,
+                valid_benchmark.test_stream[0].dataset[:][0]))
+
+        self.assertTrue(
+            torch.equal(
+                test_y,
+                valid_benchmark.test_stream[0].dataset[:][1]))
+
+    def test_benchmark_with_validation_stream_rel_size(self):
+        pattern_shape = (3, 32, 32)
+
+        # Definition of training experiences
+        # Experience 1
+        experience_1_x = torch.zeros(100, *pattern_shape)
+        experience_1_y = torch.zeros(100, dtype=torch.long)
+
+        # Experience 2
+        experience_2_x = torch.zeros(80, *pattern_shape)
+        experience_2_y = torch.ones(80, dtype=torch.long)
+
+        # Test experience
+        test_x = torch.zeros(50, *pattern_shape)
+        test_y = torch.zeros(50, dtype=torch.long)
+
+        initial_benchmark_instance = tensors_benchmark(
+            train_tensors=[(experience_1_x, experience_1_y),
+                           (experience_2_x, experience_2_y)],
+            test_tensors=[(test_x, test_y)],
+            task_labels=[0, 0],  # Task label of each train exp
+            complete_test_set_only=True)
+
+        valid_benchmark = benchmark_with_validation_stream(
+            initial_benchmark_instance, 0.2, shuffle=False)
+        expected_rel_1_valid = int(100 * 0.2)
+        expected_rel_1_train = 100 - expected_rel_1_valid
+        expected_rel_2_valid = int(80 * 0.2)
+        expected_rel_2_train = 80 - expected_rel_2_valid
+
+        self.assertEqual(2, len(valid_benchmark.train_stream))
+        self.assertEqual(2, len(valid_benchmark.valid_stream))
+        self.assertEqual(1, len(valid_benchmark.test_stream))
+        self.assertTrue(valid_benchmark.complete_test_set_only)
+
+        self.assertEqual(
+            expected_rel_1_train, len(valid_benchmark.train_stream[0].dataset))
+        self.assertEqual(
+            expected_rel_2_train, len(valid_benchmark.train_stream[1].dataset))
+        self.assertEqual(
+            expected_rel_1_valid, len(valid_benchmark.valid_stream[0].dataset))
+        self.assertEqual(
+            expected_rel_2_valid, len(valid_benchmark.valid_stream[1].dataset))
+
+        self.assertTrue(
+            torch.equal(
+                experience_1_x[:expected_rel_1_train],
+                valid_benchmark.train_stream[0].dataset[:][0]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_2_x[:expected_rel_2_train],
+                valid_benchmark.train_stream[1].dataset[:][0]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_1_y[:expected_rel_1_train],
+                valid_benchmark.train_stream[0].dataset[:][1]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_2_y[:expected_rel_2_train],
+                valid_benchmark.train_stream[1].dataset[:][1]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_1_x[expected_rel_1_train:],
+                valid_benchmark.valid_stream[0].dataset[:][0]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_2_x[expected_rel_2_train:],
+                valid_benchmark.valid_stream[1].dataset[:][0]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_1_y[expected_rel_1_train:],
+                valid_benchmark.valid_stream[0].dataset[:][1]))
+
+        self.assertTrue(
+            torch.equal(
+                experience_2_y[expected_rel_2_train:],
+                valid_benchmark.valid_stream[1].dataset[:][1]))
+
+        self.assertTrue(
+            torch.equal(
+                test_x,
+                valid_benchmark.test_stream[0].dataset[:][0]))
+
+        self.assertTrue(
+            torch.equal(
+                test_y,
+                valid_benchmark.test_stream[0].dataset[:][1]))


### PR DESCRIPTION
This PR introduces and helper that can be used to obtain a benchmark instance with a proper validation stream.

This simple helper `benchmark_with_validation_stream` takes an existing benchmark instance as an input and splits each experience in the train stream to obtain a valid stream with the same amount of experiences.

As of now no class balancing is used (as the helper must be general enough to handle non-classification tasks), but a custom splitting strategy can be employed as well.

The size of validation experiences can be set by passing an absolute size (int) or a relative size (float between 0 and 1).

Fixes #262