### PR TITLE
Added csvlogger

### DIFF
--- a/avalanche/logging/__init__.py
+++ b/avalanche/logging/__init__.py
@@ -16,5 +16,4 @@ from .tensorboard_logger import *
 from .wandb_logger import *
 from .text_logging import TextLogger
 from .interactive_logging import InteractiveLogger
-
-from avalanche.logging import InteractiveLogger
+from .csv_logger import CSVLogger

--- a/avalanche/logging/csv_logger.py
+++ b/avalanche/logging/csv_logger.py
@@ -1,0 +1,176 @@
+################################################################################
+# Copyright (c) 2021 ContinualAI.                                              #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 2020-01-25                                                             #
+# Author(s): Andrea Cossu                                                      #
+# E-mail: contact@continualai.org                                              #
+# Website: avalanche.continualai.org                                           #
+################################################################################
+
+from typing import List, TYPE_CHECKING
+
+import torch
+import os
+
+from avalanche.evaluation.metric_results import MetricValue
+from avalanche.logging import StrategyLogger
+
+if TYPE_CHECKING:
+    from avalanche.training import BaseStrategy
+
+
+class CSVLogger(StrategyLogger):
+    """
+    The `CSVLogger` logs accuracy and loss metrics into a csv file.
+    Metrics are logged separately for training and evaluation in files
+    training_results.csv and eval_results.csv, respectively.
+    This Logger assumes that the user is evaluating on only one experience
+    during training (see below for an example of a `train` call).
+
+    Trough the `EvaluationPlugin`, the user should monitor at least
+    EpochAccuracy/Loss and ExperienceAccuracy/Loss.
+    If monitored, the logger will also record Experience Forgetting.
+    In order to monitor the performance on held-out experience
+    associated to the current training experience, set
+    `eval_every=1` (or larger value) in the strategy constructor
+    and pass the eval experience to the `train` method:
+    `for i, exp in enumerate(scenario.train_stream):`
+        `strategy.train(exp, eval_streams=[scenario.test_stream[i]])`
+
+    When not provided, validation loss and validation accuracy
+    will be logged as zero.
+
+    The training file header is composed of:
+    training_exp_id, epoch, training_accuracy, val_accuracy,
+    training_loss, val_loss.
+
+    The evaluation file header is composed of:
+    eval_exp, training_exp, eval_accuracy, eval_loss, forgetting
+    """
+
+    def __init__(self, log_folder=None):
+        """
+        Creates an instance of `CSVLogger` class.
+
+        :param log_folder: folder in which to create log files.
+            If None, `csvlogs` folder in the default current directory
+            will be used.
+        """
+
+        super().__init__()
+        self.log_folder = log_folder if log_folder is not None else "csvlogs"
+        os.makedirs(self.log_folder, exist_ok=True)
+
+        self.training_file = open(os.path.join(self.log_folder,
+                                               'training_results.csv'), 'w')
+        self.eval_file = open(os.path.join(self.log_folder,
+                                           'eval_results.csv'), 'w')
+        os.makedirs(self.log_folder, exist_ok=True)
+
+        # current training experience id
+        self.training_exp_id = None
+
+        # if we are currently training or evaluating
+        # evaluation within training will not change this flag
+        self.in_train_phase = None
+
+        # validation metrics computed during training
+        self.val_acc, self.val_loss = 0, 0
+
+        # print csv headers
+        print('training_exp', 'epoch', 'training_accuracy', 'val_accuracy',
+              'training_loss', 'val_loss', sep=',', file=self.training_file,
+              flush=True)
+        print('eval_exp', 'training_exp', 'eval_accuracy', 'eval_loss',
+              'forgetting', sep=',', file=self.eval_file, flush=True)
+
+    def log_metric(self, metric_value: 'MetricValue', callback: str) -> None:
+        pass
+
+    def _val_to_str(self, m_val):
+        if isinstance(m_val, torch.Tensor):
+            return '\n' + str(m_val)
+        elif isinstance(m_val, float):
+            return f'{m_val:.4f}'
+        else:
+            return str(m_val)
+
+    def print_train_metrics(self, training_exp, epoch, train_acc,
+                            val_acc, train_loss, val_loss):
+        print(training_exp, epoch, self._val_to_str(train_acc),
+              self._val_to_str(val_acc), self._val_to_str(train_loss),
+              self._val_to_str(val_loss), sep=',',
+              file=self.training_file, flush=True)
+
+    def print_eval_metrics(self, eval_exp, training_exp, eval_acc,
+                           eval_loss, forgetting):
+        print(eval_exp, training_exp, self._val_to_str(eval_acc),
+              self._val_to_str(eval_loss), self._val_to_str(forgetting),
+              sep=',', file=self.eval_file, flush=True)
+
+    def after_training_epoch(self, strategy: 'BaseStrategy',
+                             metric_values: List['MetricValue'], **kwargs):
+        super().after_training_epoch(strategy, metric_values, **kwargs)
+        train_acc, val_acc, train_loss, val_loss = 0, 0, 0, 0
+        for val in metric_values:
+            if 'train_stream' in val.name:
+                if val.name.startswith('Top1_Acc_Epoch'):
+                    train_acc = val.value
+                elif val.name.startswith('Loss_Epoch'):
+                    train_loss = val.value
+
+        self.print_train_metrics(self.training_exp_id, strategy.epoch,
+                                 train_acc, self.val_acc, train_loss,
+                                 self.val_loss)
+
+    def after_eval_exp(self, strategy: 'BaseStrategy',
+                       metric_values: List['MetricValue'], **kwargs):
+        super().after_eval_exp(strategy, metric_values, **kwargs)
+        acc, loss, forgetting = 0, 0, 0
+
+        for val in metric_values:
+            if self.in_train_phase:  # validation within training
+                if val.name.startswith('Top1_Acc_Exp'):
+                    self.val_acc = val.value
+                elif val.name.startswith('Loss_Exp'):
+                    self.val_loss = val.value
+            else:
+                if val.name.startswith('Top1_Acc_Exp'):
+                    acc = val.value
+                elif val.name.startswith('Loss_Exp'):
+                    loss = val.value
+                elif val.name.startswith('ExperienceForgetting'):
+                    forgetting = val.value
+
+        if not self.in_train_phase:
+            self.print_eval_metrics(strategy.experience.current_experience,
+                                    self.training_exp_id, acc, loss,
+                                    forgetting)
+
+    def before_training_exp(self, strategy: 'BaseStrategy',
+                            metric_values: List['MetricValue'], **kwargs):
+        super().before_training(strategy, metric_values, **kwargs)
+        self.training_exp_id = strategy.experience.current_experience
+
+    def before_eval(self, strategy: 'BaseStrategy',
+                    metric_values: List['MetricValue'], **kwargs):
+        """
+        Manage the case in which `eval` is first called before `train`
+        """
+        if self.in_train_phase is None:
+            self.in_train_phase = False
+
+    def before_training(self, strategy: 'BaseStrategy',
+                        metric_values: List['MetricValue'], **kwargs):
+        self.in_train_phase = True
+
+    def after_training(self, strategy: 'BaseStrategy',
+                       metric_values: List['MetricValue'], **kwargs):
+        self.in_train_phase = False
+
+    def close(self):
+        self.training_file.close()
+        self.eval_file.close()
+

