### PR TITLE
Refactored metrics to follow a GenericPluginMetric class

### DIFF
--- a/avalanche/evaluation/metric_results.py
+++ b/avalanche/evaluation/metric_results.py
@@ -9,12 +9,13 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from typing import Union, List, Tuple, Optional
+from typing import Union, List, Tuple, Optional, TYPE_CHECKING
 
 from PIL.Image import Image
 from torch import Tensor
 
-from avalanche.evaluation import Metric
+if TYPE_CHECKING:
+    from .metric_definitions import Metric
 
 MetricType = Union[float, int, Tensor, Image]
 MetricResult = Optional[List['MetricValue']]
@@ -55,7 +56,7 @@ class MetricValue(object):
     an Image. It's up to the Logger, according to its capabilities, decide which
     representation to use.
     """
-    def __init__(self, origin: Metric, name: str,
+    def __init__(self, origin: 'Metric', name: str,
                  value: Union[MetricType, AlternativeValues], x_plot: int):
         """
         Creates an instance of MetricValue.
@@ -76,7 +77,7 @@ class MetricValue(object):
             to the x-axis position of the value in a plot. When logging a
             singleton value, pass 0 as a value for this parameter.
         """
-        self.origin: Metric = origin
+        self.origin: 'Metric' = origin
         self.name: str = name
         self.value: Union[MetricType, AlternativeValues] = value
         self.x_plot: int = x_plot

--- a/avalanche/evaluation/metrics/accuracy.py
+++ b/avalanche/evaluation/metrics/accuracy.py
@@ -13,15 +13,8 @@ from typing import TYPE_CHECKING, List
 
 import torch
 from torch import Tensor
-
-from avalanche.evaluation import Metric, PluginMetric
-from avalanche.evaluation.metric_results import MetricValue, MetricResult
-from avalanche.evaluation.metric_utils import get_metric_name, \
-    phase_and_task, stream_type
+from avalanche.evaluation import Metric, PluginMetric, GenericPluginMetric
 from avalanche.evaluation.metrics.mean import Mean
-
-if TYPE_CHECKING:
-    from avalanche.training import BaseStrategy
 
 
 class Accuracy(Metric[float]):
@@ -107,7 +100,21 @@ class Accuracy(Metric[float]):
         self._mean_accuracy.reset()
 
 
-class MinibatchAccuracy(PluginMetric[float]):
+class AccuracyPluginMetric(GenericPluginMetric[float]):
+    """
+    Base class for all accuracies plugin metrics
+    """
+    def __init__(self, reset_at, emit_at, mode):
+        self._accuracy = Accuracy()
+        super(AccuracyPluginMetric, self).__init__(
+            self._accuracy, reset_at=reset_at, emit_at=emit_at,
+            mode=mode)
+
+    def update(self, strategy):
+        self._accuracy.update(strategy.mb_output, strategy.mb_y)
+
+
+class MinibatchAccuracy(AccuracyPluginMetric):
     """
     The minibatch plugin accuracy metric.
     This metric only works at training time.
@@ -119,43 +126,18 @@ class MinibatchAccuracy(PluginMetric[float]):
     If a more coarse-grained logging is needed, consider using
     :class:`EpochAccuracy` instead.
     """
-
     def __init__(self):
         """
         Creates an instance of the MinibatchAccuracy metric.
         """
-
-        super().__init__()
-
-        self._minibatch_accuracy = Accuracy()
-
-    def result(self) -> float:
-        return self._minibatch_accuracy.result()
-
-    def reset(self) -> None:
-        self._minibatch_accuracy.reset()
-
-    def after_training_iteration(self, strategy: 'BaseStrategy') \
-            -> MetricResult:
-        super().after_training_iteration(strategy)
-        self.reset()  # Because this metric computes the accuracy of a single mb
-        self._minibatch_accuracy.update(strategy.mb_y,
-                                        strategy.mb_output)
-        return self._package_result(strategy)
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        metric_value = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+        super(MinibatchAccuracy, self).__init__(
+            reset_at='iteration', emit_at='iteration', mode='train')
 
     def __str__(self):
         return "Top1_Acc_MB"
 
 
-class EpochAccuracy(PluginMetric[float]):
+class EpochAccuracy(AccuracyPluginMetric):
     """
     The average accuracy over a single training epoch.
     This plugin metric only works at training time.
