### PR TITLE
[Replay] Add some memory selection strategies

### DIFF
--- a/avalanche/benchmarks/utils/avalanche_dataset.py
+++ b/avalanche/benchmarks/utils/avalanche_dataset.py
@@ -35,11 +35,11 @@ from .dataset_definitions import ITensorDataset, ClassificationDataset, \
 
 try:
     from typing import List, Any, Iterable, Sequence, Union, Optional, \
-        TypeVar, Protocol, SupportsInt, Generic, Callable, Dict, Tuple, Literal
+    TypeVar, Protocol, SupportsInt, Generic, Callable, Dict, Tuple, Literal, \
+    Collection
 except ImportError:
     from typing import List, Any, Iterable, Sequence, Union, Optional, \
         TypeVar, SupportsInt, Generic, Callable, Dict, Tuple
-    from typing_extensions import Protocol, Literal
 
 T_co = TypeVar('T_co', covariant=True)
 TTargetType = TypeVar('TTargetType')
@@ -1494,7 +1494,7 @@ class AvalancheConcatDataset(AvalancheDataset[T_co, TTargetType]):
     (if they are subclasses of :class:`AvalancheDataset`).
     """
     def __init__(self,
-                 datasets: Sequence[SupportedDataset],
+                 datasets: Collection[SupportedDataset],
                  *,
                  transform: Callable[[Any], Any] = None,
                  target_transform: Callable[[int], int] = None,
@@ -1511,7 +1511,7 @@ class AvalancheConcatDataset(AvalancheDataset[T_co, TTargetType]):
         """
         Creates a ``AvalancheConcatDataset`` instance.
 
-        :param datasets: A sequence of datasets.
+        :param datasets: A collection of datasets.
         :param transform: A function/transform that takes the X value of a
             pattern from the original dataset and returns a transformed version.
         :param target_transform: A function/transform that takes in the target
@@ -1573,14 +1573,15 @@ class AvalancheConcatDataset(AvalancheDataset[T_co, TTargetType]):
             the value of the second element returned by `__getitem__`.
             The adapter is used to adapt the values of the targets field only.
         """
+        dataset_list = list(datasets)
 
         dataset_type, collate_fn, targets_adapter = \
             self._get_dataset_type_collate_and_adapter(
-                datasets, dataset_type, collate_fn, targets_adapter)
+                self._dataset_list, dataset_type, collate_fn, targets_adapter)
 
-        self._dataset_list = list(datasets)
-        self._datasets_lengths = [len(dataset) for dataset in datasets]
-        self._datasets_cumulative_lengths = ConcatDataset.cumsum(datasets)
+        self._dataset_list = dataset_list
+        self._datasets_lengths = [len(dataset) for dataset in dataset_list]
+        self._datasets_cumulative_lengths = ConcatDataset.cumsum(dataset_list)
         self._overall_length = sum(self._datasets_lengths)
 
         if initial_transform_group is None:

--- a/avalanche/benchmarks/utils/avalanche_dataset.py
+++ b/avalanche/benchmarks/utils/avalanche_dataset.py
@@ -25,21 +25,21 @@ from torch.utils.data.dataloader import default_collate
 from torch.utils.data.dataset import Dataset, Subset, ConcatDataset
 from torchvision.transforms import Compose
 
+from .dataset_definitions import ITensorDataset, ClassificationDataset, \
+    IDatasetWithTargets, ISupportedClassificationDataset
 from .dataset_utils import manage_advanced_indexing, \
     SequenceDataset, ClassificationSubset, \
     LazyConcatIntTargets, find_list_from_index, ConstantSequence, \
     LazyClassMapping, optimize_sequence, SubSequence, LazyConcatTargets, \
     TupleTLabel
-from .dataset_definitions import ITensorDataset, ClassificationDataset, \
-    IDatasetWithTargets, ISupportedClassificationDataset
 
 try:
     from typing import List, Any, Iterable, Sequence, Union, Optional, \
-    TypeVar, Protocol, SupportsInt, Generic, Callable, Dict, Tuple, Literal, \
-    Collection
+        TypeVar, Protocol, SupportsInt, Generic, Callable, Dict, Tuple, \
+        Literal, Collection
 except ImportError:
     from typing import List, Any, Iterable, Sequence, Union, Optional, \
-        TypeVar, SupportsInt, Generic, Callable, Dict, Tuple
+        TypeVar, SupportsInt, Generic, Callable, Dict, Tuple, Collection
 
 T_co = TypeVar('T_co', covariant=True)
 TTargetType = TypeVar('TTargetType')
@@ -95,6 +95,7 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
     parameter, each pattern will be assigned a default task label "0".
     See the constructor for more details.
     """
