### PR TITLE
[wandb] Fix Confusion Matrix Plugin

### DIFF
--- a/avalanche/evaluation/metrics/confusion_matrix.py
+++ b/avalanche/evaluation/metrics/confusion_matrix.py
@@ -372,7 +372,7 @@ class WandBStreamConfusionMatrix(PluginMetric):
 
     def after_eval_iteration(self, strategy: 'BaseStrategy'):
         super(WandBStreamConfusionMatrix, self).after_eval_iteration(strategy)
-        self.update(strategy.logits, strategy.mb_y)
+        self.update(strategy.mb_output, strategy.mb_y)
 
     def after_eval(self, strategy: 'BaseStrategy') -> MetricResult:
         return self._package_result(strategy)


### PR DESCRIPTION
`BaseStrategy.logits` was renamed to `BaseStrategy.mb_outputs`, but wandb confusion matrix plugin got forgotten.