@@ -169,41 +151,15 @@ class EpochAccuracy(PluginMetric[float]):
         """
         Creates an instance of the EpochAccuracy metric.
         """
-        super().__init__()
 
-        self._accuracy_metric = Accuracy()
-
-    def reset(self) -> None:
-        self._accuracy_metric.reset()
-
-    def result(self) -> float:
-        return self._accuracy_metric.result()
-
-    def after_training_iteration(self, strategy: 'BaseStrategy') -> None:
-        super().after_training_iteration(strategy)
-        self._accuracy_metric.update(strategy.mb_y,
-                                     strategy.mb_output)
-
-    def before_training_epoch(self, strategy: 'BaseStrategy') -> None:
-        self.reset()
-
-    def after_training_epoch(self, strategy: 'BaseStrategy') \
-            -> MetricResult:
-        return self._package_result(strategy)
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        metric_value = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+        super(EpochAccuracy, self).__init__(
+            reset_at='epoch', emit_at='epoch', mode='train')
 
     def __str__(self):
         return "Top1_Acc_Epoch"
 
 
-class RunningEpochAccuracy(EpochAccuracy):
+class RunningEpochAccuracy(AccuracyPluginMetric):
     """
     The average accuracy across all minibatches up to the current
     epoch iteration.
@@ -219,31 +175,14 @@ class RunningEpochAccuracy(EpochAccuracy):
         Creates an instance of the RunningEpochAccuracy metric.
         """
 
-        super().__init__()
-
-    def after_training_iteration(self, strategy: 'BaseStrategy') \
-            -> MetricResult:
-        super().after_training_iteration(strategy)
-        return self._package_result(strategy)
-
-    def after_training_epoch(self, strategy: 'BaseStrategy') -> None:
-        # Overrides the method from EpochAccuracy so that it doesn't
-        # emit a metric value on epoch end!
-        return None
-
-    def _package_result(self, strategy: 'BaseStrategy'):
-        metric_value = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+        super(RunningEpochAccuracy, self).__init__(
+            reset_at='epoch', emit_at='iteration', mode='train')
 
     def __str__(self):
         return "Top1_RunningAcc_Epoch"
 
 
-class ExperienceAccuracy(PluginMetric[float]):
+class ExperienceAccuracy(AccuracyPluginMetric):
     """
     At the end of each experience, this plugin metric reports
     the average accuracy over all patterns seen in that experience.
@@ -254,43 +193,14 @@ class ExperienceAccuracy(PluginMetric[float]):
         """
         Creates an instance of ExperienceAccuracy metric
         """
-        super().__init__()
-
-        self._accuracy_metric = Accuracy()
-
-    def reset(self) -> None:
-        self._accuracy_metric.reset()
-
-    def result(self) -> float:
-        return self._accuracy_metric.result()
-
-    def before_eval_exp(self, strategy: 'BaseStrategy') -> None:
-        self.reset()
-
-    def after_eval_iteration(self, strategy: 'BaseStrategy') -> None:
-        super().after_eval_iteration(strategy)
-        self._accuracy_metric.update(strategy.mb_y,
-                                     strategy.mb_output)
-
-    def after_eval_exp(self, strategy: 'BaseStrategy') -> \
-            'MetricResult':
-        return self._package_result(strategy)
-
-    def _package_result(self, strategy: 'BaseStrategy') -> \
-            MetricResult:
-        metric_value = self.result()
-
-        metric_name = get_metric_name(self, strategy, add_experience=True)
-
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+        super(ExperienceAccuracy, self).__init__(
+            reset_at='experience', emit_at='experience', mode='eval')
 
     def __str__(self):
         return "Top1_Acc_Exp"
 
 
-class StreamAccuracy(PluginMetric[float]):
+class StreamAccuracy(AccuracyPluginMetric):
     """
     At the end of the entire stream of experiences, this plugin metric
     reports the average accuracy over all patterns seen in all experiences.