+
     def __init__(self,
                  dataset: SupportedDataset,
                  *,
@@ -1034,6 +1035,7 @@ class AvalancheSubset(AvalancheDataset[T_co, TTargetType]):
     the targets field, class mapping and all the other goodies listed in
     :class:`AvalancheDataset`.
     """
+
     def __init__(self,
                  dataset: SupportedDataset,
                  indices: Sequence[int] = None,
@@ -1387,6 +1389,7 @@ class AvalancheTensorDataset(AvalancheDataset[T_co, TTargetType]):
     the targets field and all the other goodies listed in
     :class:`AvalancheDataset`.
     """
+
     def __init__(self,
                  *dataset_tensors: Sequence,
                  transform: Callable[[Any], Any] = None,
@@ -1493,6 +1496,7 @@ class AvalancheConcatDataset(AvalancheDataset[T_co, TTargetType]):
     and transformations groups are consistent across the concatenated dataset
     (if they are subclasses of :class:`AvalancheDataset`).
     """
+
     def __init__(self,
                  datasets: Collection[SupportedDataset],
                  *,
@@ -1649,7 +1653,6 @@ class AvalancheConcatDataset(AvalancheDataset[T_co, TTargetType]):
 
         if dataset_type != AvalancheDatasetType.UNDEFINED and \
                 (collate_fn is not None or targets_adapter is not None):
-
             raise ValueError(
                 'dataset_type {} was inferred from the list of '
                 'concatenated dataset. This dataset type can\'t be used '
@@ -1935,7 +1938,6 @@ def as_avalanche_dataset(
         dataset: ISupportedClassificationDataset[T_co],
         dataset_type: AvalancheDatasetType = None) \
         -> AvalancheDataset[T_co, TTargetType]:
-
     if isinstance(dataset, AvalancheDataset) and dataset_type is None:
         # There is no need to show the warning
         return dataset
@@ -2003,7 +2005,6 @@ def train_eval_avalanche_datasets(
 def _traverse_supported_dataset(
         dataset, values_selector: Callable[[Dataset, List[int]], List],
         indices=None) -> List:
-
     initial_error = None
     try:
         result = values_selector(dataset, indices)

--- a/avalanche/benchmarks/utils/avalanche_dataset.py
+++ b/avalanche/benchmarks/utils/avalanche_dataset.py
@@ -1577,7 +1577,7 @@ class AvalancheConcatDataset(AvalancheDataset[T_co, TTargetType]):
 
         dataset_type, collate_fn, targets_adapter = \
             self._get_dataset_type_collate_and_adapter(
-                self._dataset_list, dataset_type, collate_fn, targets_adapter)
+                dataset_list, dataset_type, collate_fn, targets_adapter)
 
         self._dataset_list = dataset_list
         self._datasets_lengths = [len(dataset) for dataset in dataset_list]

--- a/avalanche/benchmarks/utils/avalanche_dataset.py
+++ b/avalanche/benchmarks/utils/avalanche_dataset.py
@@ -25,21 +25,16 @@ from torch.utils.data.dataloader import default_collate
 from torch.utils.data.dataset import Dataset, Subset, ConcatDataset
 from torchvision.transforms import Compose
 
-from .dataset_definitions import ITensorDataset, ClassificationDataset, \
-    IDatasetWithTargets, ISupportedClassificationDataset
 from .dataset_utils import manage_advanced_indexing, \
     SequenceDataset, ClassificationSubset, \
     LazyConcatIntTargets, find_list_from_index, ConstantSequence, \
     LazyClassMapping, optimize_sequence, SubSequence, LazyConcatTargets, \
     TupleTLabel
+from .dataset_definitions import ITensorDataset, ClassificationDataset, \
+    IDatasetWithTargets, ISupportedClassificationDataset
 
-try:
-    from typing import List, Any, Iterable, Sequence, Union, Optional, \
-        TypeVar, Protocol, SupportsInt, Generic, Callable, Dict, Tuple, \
-        Literal, Collection
-except ImportError:
-    from typing import List, Any, Iterable, Sequence, Union, Optional, \
-        TypeVar, SupportsInt, Generic, Callable, Dict, Tuple, Collection
+from typing import List, Any, Sequence, Union, Optional, TypeVar, SupportsInt, \
+    Callable, Dict, Tuple, Collection
 
 T_co = TypeVar('T_co', covariant=True)
 TTargetType = TypeVar('TTargetType')
@@ -95,7 +90,6 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
     parameter, each pattern will be assigned a default task label "0".
     See the constructor for more details.
     """
-
     def __init__(self,
                  dataset: SupportedDataset,
                  *,
@@ -751,7 +745,7 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
 
             if not len(map_value) == 2:
                 raise ValueError(
-                    'Transformations for group "' + str(map_key) + '" must be ' 
+                    'Transformations for group "' + str(map_key) + '" must be '
                     'a tuple containing 2 elements: a transformation for the X '
                     'values and a transformation for the Y values')
 
@@ -1035,7 +1029,6 @@ class AvalancheSubset(AvalancheDataset[T_co, TTargetType]):
     the targets field, class mapping and all the other goodies listed in
     :class:`AvalancheDataset`.
     """
-
     def __init__(self,
                  dataset: SupportedDataset,
                  indices: Sequence[int] = None,
@@ -1389,7 +1382,6 @@ class AvalancheTensorDataset(AvalancheDataset[T_co, TTargetType]):
     the targets field and all the other goodies listed in
     :class:`AvalancheDataset`.
     """
-
     def __init__(self,
                  *dataset_tensors: Sequence,
                  transform: Callable[[Any], Any] = None,
@@ -1496,7 +1488,6 @@ class AvalancheConcatDataset(AvalancheDataset[T_co, TTargetType]):
     and transformations groups are consistent across the concatenated dataset
     (if they are subclasses of :class:`AvalancheDataset`).
     """
-
     def __init__(self,
                  datasets: Collection[SupportedDataset],
                  *,

--- a/avalanche/training/plugins/replay.py
+++ b/avalanche/training/plugins/replay.py
@@ -1,6 +1,6 @@
 import random
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 
 import torch
 from numpy import inf
@@ -14,6 +14,9 @@ from avalanche.benchmarks.utils.data_loader import \
     ReplayDataLoader
 from avalanche.models import FeatureExtractorBackbone
 from avalanche.training.plugins.strategy_plugin import StrategyPlugin
+
+if TYPE_CHECKING:
+    from avalanche.training.strategies import BaseStrategy
 
 
 class ReplayPlugin(StrategyPlugin):

--- a/avalanche/training/plugins/replay.py
+++ b/avalanche/training/plugins/replay.py
@@ -33,6 +33,8 @@ class ReplayPlugin(StrategyPlugin):
 
     The :mem_size: attribute controls the total number of patterns to be stored 
     in the external memory.
+    :param storage_policy: The policy that controls how to add new exemplars
+                           in memory
     """
 
     def __init__(self, mem_size: int = 200,
@@ -175,6 +177,8 @@ class ClassBalancedStoragePolicy(StoragePolicy):
                             observed experiences (keys in replay_mem).
         :param total_num_classes: If adaptive size is False, the fixed number
                                   of classes to divide capacity over.
+        :param selection_strategy: The strategy used to select exemplars to 
+                                   keep in memory when cutting it off
         """
         super().__init__(ext_mem, mem_size)
         self.selection_strategy = selection_strategy or \

--- a/avalanche/training/plugins/replay.py
+++ b/avalanche/training/plugins/replay.py
@@ -69,7 +69,15 @@ class ReplayPlugin(StrategyPlugin):
 
 
 class StoragePolicy(ABC):
-    """ A policy to store exemplars in a replay memory."""
+    """
+    A policy to store exemplars in a replay memory.
+
+    :param ext_mem: The replay memory dictionary to store samples.
+    :param mem_size: max number of total input samples in the replay memory.
+    """
+    def __init__(self, ext_mem: Dict[int, AvalancheDataset], mem_size: int):
+        self.ext_mem = ext_mem
+        self.mem_size = mem_size
 
     @abstractmethod
     def __call__(self, data_source: AvalancheDataset, **kwargs):
@@ -95,8 +103,7 @@ class ExperienceBalancedStoragePolicy(StoragePolicy):
         :param num_experiences: If adaptive size is False, the fixed number
                                 of experiences to divide capacity over.
         """
-        self.ext_mem = ext_mem
-        self.mem_size = mem_size
+        super().__init__(ext_mem, mem_size)
         self.adaptive_size = adaptive_size
         self.num_experiences = num_experiences
 
@@ -163,8 +170,7 @@ class ClassBalancedStoragePolicy(StoragePolicy):
         :param total_num_classes: If adaptive size is False, the fixed number
                                   of classes to divide capacity over.
         """
-        self.ext_mem = ext_mem
-        self.mem_size = mem_size
+        super().__init__(ext_mem, mem_size)
         self.adaptive_size = adaptive_size
         self.total_num_classes = total_num_classes
         self.seen_classes = set()

--- a/tests/training/test_replay.py
+++ b/tests/training/test_replay.py
@@ -1,12 +1,18 @@
 import unittest
+from typing import List, Dict
+from unittest.mock import MagicMock
+
+from torch import tensor
 from torch.nn import CrossEntropyLoss
 from torch.optim import SGD
+from torch.utils.data import TensorDataset
 
+from avalanche.benchmarks.utils import AvalancheDataset, AvalancheDatasetType
 from avalanche.models import SimpleMLP
 from avalanche.training.plugins import ExperienceBalancedStoragePolicy, \
     ClassBalancedStoragePolicy, ReplayPlugin
-from avalanche.training.strategies import Naive
-
+from avalanche.training.plugins.replay import ClassExemplarsSelectionStrategy
+from avalanche.training.strategies import Naive, BaseStrategy
 from tests.unit_tests_utils import get_fast_scenario
 
 
@@ -69,3 +75,74 @@ class ReplayTest(unittest.TestCase):
             # buffer size should equal self.mem_size if data is large enough
             len_tot = sum([len(el) for el in ext_mem.values()])
             assert len_tot == policy.mem_size
+
+
+class ClassBalancePolicyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.memory = {}
+        self.policy = ClassBalancedStoragePolicy(self.memory, mem_size=4)
+
+    def test_store_alone_with_enough_memory(self):
+        order = [2, 0, 1, 3]
+
+        self.observe_exemplars({0: list(range(4))}, selection_order=order)
+
+        self.assert_memory_equal({0: order})
+
+    def test_store_alone_without_enough_memory(self):
+        order = [6, 4, 2, 0, 1, 3, 5]
+
+        self.observe_exemplars({0: list(range(7))}, selection_order=order)
+
+        self.assert_memory_equal({0: order[:4]})
+
+    def test_store_multiple_with_enough_memory(self):
+        self.observe_exemplars({0: [0, 1], 1: [10, 11]}, selection_order=[1, 0])
+
+        self.assert_memory_equal({0: [1, 0], 1: [11, 10]})
+
+    def test_store_multiple_without_enough_memory(self):
+        self.observe_exemplars({0: [0, 1, 2], 1: [10, 11, 12]},
+                               selection_order=[2, 0, 1])
+
+        self.assert_memory_equal({0: [2, 0], 1: [12, 10]})
+
+    def test_sequence(self):
+        # 1st observation
+        self.observe_exemplars({0: [0, 1], 1: [10, 11]}, selection_order=[1, 0])
+        self.assert_memory_equal({0: [1, 0], 1: [11, 10]})
+
+        # 2nd observation
+        self.observe_exemplars({2: [20, 21, 22], 3: [30, 31, 32]},
+                               selection_order=[2, 1, 0])
+        self.assert_memory_equal({0: [1], 1: [11], 2: [22], 3: [32]})
+
+    def observe_exemplars(self, class2exemplars: Dict[int, List[int]],
+                          selection_order: List[int]):
+        self.policy.selection_strategy = FixedSelectionStrategy(selection_order)
+        x = tensor(
+            [i for exemplars in class2exemplars.values() for i in exemplars])
+        y = tensor(
+            [class_id for class_id, exemplars in class2exemplars.items() for _
+             in exemplars]).long()
+        dataset = AvalancheDataset(
+            TensorDataset(x, y),
+            dataset_type=AvalancheDatasetType.CLASSIFICATION)
+
+        self.policy(MagicMock(experience=MagicMock(dataset=dataset)))
+
+    def assert_memory_equal(self, class2exemplars: Dict[int, List[int]]):
+        self.assertEqual(class2exemplars,
+                         {class_id: [x.tolist() for x, *_ in memory] for
+                          class_id, memory in self.memory.items()})
+
+
+class FixedSelectionStrategy(ClassExemplarsSelectionStrategy):
+    """This is a fake strategy used for testing the policy behavior"""
+
+    def __init__(self, indices: List[int]):
+        self.indices = indices
+
+    def make_sorted_indices(self, strategy: "BaseStrategy",
+                            data: AvalancheDataset) -> List[int]:
+        return self.indices

--- a/tests/training/test_replay.py
+++ b/tests/training/test_replay.py
@@ -6,9 +6,9 @@ import torch
 from torch import tensor, Tensor, zeros
 from torch.nn import CrossEntropyLoss, Module, Identity
 from torch.optim import SGD
-from torch.utils.data import TensorDataset
 
-from avalanche.benchmarks.utils import AvalancheDataset, AvalancheDatasetType
+from avalanche.benchmarks.utils import AvalancheDataset, AvalancheDatasetType, \
+    AvalancheTensorDataset
 from avalanche.models import SimpleMLP
 from avalanche.training.plugins import ExperienceBalancedStoragePolicy, \
     ClassBalancedStoragePolicy, ReplayPlugin
@@ -127,9 +127,8 @@ class ClassBalancePolicyTest(unittest.TestCase):
         y = tensor(
             [class_id for class_id, exemplars in class2exemplars.items() for _
              in exemplars]).long()
-        dataset = AvalancheDataset(
-            TensorDataset(x, y),
-            dataset_type=AvalancheDatasetType.CLASSIFICATION)
+        dataset = AvalancheTensorDataset(
+            x, y, dataset_type=AvalancheDatasetType.CLASSIFICATION)
 
         self.policy(MagicMock(experience=MagicMock(dataset=dataset)))
 
@@ -149,9 +148,10 @@ class SelectionStrategyTest(unittest.TestCase):
         # When
         # Features are [[0], [4], [5]]
         # Center is [3]
-        dataset = AvalancheDataset(
-            TensorDataset(tensor([0, -4, 5]).float(), zeros(3)),
-            dataset_type=AvalancheDatasetType.CLASSIFICATION)
+        dataset = AvalancheTensorDataset(
+            tensor([0, -4, 5]).float(), zeros(3),
+            dataset_type=AvalancheDatasetType.CLASSIFICATION
+        )
         strategy = MagicMock(device="cpu", eval_mb_size=8)
 
         # Then


### PR DESCRIPTION
This extends the `ExperienceBalancedStoragePolicy` to be able to use different selection strategies. It expect the strategy to sort the exemplars, and so only need to be called the first time they are seen.

I implemented 3 strategies:
 - Random selection (which was the previous behavior)
 - Herding (as used in the [iCaRL paper](https://arxiv.org/pdf/1611.07725.pdf))
 - Closest to center (in feature space)


[RWalk](https://arxiv.org/pdf/1801.10112.pdf) introduced other strategies, like entropy or distance to boundary decision, but herding and random seems to be the more used / best strategies.