--- a/avalanche/logging/csv_logger.py
+++ b/avalanche/logging/csv_logger.py
@@ -173,4 +173,3 @@ class CSVLogger(StrategyLogger):
     def close(self):
         self.training_file.close()
         self.eval_file.close()
-

--- a/avalanche/training/strategies/base_strategy.py
+++ b/avalanche/training/strategies/base_strategy.py
@@ -572,4 +572,3 @@ class BaseStrategy:
 
 
 __all__ = ['BaseStrategy']
-

--- a/avalanche/training/strategies/base_strategy.py
+++ b/avalanche/training/strategies/base_strategy.py
@@ -140,6 +140,9 @@ class BaseStrategy:
         self.epoch: Optional[int] = None
         """ Epoch counter. """
 
+        self.last_epoch_eval = None
+        """ Last epoch at which periodic eval has been run"""
+
         self.experience = None
         """ Current experience. """
 
@@ -246,6 +249,7 @@ class BaseStrategy:
 
         self.before_training_exp(**kwargs)
         self.epoch = 0
+        self.last_epoch_eval = None
         for self.epoch in range(self.train_epochs):
             self.before_training_epoch(**kwargs)
             self.training_epoch(**kwargs)
@@ -253,7 +257,8 @@ class BaseStrategy:
             self._periodic_eval(eval_streams, do_final=False)
 
         # Final evaluation