@@ -301,41 +211,8 @@ class StreamAccuracy(PluginMetric[float]):
         """
         Creates an instance of StreamAccuracy metric
         """
-        super().__init__()
-
-        self._accuracy_metric = Accuracy()
-
-    def reset(self) -> None:
-        self._accuracy_metric.reset()
-
-    def result(self) -> float:
-        return self._accuracy_metric.result()
-
-    def before_eval(self, strategy: 'BaseStrategy') -> None:
-        self.reset()
-
-    def after_eval_iteration(self, strategy: 'BaseStrategy') -> None:
-        super().after_eval_iteration(strategy)
-        self._accuracy_metric.update(strategy.mb_y,
-                                     strategy.mb_output)
-
-    def after_eval(self, strategy: 'BaseStrategy') -> \
-            'MetricResult':
-        return self._package_result(strategy)
-
-    def _package_result(self, strategy: 'BaseStrategy') -> \
-            MetricResult:
-        metric_value = self.result()
-
-        phase_name, _ = phase_and_task(strategy)
-        stream = stream_type(strategy.experience)
-        metric_name = '{}/{}_phase/{}_stream' \
-            .format(str(self),
-                    phase_name,
-                    stream)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+        super(StreamAccuracy, self).__init__(
+            reset_at='stream', emit_at='stream', mode='eval')
 
     def __str__(self):
         return "Top1_Acc_Stream"

--- a/avalanche/evaluation/metrics/mac.py
+++ b/avalanche/evaluation/metrics/mac.py
@@ -10,15 +10,10 @@
 ################################################################################
 
 from torch.nn import Module
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 from torch import Tensor
 
-from avalanche.evaluation import Metric, PluginMetric
-from avalanche.evaluation.metric_results import MetricValue, MetricResult
-from avalanche.evaluation.metric_utils import get_metric_name
-
-if TYPE_CHECKING:
-    from avalanche.training import BaseStrategy
+from avalanche.evaluation import Metric, PluginMetric, GenericPluginMetric
 
 
 class MAC(Metric[int]):
@@ -69,6 +64,9 @@ class MAC(Metric[int]):
         """
         return self._compute_cost
 
+    def reset(self):
+        pass
+
     def update_compute_cost(self, module, dummy_input, output):
         modname = module.__class__.__name__
         if modname == 'Linear':
@@ -84,7 +82,19 @@ class MAC(Metric[int]):
         return modname == 'Linear' or modname == 'Conv2d'
 
 
-class MinibatchMAC(PluginMetric[float]):
+class MACPluginMetric(GenericPluginMetric):
+    def __init__(self, reset_at, emit_at, mode):
+        self._mac = MAC()
+
+        super(MACPluginMetric, self).__init__(
+            self._mac, reset_at=reset_at, emit_at=emit_at, mode=mode)
+
+    def update(self, strategy):
+        self._mac.update(strategy.model,
+                         strategy.mb_x[0].unsqueeze(0))
+
+
+class MinibatchMAC(MACPluginMetric):
     """
     The minibatch MAC metric.
     This plugin metric only works at training time.
@@ -101,37 +111,14 @@ class MinibatchMAC(PluginMetric[float]):
         """
         Creates an instance of the MinibatchMAC metric.
         """
-
-        super().__init__()
-
-        self._minibatch_MAC = MAC()
-
-    def reset(self) -> None:
-        pass
-
-    def result(self) -> float:
-        return self._minibatch_MAC.result()
-
-    def after_training_iteration(self, strategy: 'BaseStrategy') \
-            -> MetricResult:
-        super().after_training_iteration(strategy)
-        self._minibatch_MAC.update(strategy.model,
-                                   strategy.mb_x[0].unsqueeze(0))
-        return self._package_result(strategy)
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        metric_value = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+        super(MinibatchMAC, self).__init__(
+            reset_at='iteration', emit_at='iteration', mode='train')
 
     def __str__(self):
         return "MAC_MB"
 
 
