### PR TITLE
Fix bug with unit test on python 3.6

### DIFF
--- a/.github/workflows/test-coverage-coveralls.yml
+++ b/.github/workflows/test-coverage-coveralls.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           conda create -n avalanche-env python=${{ matrix.python-version }} -c conda-forge
           conda activate avalanche-env
-          conda install pytorch torchvision cpuonly -c pytorch -y
+          conda install pytorch=1.8.1 torchvision=0.9.1 cpuonly -c pytorch -y
           conda env update --file environment.yml
       - name: install conda environment = 3.9
         if: matrix.python-version == '3.9'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           conda create -n avalanche-env python=${{ matrix.python-version }} -c conda-forge
           conda activate avalanche-env
-          conda install pytorch torchvision cpuonly -c pytorch -y
+          conda install pytorch=1.8.1 torchvision=0.9.1 cpuonly -c pytorch -y
           conda env update --file environment.yml
       - name: install conda environment = 3.9
         if: matrix.python-version == '3.9'


### PR DESCRIPTION
- Conda installed pytorch 1.4 (and torchvision 0.5) in the environment with python 3.6
- The bug cannot be reproduced locally, but the conda version and the installed packages are the same, so I cannot speculate almost anything about the reason of this strange behavior. 
- This is just a quick patch to the problem (versions are now hardcoded into the workflows). 
- I will take care of a better handling of the dependencies as pointed out in issue #611