-        self._periodic_eval(eval_streams, do_final=True)
+        if self.last_epoch_eval is None or self.last_epoch_eval < self.epoch:
+            self._periodic_eval(eval_streams, do_final=True)
         self.after_training_exp(**kwargs)
 
     def _periodic_eval(self, eval_streams, do_final):
@@ -270,6 +275,7 @@ class BaseStrategy:
 
         if (self.eval_every == 0 and do_final) or \
            (self.eval_every > 0 and self.epoch % self.eval_every == 0):
+            self.last_epoch_eval = self.epoch
             # in the first case we are outside epoch loop
             # in the second case we are within epoch loop
             for exp in eval_streams:
@@ -566,3 +572,4 @@ class BaseStrategy:
 
 
 __all__ = ['BaseStrategy']
+

--- a/examples/eval_plugin.py
+++ b/examples/eval_plugin.py
@@ -32,7 +32,7 @@ from avalanche.evaluation.metrics import forgetting_metrics, \
     accuracy_metrics, loss_metrics, cpu_usage_metrics, timing_metrics, \
     gpu_usage_metrics, ram_usage_metrics, disk_usage_metrics, MAC_metrics
 from avalanche.models import SimpleMLP
-from avalanche.logging import InteractiveLogger, TextLogger
+from avalanche.logging import InteractiveLogger, TextLogger, CSVLogger
 from avalanche.training.plugins import EvaluationPlugin
 from avalanche.training.strategies import Naive
 
@@ -79,6 +79,8 @@ def main(args):
     # print to stdout
     interactive_logger = InteractiveLogger()
 
+    csv_logger = CSVLogger()
+
     eval_plugin = EvaluationPlugin(
         accuracy_metrics(
             minibatch=True, epoch=True, experience=True, stream=True),
@@ -98,25 +100,26 @@ def main(args):
             minibatch=True, epoch=True, experience=True, stream=True),
         MAC_metrics(
             minibatch=True, epoch=True, experience=True),
-        loggers=[interactive_logger, text_logger],
+        loggers=[interactive_logger, text_logger, csv_logger],
         collect_all=True)  # collect all metrics (set to True by default)
 
     # CREATE THE STRATEGY INSTANCE (NAIVE)
     cl_strategy = Naive(
         model, SGD(model.parameters(), lr=0.001, momentum=0.9),
         CrossEntropyLoss(), train_mb_size=500, train_epochs=1, eval_mb_size=100,
-        device=device, evaluator=eval_plugin)
+        device=device, evaluator=eval_plugin, eval_every=1)
 
     # TRAINING LOOP
     print('Starting experiment...')
     results = []
-    for experience in scenario.train_stream:
+    for i, experience in enumerate(scenario.train_stream):
         print("Start of experience: ", experience.current_experience)
         print("Current Classes: ", experience.classes_in_this_experience)
 
         # train returns a dictionary containing last recorded value
         # for each metric.
-        res = cl_strategy.train(experience)
+        res = cl_strategy.train(experience,
+                                eval_streams=[scenario.test_stream[i]])
         print('Training completed')
 
         print('Computing accuracy on the whole test set')
@@ -141,3 +144,4 @@ if __name__ == '__main__':
                         help='Select zero-indexed cuda device. -1 to use CPU.')
     args = parser.parse_args()
     main(args)
+

--- a/examples/eval_plugin.py
+++ b/examples/eval_plugin.py
@@ -144,4 +144,3 @@ if __name__ == '__main__':
                         help='Select zero-indexed cuda device. -1 to use CPU.')
     args = parser.parse_args()
     main(args)
-


### PR DESCRIPTION
This PR brings the `CSVLogger`: a logger which can be used to produce two files.
The training file lists for each epoch and experience the training and validation accuracies and losses.
The evaluation file lists for each training and evaluation experience the accuracy, loss and forgetting.

Important points which may reduce the value of this logger: 
this is quite a specific logger which assumes 
1) logging at least accuracy explicitly for each epoch and experience (maybe the logger name could be changed into `CSVClassificationLogger` but I don't like it very much). 
2) evaluation during training is performed only on the eval experience corresponding to the training one.
The example `eval_plugin` shows how to use it and I could provide a separate one if needed. We could also think about making it more general so that the metrics are not pre-defined in the logger.
I would like to know your opinion on this: do you believe this to be something useful?

@AntonioCarta I also proposed a rough fix so that the periodic eval is not run twice if `eval_every` is a multiple of `epochs`. Let me know if you have better solutions to this problem.