-class EpochMAC(PluginMetric[float]):
+class EpochMAC(MACPluginMetric):
     """
     The MAC at the end of each epoch computed on a
     single pattern.
@@ -144,35 +131,14 @@ class EpochMAC(PluginMetric[float]):
         """
         Creates an instance of the EpochMAC metric.
         """
-        super().__init__()
-
-        self._MAC_metric = MAC()
-
-    def reset(self) -> None:
-        pass
-
-    def result(self) -> float:
-        return self._MAC_metric.result()
-
-    def after_training_epoch(self, strategy: 'BaseStrategy') \
-            -> MetricResult:
-        self._MAC_metric.update(strategy.model,
-                                strategy.mb_x[0].unsqueeze(0))
-        return self._package_result(strategy)
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        metric_value = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+        super(EpochMAC, self).__init__(
+            reset_at='epoch', emit_at='epoch', mode='train')
 
     def __str__(self):
         return "MAC_Epoch"
 
 
-class ExperienceMAC(PluginMetric[float]):
+class ExperienceMAC(MACPluginMetric):
     """
     At the end of each experience, this metric reports the
     MAC computed on a single pattern.
@@ -183,31 +149,8 @@ class ExperienceMAC(PluginMetric[float]):
         """
         Creates an instance of ExperienceMAC metric
         """
-        super().__init__()
-
-        self._MAC_metric = MAC()
-
-    def reset(self) -> None:
-        pass
-
-    def result(self) -> float:
-        return self._MAC_metric.result()
-
-    def after_eval_exp(self, strategy: 'BaseStrategy') -> \
-            'MetricResult':
-        self._MAC_metric.update(strategy.model,
-                                strategy.mb_x[0].unsqueeze(0))
-        return self._package_result(strategy)
-
-    def _package_result(self, strategy: 'BaseStrategy') -> \
-            MetricResult:
-        metric_value = self.result()
-
-        metric_name = get_metric_name(self, strategy, add_experience=True)
-
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+        super(ExperienceMAC, self).__init__(
+            reset_at='experience', emit_at='experience', mode='eval')
 
     def __str__(self):
         return "MAC_Exp"

--- a/avalanche/evaluation/metrics/ram_usage.py
+++ b/avalanche/evaluation/metrics/ram_usage.py
@@ -15,10 +15,8 @@ from typing import Optional, List, TYPE_CHECKING
 from threading import Thread
 from psutil import Process
 
-from avalanche.evaluation import Metric, PluginMetric
-from avalanche.evaluation.metric_results import MetricResult, MetricValue
-from avalanche.evaluation.metric_utils import get_metric_name, \
-    phase_and_task, stream_type
+from avalanche.evaluation import Metric, PluginMetric, GenericPluginMetric
+from avalanche.evaluation.metric_results import MetricResult
 
 if TYPE_CHECKING:
     from avalanche.training import BaseStrategy
@@ -115,8 +113,22 @@ class MaxRAM(Metric[float]):
         """
         self.max_usage = 0
 
+    def update(self):
+        pass
 
-class MinibatchMaxRAM(PluginMetric[float]):
+
+class RAMPluginMetric(GenericPluginMetric[float]):
+    def __init__(self, every, reset_at, emit_at, mode):
+        self._ram = MaxRAM(every)
+
+        super(RAMPluginMetric, self).__init__(
+            self._ram, reset_at, emit_at, mode)
+
+    def update(self, strategy):
+        self._ram.update()
+
+
+class MinibatchMaxRAM(RAMPluginMetric):
     """
     The Minibatch Max RAM metric.
     This plugin metric only works at training time.
@@ -128,44 +140,23 @@ class MinibatchMaxRAM(PluginMetric[float]):
         :param every: seconds after which update the maximum RAM
             usage
         """
-        super().__init__()
-
-        self._ram = MaxRAM(every)
+        super(MinibatchMaxRAM, self).__init__(
+            every, reset_at='iteration', emit_at='iteration', mode='train')
 
     def before_training(self, strategy: 'BaseStrategy') \
             -> None:
+        super().before_training(strategy)
         self._ram.start_thread()
 
-    def before_training_iteration(self, strategy: 'BaseStrategy') -> None:
-        self.reset()
-
-    def after_training_iteration(self, strategy: 'BaseStrategy') \
-            -> MetricResult:
-        super().after_training_iteration(strategy)
-        return self._package_result(strategy)
-
     def after_training(self, strategy: 'BaseStrategy') -> None:
+        super().after_training(strategy)
         self._ram.stop_thread()
-
-    def reset(self) -> None:
-        self._ram.reset()
-
-    def result(self) -> float:
-        return self._ram.result()
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        ram_usage = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, ram_usage, plot_x_position)]
 
     def __str__(self):
         return "MaxRAMUsage_MB"
 
 
-class EpochMaxRAM(PluginMetric[float]):
+class EpochMaxRAM(RAMPluginMetric):
     """
     The Epoch Max RAM metric.
     This plugin metric only works at training time.
