### PR TITLE
[TensorboardLogger] Add support for AWS and Gcloud buckets

### DIFF
--- a/avalanche/logging/tensorboard_logger.py
+++ b/avalanche/logging/tensorboard_logger.py
@@ -60,6 +60,9 @@ class TensorboardLogger(StrategyLogger):
         self.writer = SummaryWriter(tb_log_dir,
                                     filename_suffix=filename_suffix)
 
+    def __del__(self):
+        self.writer.close()
+
     def log_metric(self, metric_value: MetricValue, callback: str):
         super().log_metric(metric_value, callback)
         name = metric_value.name


### PR DESCRIPTION
PyTorch's `SummaryWriter` support writing logs directly to AWS S3 buckets and Google Cloud buckets if the path provided starts by `s3://` or `gs://`. (GS buckets are only supported if tensorflow is also installed https://github.com/pytorch/pytorch/issues/24468#issuecomment-549415705_)

We were not able to use this functionality previously because of the Path conversion. 

🐛  I also noticed that the last logs were often missing (flushing is done automatically every 2 min, and if we don't do it manually at the end then the non flushed logs are lost). Closing the writer in the logger destructor fixes that issue.