### PR TITLE
Adding Category-Level Classification Support for CORe50

### DIFF
--- a/avalanche/benchmarks/classic/core50.py
+++ b/avalanche/benchmarks/classic/core50.py
@@ -41,6 +41,7 @@ scen2dirs = {
 def CORe50(root=expanduser("~") + "/.avalanche/data/core50/",
            scenario="nicv2_391",
            run=0,
+           object_lvl=True,
            train_transform=None,
            eval_transform=None):
     """
@@ -69,6 +70,8 @@ def CORe50(root=expanduser("~") + "/.avalanche/data/core50/",
         'nic', 'nicv2_79', 'nicv2_196' or 'nicv2_391.'
     :param run: number of run for the scenario. Each run defines a different
         ordering. Must be a number between 0 and 9.
+    :param object_lvl: True for a 50-way classification at the object level.
+        False if you want to use the categories as classes. Default to True.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -95,7 +98,11 @@ def CORe50(root=expanduser("~") + "/.avalanche/data/core50/",
     root = core_data.data_folder
     root_img = root + "core50_128x128/"
 
-    filelists_bp = scen2dirs[scenario] + "run" + str(run) + "/"
+    if object_lvl:
+        suffix = "/"
+    else:
+        suffix = "_cat/"
+    filelists_bp = scen2dirs[scenario][:-1] + suffix + "run" + str(run) + "/"
     train_failists_paths = []
     for i in range(nbatch[scenario]):
         train_failists_paths.append(

--- a/avalanche/benchmarks/datasets/core50/core50.py
+++ b/avalanche/benchmarks/datasets/core50/core50.py
@@ -101,7 +101,7 @@ class CORe50(Dataset):
             self.paths.append(self.train_test_paths[idx])
             div = 1
             if not self.object_level:
-                div=5
+                div = 5
             self.targets.append(self.train_test_targets[idx] // div)
 
     def __getitem__(self, index):

--- a/avalanche/benchmarks/datasets/core50/core50.py
+++ b/avalanche/benchmarks/datasets/core50/core50.py
@@ -35,13 +35,28 @@ class CORe50(Dataset):
 
     def __init__(self, root=expanduser("~")+"/.avalanche/data/core50/",
                  train=True, transform=ToTensor(), target_transform=None,
-                 loader=pil_loader, download=True):
+                 loader=pil_loader, download=True, object_level=True):
+        """
+
+        :param root: root for the datasets data.
+        :param train: train or test split.
+        :param transform: eventual transformations to be applied.
+        :param target_transform: eventual transformation to be applied to the
+            targets.
+        :param loader: data loader method from disk.
+        :param download: boolean to automatically download data. Default to
+            True.
+        :param object_level: if the classification is objects based or
+            category based: 50 or 10 way classification problem. Default to True
+            (50-way object classification problem)
+        """
 
         self.train = train  # training set or test set
         self.transform = transform
         self.target_transform = target_transform
         self.root = root
         self.loader = loader
+        self.object_level = object_level
         self.log = logging.getLogger("avalanche")
 
         # any scenario and run is good here since we want just to load the
@@ -68,6 +83,10 @@ class CORe50(Dataset):
         with open(os.path.join(root, 'LUP.pkl'), 'rb') as f:
             self.LUP = pkl.load(f)
 
+        self.log.info("Loading labels names...")
+        with open(os.path.join(root, 'labels2names.pkl'), 'rb') as f:
+            self.labels2names = pkl.load(f)
+
         self.idx_list = []
         if train:
             for i in range(nbatch + 1):
@@ -80,7 +99,10 @@ class CORe50(Dataset):
 
         for idx in self.idx_list:
             self.paths.append(self.train_test_paths[idx])
-            self.targets.append(self.train_test_targets[idx])
+            div = 1
+            if not self.object_level:
+                div=5
+            self.targets.append(self.train_test_targets[idx] // div)
 
     def __getitem__(self, index):
         """
@@ -122,6 +144,7 @@ if __name__ == "__main__":
     test_data = CORe50(train=False)
     print("train size: ", len(train_data))
     print("Test size: ", len(test_data))
+    print(train_data.labels2names)
     dataloader = DataLoader(train_data, batch_size=1)
 
     for batch_data in dataloader:

--- a/avalanche/benchmarks/datasets/core50/core50_data.py
+++ b/avalanche/benchmarks/datasets/core50/core50_data.py
@@ -14,7 +14,9 @@
 import os
 import sys
 import logging
-from zipfile import ZipFile 
+import glob
+import pickle as pkl
+from zipfile import ZipFile
 
 
 if sys.version_info[0] >= 3:
@@ -36,6 +38,8 @@ data = [
     ('paths.pkl', 'https://vlomonaco.github.io/core50/data/paths.pkl'),
     ('LUP.pkl', 'https://vlomonaco.github.io/core50/data/LUP.pkl'),
     ('labels.pkl', 'https://vlomonaco.github.io/core50/data/labels.pkl'),
+    ('labels2names.pkl',
+     'https://vlomonaco.github.io/core50/data/labels2names.pkl')
 ]
 
 extra_data = [
@@ -43,6 +47,27 @@ extra_data = [
      'http://bias.csr.unibo.it/maltoni/download/core50/core50_imgs.npz')
 ]
 
+scen2dirs = {
+    'ni': "batches_filelists/NI_inc/",
+    'nc': "batches_filelists/NC_inc/",
+    'nic': "batches_filelists/NIC_inc/",
+    'nicv2_79': "NIC_v2_79/",
+    'nicv2_196': "NIC_v2_196/",
+    'nicv2_391': "NIC_v2_391/"
+}
+
+name2cat = {
+    'plug_adapter': 0,
+    'mobile_phone': 1,
+    'scissor': 2,
+    'light_bulb': 3,
+    'can': 4,
+    'glass': 5,
+    'ball': 6,
+    'marker': 7,
+    'cup': 8,
+    'remote_control': 9
+}
 
 class CORE50_DATA(object):
     """
@@ -74,6 +99,15 @@ class CORE50_DATA(object):
             self.download = False
             self.log.error("Directory %s already exists", self.data_folder)
 
+        with open(os.path.join(data_folder, 'labels2names.pkl'), 'rb') as f:
+            self.labels2names = pkl.load(f)
+
+        if os.path.exists(os.path.join(data_folder, "NIC_v2_79_cat")):
+            # It means category filelists has been already created
+            pass
+        else:
+            self._create_cat_filelists()
+
     def download_core50(self, extra=False):
         """ Download and extract CORe50 data
 
@@ -98,6 +132,42 @@ class CORE50_DATA(object):
                     self.log.info('Done!')
 
         self.log.info("Download complete.")
+
+
+    def _objlab2cat(self, label, scen, run):
+        """ Mapping an object label into its corresponding category label
+        based on the scenario. """
+
+        if scen == "nc":
+            return name2cat[self.labels2names['nc'][run][label][:-1]]
+        else:
+            return int(label) // 5
+
+    def _create_cat_filelists(self):
+        """ Generates corresponding filelists with category-wise labels. The
+        default one are based on the object-level labels from 0 to 49."""
+
+        for k, v  in scen2dirs.items():
+            orig_root_path = os.path.join(self.data_folder, v)
+            root_path = os.path.join(self.data_folder, v[:-1] + "_cat")
+            if not os.path.exists(root_path):
+                os.makedirs(root_path)
+            for run in range(10):
+                cur_path = os.path.join(root_path, "run"+str(run))
+                orig_cur_path = os.path.join(orig_root_path, "run"+str(run))
+                if not os.path.exists(cur_path):
+                    os.makedirs(cur_path)
+                for file in glob.glob(os.path.join(orig_cur_path, "*.txt")):
+                    o_filename = file
+                    _, d_filename = os.path.split(o_filename)
+                    orig_f = open(o_filename, "r")
+                    dst_f = open(os.path.join(cur_path, d_filename), "w")
+                    for line in orig_f:
+                        path, label = line.split(" ")
+                        new_label = self._objlab2cat(int(label), k, run)
+                        dst_f.write(path + " " + str(new_label) + "\n")
+                    orig_f.close()
+                    dst_f.close()
 
 
 __all__ = [

--- a/avalanche/benchmarks/datasets/core50/core50_data.py
+++ b/avalanche/benchmarks/datasets/core50/core50_data.py
@@ -69,6 +69,7 @@ name2cat = {
     'remote_control': 9
 }
 
+
 class CORE50_DATA(object):
     """
     CORE50 downloader.
@@ -133,7 +134,6 @@ class CORE50_DATA(object):
 
         self.log.info("Download complete.")
 
-
     def _objlab2cat(self, label, scen, run):
         """ Mapping an object label into its corresponding category label
         based on the scenario. """
@@ -147,7 +147,7 @@ class CORE50_DATA(object):
         """ Generates corresponding filelists with category-wise labels. The
         default one are based on the object-level labels from 0 to 49."""
 
-        for k, v  in scen2dirs.items():
+        for k, v in scen2dirs.items():
             orig_root_path = os.path.join(self.data_folder, v)
             root_path = os.path.join(self.data_folder, v[:-1] + "_cat")
             if not os.path.exists(root_path):

--- a/tests/test_core50.py
+++ b/tests/test_core50.py
@@ -12,6 +12,8 @@
 """ CORe50 Tests"""
 
 import unittest
+import os
+
 
 from avalanche.benchmarks.classic import CORe50
 
@@ -19,24 +21,25 @@ from avalanche.benchmarks.classic import CORe50
 class CORe50Test(unittest.TestCase):
     def test_core50_ni_scenario(self):
 
-        # for now we disable it as it takes a while to download the CORe50
-        # dataset.
-        pass
-
-        # scenario = CORe50(scenario="ni")
-        # for task_info in scenario:
-        #     self.assertIsInstance(task_info, IExperience)
+        if "FAST_TEST" in os.environ:
+            pass
+        else:
+            scenario = CORe50(scenario="ni")
+            for task_info in scenario:
+                pass
 
     def test_core50_nc_scenario(self):
-        benchmark_instance = CORe50(scenario='nc')
+        if "FAST_TEST" in os.environ:
+            pass
+        else:
+            benchmark_instance = CORe50(scenario='nc')
+            self.assertEqual(1, len(benchmark_instance.test_stream))
 
-        self.assertEqual(1, len(benchmark_instance.test_stream))
-
-        classes_in_test = benchmark_instance.\
-            classes_in_experience['test'][0]
-        self.assertSetEqual(
-            set(range(50)),
-            set(classes_in_test))
+            classes_in_test = benchmark_instance.\
+                classes_in_experience['test'][0]
+            self.assertSetEqual(
+                set(range(50)),
+                set(classes_in_test))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR brings support for the Category-Level Classification in CORe50, partially tackling issue #547.
In particular it adds support for:

* Downloading additional data regarding the labels human-readable names.
* Changing the labels value for the basic CORe50 Dataset
* Generating category-level filelists for all the scenario
* Adding a new parameter to the classic benchmark to control the classification level (object-level vs category-level) 