@@ -177,43 +168,23 @@ class EpochMaxRAM(PluginMetric[float]):
         :param every: seconds after which update the maximum RAM
             usage
         """
-        super().__init__()
-
-        self._ram = MaxRAM(every)
+        super(EpochMaxRAM, self).__init__(
+            every, reset_at='epoch', emit_at='epoch', mode='train')
 
     def before_training(self, strategy: 'BaseStrategy') \
             -> None:
+        super().before_training(strategy)
         self._ram.start_thread()
 
-    def before_training_epoch(self, strategy) -> MetricResult:
-        self.reset()
-
-    def after_training_epoch(self, strategy: 'BaseStrategy') \
-            -> MetricResult:
-        return self._package_result(strategy)
-
     def after_training(self, strategy: 'BaseStrategy') -> None:
+        super().before_training(strategy)
         self._ram.stop_thread()
-
-    def reset(self) -> None:
-        self._ram.reset()
-
-    def result(self) -> float:
-        return self._ram.result()
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        ram_usage = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, ram_usage, plot_x_position)]
 
     def __str__(self):
         return "MaxRAMUsage_Epoch"
 
 
-class ExperienceMaxRAM(PluginMetric[float]):
+class ExperienceMaxRAM(RAMPluginMetric):
     """
     The Experience Max RAM metric.
     This plugin metric only works at eval time.
@@ -225,43 +196,23 @@ class ExperienceMaxRAM(PluginMetric[float]):
         :param every: seconds after which update the maximum RAM
             usage
         """
-        super().__init__()
-
-        self._ram = MaxRAM(every)
+        super(ExperienceMaxRAM, self).__init__(
+            every, reset_at='experience', emit_at='experience', mode='eval')
 
     def before_eval(self, strategy: 'BaseStrategy') \
             -> None:
+        super().before_eval(strategy)
         self._ram.start_thread()
 
-    def before_eval_exp(self, strategy) -> MetricResult:
-        self.reset()
-
-    def after_eval_exp(self, strategy: 'BaseStrategy') \
-            -> MetricResult:
-        return self._package_result(strategy)
-
     def after_eval(self, strategy: 'BaseStrategy') -> None:
+        super().after_eval(strategy)
         self._ram.stop_thread()
-
-    def reset(self) -> None:
-        self._ram.reset()
-
-    def result(self) -> float:
-        return self._ram.result()
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        ram_usage = self.result()
-
-        metric_name = get_metric_name(self, strategy, add_experience=True)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, ram_usage, plot_x_position)]
 
     def __str__(self):
         return "MaxRAMUsage_Experience"
 
 
-class StreamMaxRAM(PluginMetric[float]):
+class StreamMaxRAM(RAMPluginMetric):
     """
     The Stream Max RAM metric.
     This plugin metric only works at eval time.
@@ -273,38 +224,18 @@ class StreamMaxRAM(PluginMetric[float]):
         :param every: seconds after which update the maximum RAM
             usage
         """
-        super().__init__()
-
-        self._ram = MaxRAM(every)
+        super(StreamMaxRAM, self).__init__(
+            every, reset_at='stream', emit_at='stream', mode='eval')
 
     def before_eval(self, strategy) -> MetricResult:
-        self.reset()
+        super().before_eval(strategy)
         self._ram.start_thread()
 
     def after_eval(self, strategy: 'BaseStrategy') \
             -> MetricResult:
-        packed = self._package_result(strategy)
+        packed = super().after_eval(strategy)
         self._ram.stop_thread()
         return packed
-
-    def reset(self) -> None:
-        self._ram.reset()
-
-    def result(self) -> float:
-        return self._ram.result()
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        ram_usage = self.result()
-
-        phase_name, _ = phase_and_task(strategy)
-        stream = stream_type(strategy.experience)
-        metric_name = '{}/{}_phase/{}_stream' \
-            .format(str(self),
-                    phase_name,
-                    stream)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, ram_usage, plot_x_position)]
 
     def __str__(self):
         return "MaxRAMUsage_Stream"

--- a/avalanche/evaluation/metrics/timing.py
+++ b/avalanche/evaluation/metrics/timing.py
@@ -12,7 +12,7 @@
 import time
 from typing import TYPE_CHECKING, List
 
-from avalanche.evaluation import Metric, PluginMetric
+from avalanche.evaluation import Metric, PluginMetric, GenericPluginMetric
 from avalanche.evaluation.metric_results import MetricValue, MetricResult
 from avalanche.evaluation.metric_utils import get_metric_name
 from avalanche.evaluation.metrics.mean import Mean
@@ -86,7 +86,18 @@ class ElapsedTime(Metric[float]):
         self._init_time = None
 
 
-class MinibatchTime(PluginMetric[float]):
+class TimePluginMetric(GenericPluginMetric[float]):
+    def __init__(self, reset_at, emit_at, mode):
+        self._time = ElapsedTime()
+
+        super(TimePluginMetric, self).__init__(
+            self._time, reset_at, emit_at, mode)
+
+    def update(self, strategy):
+        self._time.update()
+
+
+class MinibatchTime(TimePluginMetric):
     """
     The minibatch time metric.
     This plugin metric only works at training time.
@@ -101,39 +112,18 @@ class MinibatchTime(PluginMetric[float]):
         """
         Creates an instance of the minibatch time metric.
         """
-        super().__init__()
-
-        self._minibatch_time = ElapsedTime()
-
-    def result(self) -> float:
-        return self._minibatch_time.result()
-
-    def reset(self) -> None:
-        self._minibatch_time.reset()
+        super(MinibatchTime, self).__init__(
+            reset_at='iteration', emit_at='iteration', mode='train')
 
     def before_training_iteration(self, strategy) -> MetricResult:
-        self.reset()
-        self._minibatch_time.update()
-
-    def after_training_iteration(self, strategy: 'BaseStrategy') \
-            -> MetricResult:
-        super().after_training_iteration(strategy)
-        self._minibatch_time.update()
-        return self._package_result(strategy)
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        metric_value = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, metric_value, plot_x_position)]
+        super().before_training_iteration(strategy)
+        self._time.update()
 
     def __str__(self):
         return "Time_MB"
 
 
-class EpochTime(PluginMetric[float]):
+class EpochTime(TimePluginMetric):
     """
     The epoch elapsed time metric.
     This plugin metric only works at training time.
@@ -146,38 +136,18 @@ class EpochTime(PluginMetric[float]):
         Creates an instance of the epoch time metric.
         """
 
-        super().__init__()
-
-        self._elapsed_time = ElapsedTime()
+        super(EpochTime, self).__init__(
+            reset_at='epoch', emit_at='epoch', mode='train')
 
     def before_training_epoch(self, strategy) -> MetricResult:
-        self.reset()
-        self._elapsed_time.update()
-
-    def after_training_epoch(self, strategy: 'BaseStrategy') \
-            -> MetricResult:
-        self._elapsed_time.update()
-        return self._package_result(strategy)
-
-    def reset(self) -> None:
-        self._elapsed_time.reset()
-
-    def result(self) -> float:
-        return self._elapsed_time.result()
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        elapsed_time = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, elapsed_time, plot_x_position)]
+        super().before_training_epoch(strategy)
+        self._time.update()
 
     def __str__(self):
         return "Time_Epoch"
 
 
-class RunningEpochTime(PluginMetric[float]):
+class RunningEpochTime(GenericPluginMetric):
     """
     The running epoch time metric.
     This plugin metric only works at training time.
@@ -191,48 +161,31 @@ class RunningEpochTime(PluginMetric[float]):
         """
         Creates an instance of the running epoch time metric..
         """
-        super().__init__()
-
         self._time_mean = Mean()
-        self._epoch_time = ElapsedTime()
+
+        super(RunningEpochTime, self).__init__(
+            reset_at='epoch', emit_at='iteration', mode='train')
 
     def before_training_epoch(self, strategy) -> MetricResult:
-        self.reset()
-        self._epoch_time.update()
-
-    def before_training_iteration(self, strategy: 'BaseStrategy') \
-            -> None:
-        self._epoch_time.update()
+        super().before_training_epoch(strategy)
+        self._time_mean.reset()
+        self._time.update()
 
     def after_training_iteration(self, strategy: 'BaseStrategy') \
             -> MetricResult:
         super().after_training_iteration(strategy)
-        self._epoch_time.update()
-        self._time_mean.update(self._epoch_time.result())
-        self._epoch_time.reset()
+        self._time_mean.update(self._time.result())
+        self._time.reset()
         return self._package_result(strategy)
-
-    def reset(self) -> None:
-        self._epoch_time.reset()
-        self._time_mean.reset()
 
     def result(self) -> float:
         return self._time_mean.result()
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        average_epoch_time = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(
-            self, metric_name, average_epoch_time, plot_x_position)]
 
     def __str__(self):
         return "RunningTime_Epoch"
 
 
-class ExperienceTime(PluginMetric[float]):
+class ExperienceTime(TimePluginMetric):
     """
     The experience time metric.
     This plugin metric only works at eval time.
@@ -245,37 +198,18 @@ class ExperienceTime(PluginMetric[float]):
         """
         Creates an instance of the experience time metric.
         """
-        super().__init__()
-
-        self._elapsed_time = ElapsedTime()
+        super(ExperienceTime, self).__init__(
+            reset_at='experience', emit_at='experience', mode='eval')
 
     def before_eval_exp(self, strategy: 'BaseStrategy') -> MetricResult:
-        self.reset()
-        self._elapsed_time.update()
-
-    def after_eval_exp(self, strategy: 'BaseStrategy') -> MetricResult:
-        self._elapsed_time.update()
-        return self._package_result(strategy)
-
-    def reset(self) -> None:
-        self._elapsed_time.reset()
-
-    def result(self) -> float:
-        return self._elapsed_time.result()
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        exp_time = self.result()
-
-        metric_name = get_metric_name(self, strategy, add_experience=True)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, exp_time, plot_x_position)]
+        super().before_eval_exp(strategy)
+        self._time.update()
 
     def __str__(self):
         return "Time_Exp"
 
 
-class StreamTime(PluginMetric[float]):
+class StreamTime(TimePluginMetric):
     """
     The stream time metric.
     This metric only works at eval time.
@@ -288,31 +222,12 @@ class StreamTime(PluginMetric[float]):
         """
         Creates an instance of the stream time metric.
         """
-        super().__init__()
-
-        self._elapsed_time = ElapsedTime()
+        super(StreamTime, self).__init__(
+            reset_at='stream', emit_at='stream', mode='eval')
 
     def before_eval(self, strategy: 'BaseStrategy') -> MetricResult:
-        self.reset()
-        self._elapsed_time.update()
-
-    def after_eval(self, strategy: 'BaseStrategy') -> MetricResult:
-        self._elapsed_time.update()
-        return self._package_result(strategy)
-
-    def reset(self) -> None:
-        self._elapsed_time.reset()
-
-    def result(self) -> float:
-        return self._elapsed_time.result()
-
-    def _package_result(self, strategy: 'BaseStrategy') -> MetricResult:
-        exp_time = self.result()
-
-        metric_name = get_metric_name(self, strategy)
-        plot_x_position = self.get_global_counter()
-
-        return [MetricValue(self, metric_name, exp_time, plot_x_position)]
+        super().before_eval(strategy)
+        self._time.update()
 
     def __str__(self):
         return "Time_Stream"


### PR DESCRIPTION
This PR refactors most of the existing metrics following the newly introduced `GenericPluginMetric`. This change does not affect neither the metric behavior nor the user interface.

Forgetting and confusion matrix metrics are still implemented through the `PluginMetric` class since they have a slightly more complex flow.

Now the generic plugin can be used to easily build new metrics.