### PR TITLE
added icarl plugin

### DIFF
--- a/avalanche/models/__init__.py
+++ b/avalanche/models/__init__.py
@@ -14,3 +14,5 @@ from .mobilenetv1 import MobilenetV1
 from .dynamic_modules import *
 from .utils import *
 from .slda_resnet import SLDAResNetModel
+from .icarl_resnet import *
+from .ncm_classifier import NCMClassifier

--- a/avalanche/models/dynamic_modules.py
+++ b/avalanche/models/dynamic_modules.py
@@ -33,7 +33,7 @@ class DynamicModule(torch.nn.Module):
         """
         super().__init__()
 
-    def adaptation(self, dataset: AvalancheDataset):
+    def adaptation(self, dataset: AvalancheDataset = None):
         """ Adapt the module (freeze units, add units...) using the current
         data. Optimizers must be updated after the model adaptation.
 
@@ -236,9 +236,44 @@ class MultiHeadClassifier(MultiTaskModule, DynamicModule):
         return self.classifiers[str(task_label)](x)
 
 
+class TrainEvalModel(DynamicModule):
+    """
+        TrainEvalModel.
+        This module allows to wrap together a common feature extractor and
+        two classifiers: one used during training time and another
+        used at test time. The classifier is switched when `self.adaptation()`
+        is called.
+    """
+    def __init__(self, feature_extractor, train_classifier, eval_classifier):
+        """
+        :param feature_extractor: a differentiable feature extractor
+        :param train_classifier: a differentiable classifier used
+            during training
+        :param eval_classifier: a classifier used during testing.
+            Doesn't have to be differentiable.
+        """
+        super().__init__()
+        self.feature_extractor = feature_extractor
+        self.train_classifier = train_classifier
+        self.eval_classifier = eval_classifier
+
+        self.classifier = train_classifier
+
+    def forward(self, x):
+        x = self.feature_extractor(x)
+        return self.classifier(x)
+
+    def train_adaptation(self, dataset: AvalancheDataset = None):
+        self.classifier = self.train_classifier
+
+    def eval_adaptation(self, dataset: AvalancheDataset = None):
+        self.classifier = self.eval_classifier
+
+
 __all__ = [
     'DynamicModule',
     'MultiTaskModule',
     'IncrementalClassifier',
-    'MultiHeadClassifier'
+    'MultiHeadClassifier',
+    'TrainEvalModel'
 ]

--- a/avalanche/models/icarl_resnet.py
+++ b/avalanche/models/icarl_resnet.py
@@ -1,0 +1,163 @@
+from typing import Union, Sequence, Callable
+
+import torch
+from torch.nn import Module, Sequential, BatchNorm2d, Conv2d, ReLU,\
+    ConstantPad3d, Identity, AdaptiveAvgPool2d, Linear
+from torch import Tensor
+from torch.nn.init import zeros_, kaiming_normal_
+from torch.nn.modules.flatten import Flatten
+import torch.nn.functional as F
+
+
+class IdentityShortcut(Module):
+    def __init__(self, transform_function: Callable[[Tensor], Tensor]):
+        super(IdentityShortcut, self).__init__()
+        self.transform_function = transform_function
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.transform_function(x)
+
+
+def conv3x3(in_planes: int, out_planes: int,
+            stride: Union[int, Sequence[int]] = 1):
+    return Conv2d(in_planes, out_planes,
+                  kernel_size=3, stride=stride, padding=1, bias=False)
+
+
+def batch_norm(num_channels: int) -> BatchNorm2d:
+    return BatchNorm2d(num_channels)
+
+
+class ResidualBlock(Module):
+
+    def __init__(self, input_num_filters: int,
+                 increase_dim: bool = False,
+                 projection: bool = False,
+                 last: bool = False):
+        super().__init__()
+        self.last: bool = last
+
+        if increase_dim:
+            first_stride = (2, 2)
+            out_num_filters = input_num_filters * 2
+        else:
+            first_stride = (1, 1)
+            out_num_filters = input_num_filters
+
+        self.direct = Sequential(
+            conv3x3(input_num_filters, out_num_filters, stride=first_stride),
+            batch_norm(out_num_filters),
+            ReLU(True),
+            conv3x3(out_num_filters, out_num_filters, stride=(1, 1)),
+            batch_norm(out_num_filters),
+        )
+
+        self.shortcut: Module
+
+        # add shortcut connections
+        if increase_dim:
+            if projection:
+                # projection shortcut, as option B in paper
+                self.shortcut = Sequential(
+                    Conv2d(input_num_filters, out_num_filters,
+                           kernel_size=(1, 1), stride=(2, 2), bias=False),
+                    batch_norm(out_num_filters)
+                )
+            else:
+                # identity shortcut, as option A in paper
+                self.shortcut = Sequential(
+                    IdentityShortcut(lambda x: x[:, :, ::2, ::2]),
+                    ConstantPad3d((0, 0, 0, 0,
+                                   out_num_filters // 4,
+                                   out_num_filters // 4), 0.0)
+                )
+        else:
+            self.shortcut = Identity()
+
+    def forward(self, x):
+        if self.last:
+            return self.direct(x) + self.shortcut(x)
+        else:
+            return torch.relu(self.direct(x) + self.shortcut(x))
+
+
+class IcarlNet(Module):
+    def __init__(self, num_classes: int, n=5, c=3):
+        super().__init__()
+
+        self.is_train = True
+        input_dims = c
+        output_dims = 16
+
+        first_conv = Sequential(
+            conv3x3(input_dims, output_dims, stride=(1, 1)),
+            batch_norm(16),
+            ReLU(True)
+        )
+
+        input_dims = output_dims
+        output_dims = 16
+
+        # first stack of residual blocks, output is 16 x 32 x 32
+        layers_list = []
+        for _ in range(n):
+            layers_list.append(ResidualBlock(input_dims))
+        first_block = Sequential(*layers_list)
+
+        input_dims = output_dims
+        output_dims = 32
+
+        # second stack of residual blocks, output is 32 x 16 x 16
+        layers_list = [ResidualBlock(input_dims, increase_dim=True)]
+        for _ in range(1, n):
+            layers_list.append(ResidualBlock(output_dims))
+        second_block = Sequential(*layers_list)
+
+        input_dims = output_dims
+        output_dims = 64
+
+        # third stack of residual blocks, output is 64 x 8 x 8
+        layers_list = [ResidualBlock(input_dims, increase_dim=True)]
+        for _ in range(1, n-1):
+            layers_list.append(ResidualBlock(output_dims))
+        layers_list.append(ResidualBlock(output_dims, last=True))
+        third_block = Sequential(*layers_list)
+        final_pool = AdaptiveAvgPool2d(output_size=(1, 1))
+
+        self.feature_extractor = Sequential(
+            first_conv, first_block,
+            second_block, third_block,
+            final_pool, Flatten())
+
+        input_dims = output_dims
+        output_dims = num_classes
+
+        self.classifier = Linear(input_dims, output_dims)
+
+    def forward(self, x):
+        x = self.feature_extractor(x)  # Already flattened
+        x = self.classifier(x)
+        return x
+
+
+def make_icarl_net(num_classes: int, n=5, c=3) -> IcarlNet:
+    return IcarlNet(num_classes, n=n, c=c)
+
+
+def initialize_icarl_net(m: Module):
+    if isinstance(m, Conv2d):
+        kaiming_normal_(m.weight.data, mode='fan_in', nonlinearity='relu')
+        if m.bias is not None:
+            zeros_(m.bias.data)
+
+    elif isinstance(m, Linear):
+        kaiming_normal_(m.weight.data, mode='fan_in', nonlinearity='sigmoid')
+        if m.bias is not None:
+            zeros_(m.bias.data)
+
+
+__all__ = [
+    'initialize_icarl_net',
+    'make_icarl_net',
+    'IcarlNet'
+]

--- a/avalanche/models/ncm_classifier.py
+++ b/avalanche/models/ncm_classifier.py
@@ -1,0 +1,26 @@
+import torch
+from torch import nn
+
+
+class NCMClassifier(nn.Module):
+    """
+        NCM Classifier.
+        NCMClassifier performs nearest class mean classification
+        measuring the distance between the input tensor and the
+        ones stored in 'self.class_means'.
+    """
+    def __init__(self, class_mean=None):
+        """
+        :param class_mean: tensor of dimension (num_classes x feature_size)
+            used to classify input patterns.
+        """
+        super().__init__()
+        self.class_means = class_mean
+
+    def forward(self, x):
+        pred_inter = (x.T / torch.norm(x.T, dim=0)).T
+        sqd = torch.cdist(self.class_means[:, :].T, pred_inter)
+        return (-sqd).T
+
+
+__all__ = ['NCMClassifier']

--- a/avalanche/training/losses.py
+++ b/avalanche/training/losses.py
@@ -25,7 +25,7 @@ class ICaRLLossPlugin(StrategyPlugin):
         self.old_model = None
         self.old_logits = None
 
-    def before_forward(self, strategy: 'BaseStrategy', **kwargs):
+    def before_forward(self, strategy, **kwargs):
         if self.old_model is not None:
             with torch.no_grad():
                 self.old_logits = self.old_model(strategy.mb_x)
@@ -44,7 +44,7 @@ class ICaRLLossPlugin(StrategyPlugin):
 
         return self.criterion(predictions, one_hot)
 
-    def after_training_exp(self, strategy: 'BaseStrategy', **kwargs):
+    def after_training_exp(self, strategy, **kwargs):
         if self.old_model is None:
             old_model = copy.deepcopy(strategy.model)
             old_model.eval()

--- a/avalanche/training/losses.py
+++ b/avalanche/training/losses.py
@@ -1,0 +1,59 @@
+import copy
+
+import torch
+from avalanche.training.plugins import StrategyPlugin
+from torch.nn import BCELoss
+import numpy as np
+
+
+class ICaRLLossPlugin(StrategyPlugin):
+    """
+    ICaRLLossPlugin
+    Similar to the Knowledge Distillation Loss. Works as follows:
+        The target is constructed by taking the one-hot vector target for the
+        current sample and assigning to the position corresponding to the
+        past classes the output of the old model on the current sample.
+        Doesn't work if classes observed in previous experiences might be
+        observed again in future training experiences.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.criterion = BCELoss()
+
+        self.old_classes = []
+        self.old_model = None
+        self.old_logits = None
+
+    def before_forward(self, strategy: 'BaseStrategy', **kwargs):
+        if self.old_model is not None:
+            with torch.no_grad():
+                self.old_logits = self.old_model(strategy.mb_x)
+
+    def __call__(self, logits, targets):
+        predictions = torch.sigmoid(logits)
+
+        one_hot = torch.zeros(targets.shape[0], logits.shape[1],
+                              dtype=torch.float, device=logits.device)
+        one_hot[range(len(targets)), targets.long()] = 1
+
+        if self.old_logits is not None:
+            old_predictions = torch.sigmoid(self.old_logits)
+            one_hot[:, self.old_classes] = old_predictions[:, self.old_classes]
+            self.old_logits = None
+
+        return self.criterion(predictions, one_hot)
+
+    def after_training_exp(self, strategy: 'BaseStrategy', **kwargs):
+        if self.old_model is None:
+            old_model = copy.deepcopy(strategy.model)
+            old_model.eval()
+            self.old_model = old_model.to(strategy.device)
+
+        self.old_model.load_state_dict(strategy.model.state_dict())
+
+        self.old_classes += np.unique(
+            strategy.experience.dataset.targets).tolist()
+
+
+__all__ = ["ICaRLLossPlugin"]

--- a/avalanche/training/plugins/icarl.py
+++ b/avalanche/training/plugins/icarl.py
@@ -15,7 +15,25 @@ if TYPE_CHECKING:
 
 
 class ICaRLPlugin(StrategyPlugin):
+    """
+        iCaRL Plugin.
+        iCaRL uses nearest class exemplar classification to prevent
+        forgetting to occur at the classification layer. The feature extractor
+        is continually learned using replay and distillation. The exemplars
+        used for replay and classification are selected through herding.
+        This plugin does not use task identities.
+        """
     def __init__(self, memory_size, diff_transform=None, fixed_memory=True):
+        """
+        :param memory_size: amount of patterns saved in the memory.
+        :param diff_transform: transform to apply to to test samples to
+            get train samples. If test_transform == train_transform,
+            diff_transform is None
+        :param fixed_memory: If True a memory of size memory_size is
+            allocated and divided between samples from the observed
+            experiences. If False every time a new class is observed
+            mememory_size samples of that class are added to the memory.
+        """
         super().__init__()
 
         self.memory_size = memory_size

--- a/avalanche/training/plugins/icarl.py
+++ b/avalanche/training/plugins/icarl.py
@@ -1,0 +1,252 @@
+import copy
+import itertools
+from typing import TYPE_CHECKING
+import torch
+from avalanche.benchmarks.utils import AvalancheConcatDataset, \
+    AvalancheTensorDataset, AvalancheSubset
+from torch import nn
+from math import ceil
+from avalanche.training.plugins.strategy_plugin import StrategyPlugin
+from torch.nn import BCELoss
+from torch.utils.data import DataLoader
+
+if TYPE_CHECKING:
+    from avalanche.training.strategies import BaseStrategy
+
+
+class ICaRLPlugin(StrategyPlugin):
+    def __init__(self, memory_size, diff_transform=None, fixed_memory=True):
+        super().__init__()
+
+        self.memory_size = memory_size
+        self.diff_transform = diff_transform
+        self.fixed_memory = fixed_memory
+
+        self.x_memory = []
+        self.y_memory = []
+        self.order = []
+
+        self.old_model = None
+        self.observed_classes = []
+        self.class_means = None
+        self.embedding_size = None
+        self.output_size = None
+        self.input_size = None
+
+        self.setup = False
+
+    def before_training(self, strategy: 'BaseStrategy', **kwargs):
+        if not self.setup:
+            strategy.model = ICaRLModel(strategy.model.feature_extractor,
+                                        train_head=strategy.model.classifier,
+                                        eval_head=NCMClassifier())
+            self.setup = True
+
+    def after_train_dataset_adaptation(self, strategy: 'BaseStrategy',
+                                       **kwargs):
+
+        if strategy.training_exp_counter != 0:
+            memory = AvalancheTensorDataset(
+                torch.cat(self.x_memory).cpu(),
+                list(itertools.chain.from_iterable(self.y_memory)),
+                transform=self.diff_transform, target_transform=None)
+
+            strategy.adapted_dataset = \
+                AvalancheConcatDataset((strategy.adapted_dataset, memory))
+
+    def before_training_exp(self, strategy: 'BaseStrategy', **kwargs):
+        tid = strategy.training_exp_counter
+        scenario = strategy.experience.scenario
+        nb_cl = scenario.n_classes_per_exp[tid]
+
+        self.observed_classes.extend(
+            scenario.classes_order[tid * nb_cl:(tid + 1) * nb_cl])
+
+    def before_forward(self, strategy: 'BaseStrategy', **kwargs):
+        if self.input_size is None:
+            with torch.no_grad():
+                self.input_size = strategy.mb_x.shape[1:]
+                self.output_size = strategy.model(strategy.mb_x).shape[1]
+                self.embedding_size = strategy.model.feature_extractor(
+                    strategy.mb_x).shape[1]
+
+        tid = strategy.training_exp_counter
+
+        if tid > 0:
+            scenario = strategy.experience.scenario
+            old_classes = scenario.classes_in_exp_range(0, tid)
+            self.old_model.feature_extractor.eval()
+            self.old_model.feature_extractor.eval()
+            with torch.no_grad():
+                embds = self.old_model.feature_extractor(strategy.mb_x)
+                old_logits = self.old_model.train_head(embds)
+
+            strategy.criterion.set_old(old_classes, old_logits)
+
+    def after_training_exp(self, strategy: 'BaseStrategy', **kwargs):
+
+        if strategy.training_exp_counter == 0:
+            old_model = copy.deepcopy(strategy.model)
+            self.old_model = old_model.to(strategy.device)
+
+        self.old_model.load_state_dict(strategy.model.state_dict())
+
+        strategy.model.eval()
+
+        self.construct_exemplar_set(strategy)
+        self.reduce_exemplar_set(strategy)
+        self.compute_class_means(strategy)
+
+    def compute_class_means(self, strategy):
+        if self.class_means is None:
+            n_classes = sum(strategy.experience.scenario.n_classes_per_exp)
+            self.class_means = torch.zeros(
+                (self.embedding_size, n_classes)).to(strategy.device)
+
+        for i, class_samples in enumerate(self.x_memory):
+            l = self.y_memory[i][0]
+            class_samples = class_samples.to(strategy.device)
+
+            with torch.no_grad():
+                mapped_prototypes = strategy.model.feature_extractor(
+                    class_samples).detach()
+            D = mapped_prototypes.T
+            D = D / torch.norm(D, dim=0)
+
+            with torch.no_grad():
+                mapped_prototypes2 = strategy.model.feature_extractor(
+                    torch.flip(class_samples, [3])).detach()
+
+            D2 = mapped_prototypes2.T
+            D2 = D2 / torch.norm(D2, dim=0)
+
+            div = torch.ones(class_samples.shape[0], device=strategy.device) \
+                  / class_samples.shape[0]
+
+            m1 = torch.mm(D, div.unsqueeze(1)).squeeze(1)
+            m2 = torch.mm(D2, div.unsqueeze(1)).squeeze(1)
+            self.class_means[:, l] = (m1 + m2) / 2
+            self.class_means[:, l] /= torch.norm(self.class_means[:, l])
+
+            strategy.model.eval_head.class_means = self.class_means
+
+    def construct_exemplar_set(self, strategy):
+        tid = strategy.training_exp_counter
+        nb_cl = strategy.experience.scenario.n_classes_per_exp
+
+        if self.fixed_memory:
+            nb_protos_cl = int(ceil(
+                self.memory_size / len(self.observed_classes)))
+        else:
+            nb_protos_cl = self.memory_size
+        new_classes = self.observed_classes[tid*nb_cl[tid]:(tid+1)*nb_cl[tid]]
+
+        dataset = strategy.experience.dataset
+        targets = torch.tensor(dataset.targets)
+        for iter_dico in range(nb_cl[tid]):
+            cd = AvalancheSubset(dataset,
+                                 torch.where(targets == new_classes[iter_dico])
+                                 [0])
+
+            class_patterns, _, _ = next(iter(
+                DataLoader(cd.eval(), batch_size=len(cd))))
+            class_patterns = class_patterns.to(strategy.device)
+
+            with torch.no_grad():
+                mapped_prototypes = strategy.model.feature_extractor(
+                    class_patterns).detach()
+            D = mapped_prototypes.T
+            D = D / torch.norm(D, dim=0)
+
+            mu = torch.mean(D, dim=1)
+            order = torch.zeros(class_patterns.shape[0])
+            w_t = mu
+
+            i, added, selected = 0, 0, []
+            while not added == nb_protos_cl and i < 1000:
+                tmp_t = torch.mm(w_t.unsqueeze(0), D)
+                ind_max = torch.argmax(tmp_t)
+
+                if ind_max not in selected:
+                    order[ind_max] = 1 + added
+                    added += 1
+                    selected.append(ind_max.item())
+
+                w_t = w_t + mu - D[:, ind_max]
+                i += 1
+
+            pick = (order > 0) * (order < nb_protos_cl + 1) * 1.
+            self.x_memory.append(class_patterns[torch.where(pick == 1)[0]])
+            self.y_memory.append(
+                [new_classes[iter_dico]]*len(torch.where(pick == 1)[0]))
+            self.order.append(order[torch.where(pick == 1)[0]])
+
+    def reduce_exemplar_set(self, strategy):
+        tid = strategy.training_exp_counter
+        nb_cl = strategy.experience.scenario.n_classes_per_exp
+
+        if self.fixed_memory:
+            nb_protos_cl = int(ceil(
+                self.memory_size / len(self.observed_classes)))
+        else:
+            nb_protos_cl = self.memory_size
+
+        for i in range(len(self.x_memory) - nb_cl[tid]):
+            pick = (self.order[i] < nb_protos_cl + 1) * 1.
+            self.x_memory[i] = self.x_memory[i][torch.where(pick == 1)[0]]
+            self.y_memory[i] = self.y_memory[i][:len(torch.where(pick==1)[0])]
+            self.order[i] = self.order[i][torch.where(pick == 1)[0]]
+
+
+class DistillationLoss:
+    def __init__(self):
+        self.criterion = BCELoss()
+        self.old_classes = None
+        self.old_logits = None
+
+    def set_old(self, old_classes, old_logits):
+        self.old_classes = old_classes
+        self.old_logits = old_logits
+
+    def __call__(self, logits, targets):
+        predictions = torch.sigmoid(logits)
+
+        one_hot = torch.zeros(targets.shape[0], logits.shape[1]
+                              , dtype=torch.float, device=logits.device)
+        one_hot[range(len(targets)), targets.long()] = 1
+
+        if self.old_classes is not None:
+            old_predictions = torch.sigmoid(self.old_logits)
+            one_hot[:, self.old_classes] = old_predictions[:, self.old_classes]
+            self.old_classes, self.old_logits = None, None
+
+        return self.criterion(predictions, one_hot)
+
+
+class NCMClassifier(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.class_means = None
+
+    def forward(self, x):
+        pred_inter = (x.T / torch.norm(x.T, dim=0)).T
+        sqd = torch.cdist(self.class_means[:, :].T, pred_inter)
+        return (-sqd).T
+
+
+class ICaRLModel(nn.Module):
+    def __init__(self, feature_extractor, train_head, eval_head):
+        super().__init__()
+        self.feature_extractor = feature_extractor
+        self.train_head = train_head
+        self.eval_head = eval_head
+
+        self.classifier = train_head
+
+    def forward(self, x):
+        x = self.feature_extractor(x)
+        return self.classifier(x)
+
+    def train(self, mode=True):
+        super().train(mode)
+        self.classifier = self.train_head if mode else self.eval_head

--- a/avalanche/training/strategies/icarl.py
+++ b/avalanche/training/strategies/icarl.py
@@ -180,8 +180,11 @@ class _ICaRLPlugin(StrategyPlugin):
             D = D / torch.norm(D, dim=0)
 
             with torch.no_grad():
+                if len(class_samples.shape) == 4:
+                    class_samples = torch.flip(class_samples, [3])
+
                 mapped_prototypes2 = strategy.model.feature_extractor(
-                    torch.flip(class_samples, [3])).detach()
+                    class_samples).detach()
 
             D2 = mapped_prototypes2.T
             D2 = D2 / torch.norm(D2, dim=0)

--- a/examples/icarl.py
+++ b/examples/icarl.py
@@ -1,0 +1,166 @@
+from os.path import expanduser
+
+import torch
+
+from avalanche.benchmarks.datasets import CIFAR100
+from avalanche.benchmarks.utils import AvalancheDataset
+from avalanche.models import IcarlNet, make_icarl_net, initialize_icarl_net
+from avalanche.training.plugins.lr_scheduling import LRSchedulerPlugin
+from torch.optim import SGD
+from torchvision import transforms
+from avalanche.benchmarks.generators import nc_benchmark
+from avalanche.training.plugins import EvaluationPlugin
+from avalanche.evaluation.metrics import ExperienceAccuracy, StreamAccuracy, \
+    EpochAccuracy
+from avalanche.logging.interactive_logging import InteractiveLogger
+import random
+import numpy as np
+from torch.optim.lr_scheduler import MultiStepLR
+
+from avalanche.training.strategies.icarl import ICaRL
+
+
+def get_dataset_per_pixel_mean(dataset):
+    result = None
+    patterns_count = 0
+
+    for img_pattern, _ in dataset:
+        if result is None:
+            result = torch.zeros_like(img_pattern, dtype=torch.float)
+
+        result += img_pattern
+        patterns_count += 1
+
+    if result is None:
+        result = torch.empty(0, dtype=torch.float)
+    else:
+        result = result / patterns_count
+
+    return result
+
+
+def icarl_cifar100_augment_data(img):
+    img = img.numpy()
+    padded = np.pad(img, ((0, 0), (4, 4), (4, 4)), mode='constant')
+    random_cropped = np.zeros(img.shape, dtype=np.float32)
+    crop = np.random.randint(0, high=8 + 1, size=(2,))
+
+    # Cropping and possible flipping
+    if np.random.randint(2) > 0:
+        random_cropped[:, :, :] = \
+            padded[:, crop[0]:(crop[0]+32), crop[1]:(crop[1]+32)]
+    else:
+        random_cropped[:, :, :] = \
+            padded[:, crop[0]:(crop[0]+32), crop[1]:(crop[1]+32)][:, :, ::-1]
+    t = torch.tensor(random_cropped)
+    return t
+
+
+def run_experiment(config):
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+    torch.manual_seed(config.seed)
+    torch.cuda.manual_seed(config.seed)
+    np.random.seed(config.seed)
+    random.seed(config.seed)
+    torch.backends.cudnn.enabled = False
+    torch.backends.cudnn.deterministic = True
+
+    per_pixel_mean = get_dataset_per_pixel_mean(
+        CIFAR100(expanduser("~") + "/.avalanche/data/cifar100/",
+                 train=True, download=True,
+                 transform=transforms.Compose([transforms.ToTensor()])))
+
+    transforms_group = dict(
+        eval=(transforms.Compose([
+            transforms.ToTensor(),
+            lambda img_pattern: img_pattern - per_pixel_mean]), None),
+        train=(transforms.Compose([
+            transforms.ToTensor(),
+            lambda img_pattern: img_pattern - per_pixel_mean,
+            icarl_cifar100_augment_data]), None),
+    )
+
+    train_set = CIFAR100(expanduser("~") + "/.avalanche/data/cifar100/",
+                         train=True, download=True, )
+    test_set = CIFAR100(expanduser("~") + "/.avalanche/data/cifar100/",
+                        train=False, download=True, )
+
+    train_set = AvalancheDataset(train_set,
+                                 transform_groups=transforms_group,
+                                 initial_transform_group='train')
+    test_set = AvalancheDataset(test_set,
+                                transform_groups=transforms_group,
+                                initial_transform_group='eval')
+
+    scenario = nc_benchmark(
+        train_dataset=train_set,
+        test_dataset=test_set,
+        n_experiences=config.nb_exp,
+        task_labels=False, seed=config.seed,
+        shuffle=False,
+        fixed_class_order=config.fixed_class_order)
+
+    evaluator = EvaluationPlugin(EpochAccuracy(), ExperienceAccuracy(),
+                                 StreamAccuracy(),
+                                 loggers=[InteractiveLogger()])
+
+    model: IcarlNet = make_icarl_net(num_classes=100)
+    model.apply(initialize_icarl_net)
+
+    optim = SGD(model.parameters(), lr=config.lr_base,
+                weight_decay=config.wght_decay, momentum=0.9)
+    sched = LRSchedulerPlugin(
+        MultiStepLR(optim, config.lr_milestones, gamma=1.0 / config.lr_factor))
+
+    strategy = ICaRL(
+        model.feature_extractor, model.classifier, optim,
+        config.memory_size,
+        buffer_transform=transforms.Compose([icarl_cifar100_augment_data]),
+        fixed_memory=True, train_mb_size=config.batch_size,
+        train_epochs=config.epochs, eval_mb_size=config.batch_size,
+        plugins=[sched], device=device, evaluator=evaluator
+    )
+
+    for i, exp in enumerate(scenario.train_stream):
+        eval_exps = [e for e in scenario.test_stream][:i + 1]
+        strategy.train(exp, num_workers=4)
+        strategy.eval(eval_exps, num_workers=4)
+
+
+class Config(dict):
+
+    def __getattribute__(self, key):
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+
+if __name__ == "__main__":
+    config = Config()
+
+    config.batch_size = 128
+    config.nb_exp = 10
+    config.memory_size = 2000
+    config.epochs = 10
+    config.lr_base = 2.
+    config.lr_milestones = [49, 63]
+    config.lr_factor = 5.
+    config.wght_decay = 0.00001
+    config.fixed_class_order = [87, 0, 52, 58, 44, 91, 68, 97, 51, 15,
+                                94, 92, 10, 72, 49, 78, 61, 14, 8, 86,
+                                84, 96, 18, 24, 32, 45, 88, 11, 4, 67,
+                                69, 66, 77, 47, 79, 93, 29, 50, 57, 83,
+                                17, 81, 41, 12, 37, 59, 25, 20, 80, 73,
+                                1, 28, 6, 46, 62, 82, 53, 9, 31, 75,
+                                38, 63, 33, 74, 27, 22, 36, 3, 16, 21,
+                                60, 19, 70, 90, 89, 43, 5, 42, 65, 76,
+                                40, 30, 23, 85, 2, 95, 56, 48, 71, 64,
+                                98, 13, 99, 7, 34, 55, 54, 26, 35, 39]
+    config.seed = 2222
+
+    run_experiment(config)

--- a/examples/icarl.py
+++ b/examples/icarl.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
     config.batch_size = 128
     config.nb_exp = 10
     config.memory_size = 2000
-    config.epochs = 10
+    config.epochs = 70
     config.lr_base = 2.
     config.lr_milestones = [49, 63]
     config.lr_factor = 5.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,7 +11,7 @@ from torch.utils.data import DataLoader
 
 from avalanche.logging import TextLogger
 from avalanche.models import MTSimpleMLP, SimpleMLP, IncrementalClassifier, \
-    MultiHeadClassifier
+    MultiHeadClassifier, SimpleCNN, NCMClassifier, TrainEvalModel
 from avalanche.models.dynamic_optimizers import add_new_params_to_optimizer, \
     update_optimizer
 from avalanche.training.strategies import Naive
@@ -258,3 +258,56 @@ class DynamicModelsTests(unittest.TestCase):
             y_t = model_t4(x)
             assert ((y_mh - y_t) ** 2).sum() < 1.e-7
             break
+
+
+class TrainEvalModelTests(unittest.TestCase):
+
+    def test_classifier_selection(self):
+        base_model = SimpleCNN()
+
+        feature_extractor = base_model.features
+        classifier1 = base_model.classifier
+        classifier2 = NCMClassifier()
+
+        model = TrainEvalModel(feature_extractor,
+                               train_classifier=classifier1,
+                               eval_classifier=classifier2)
+
+        model.eval()
+        model.adaptation()
+        assert model.classifier is classifier2
+
+        model.train()
+        model.adaptation()
+        assert model.classifier is classifier1
+
+        model.eval_adaptation()
+        assert model.classifier is classifier2
+
+        model.train_adaptation()
+        assert model.classifier is classifier1
+
+
+class NCMClassifierTest(unittest.TestCase):
+
+    def test_ncm_classification(self):
+        class_means = torch.tensor([
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1]
+        ], dtype=torch.float)
+
+        mb_x = torch.tensor([
+            [4, 3, 2, 1],
+            [3, 4, 2, 1],
+            [3, 2, 4, 1],
+            [3, 2, 1, 4]
+        ], dtype=torch.float)
+
+        mb_y = torch.tensor([0, 1, 2, 3], dtype=torch.float)
+
+        classifier = NCMClassifier(class_means)
+
+        pred = classifier(mb_x)
+        assert torch.all(torch.max(pred, 1)[1] == mb_y)

--- a/tests/training/test_losses.py
+++ b/tests/training/test_losses.py
@@ -2,8 +2,7 @@
 import unittest
 
 import torch
-
-from avalanche.training.losses import ICaRLDistillationLoss
+from avalanche.training.losses import ICaRLLossPlugin
 
 
 class TestICaRLLossPlugin(unittest.TestCase):
@@ -28,12 +27,14 @@ class TestICaRLLossPlugin(unittest.TestCase):
         criterion = ICaRLLossPlugin()
         loss1 = criterion(new_pred, mb_y)
 
-        criterion.set_old([0, 1], old_pred)
+        criterion.old_logits = old_pred
+        criterion.old_classes = [0, 1]
+
         loss2 = criterion(new_pred, mb_y)
 
         assert loss2 < loss1
 
-        criterion = ICaRLDistillationLoss()
+        criterion = ICaRLLossPlugin()
         loss3 = criterion(new_pred, mb_y)
 
         assert loss3 == loss1

--- a/tests/training/test_losses.py
+++ b/tests/training/test_losses.py
@@ -1,0 +1,39 @@
+
+import unittest
+
+import torch
+
+from avalanche.training.losses import ICaRLDistillationLoss
+
+
+class TestICaRLLossPlugin(unittest.TestCase):
+
+    def test_loss(self):
+        mb_y = torch.tensor([0, 1, 2, 3], dtype=torch.float)
+
+        old_pred = torch.tensor([
+            [2, 1, 0, 0],
+            [1, 2, 0, 0],
+            [2, 1, 0, 0],
+            [1, 2, 0, 0]
+        ], dtype=torch.float)
+
+        new_pred = torch.tensor([
+            [2, 1, 0, 0],
+            [1, 2, 0, 0],
+            [0, 0, 2, 1],
+            [0, 0, 1, 2]
+        ], dtype=torch.float)
+
+        criterion = ICaRLLossPlugin()
+        loss1 = criterion(new_pred, mb_y)
+
+        criterion.set_old([0, 1], old_pred)
+        loss2 = criterion(new_pred, mb_y)
+
+        assert loss2 < loss1
+
+        criterion = ICaRLDistillationLoss()
+        loss3 = criterion(new_pred, mb_y)
+
+        assert loss3 == loss1

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -18,7 +18,7 @@ from torch.optim import SGD
 from torch.nn import CrossEntropyLoss
 
 from avalanche.logging import TextLogger
-from avalanche.models import SimpleMLP, make_icarl_net, initialize_icarl_net
+from avalanche.models import SimpleMLP
 from avalanche.training.plugins import EvaluationPlugin
 from avalanche.training.strategies import Naive, Replay, CWRStar, \
     GDumb, LwF, AGEM, GEM, EWC, \
@@ -346,16 +346,11 @@ class StrategyTest(unittest.TestCase):
         self.run_strategy(scenario, strategy)
 
     def test_icarl(self):
-        scenario = self.load_scenario()
-
-        model = make_icarl_net(num_classes=100)
-        model.apply(initialize_icarl_net)
-
+        model, _, _, scenario = self.init_sit()
         optimizer = SGD(model.parameters(), lr=.2)
 
         strategy = ICaRL(
-            model.feature_extractor, model.classifier, optimizer,
-            2000,
+            model.features, model.classifier, optimizer, 2000,
             buffer_transform=None,
             fixed_memory=True, train_mb_size=10,
             train_epochs=1, eval_mb_size=50,
@@ -393,5 +388,4 @@ class StrategyTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    StrategyTest().test_icarl()
-    # unittest.main()
+    unittest.main()

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -14,8 +14,13 @@ import unittest
 import os
 import sys
 
+from torch.nn.init import kaiming_normal_, zeros_
+
+from avalanche.benchmarks import nc_benchmark
+from sklearn.model_selection import train_test_split
 from torch.optim import SGD
-from torch.nn import CrossEntropyLoss
+from torch.nn import CrossEntropyLoss, Linear
+from torch.utils.data import TensorDataset
 
 from avalanche.logging import TextLogger
 from avalanche.models import SimpleMLP
@@ -29,7 +34,28 @@ from avalanche.training.strategies.icarl import ICaRL
 from avalanche.training.utils import get_last_fc_layer
 from avalanche.evaluation.metrics import StreamAccuracy
 
-from tests.unit_tests_utils import get_fast_scenario
+# from tests.unit_tests_utils import get_fast_scenario
+from sklearn.datasets import make_classification
+
+def get_fast_scenario(use_task_labels=False, shuffle=True):
+    n_samples_per_class = 100
+    dataset = make_classification(
+        n_samples=10 * n_samples_per_class,
+        n_classes=10,
+        n_features=6, n_informative=6, n_redundant=0)
+
+    X = torch.from_numpy(dataset[0]).float()
+    y = torch.from_numpy(dataset[1]).long()
+
+    train_X, test_X, train_y, test_y = train_test_split(
+        X, y, train_size=0.6, shuffle=True, stratify=y)
+
+    train_dataset = TensorDataset(train_X, train_y)
+    test_dataset = TensorDataset(test_X, test_y)
+    my_nc_benchmark = nc_benchmark(train_dataset, test_dataset, 5,
+                                   task_labels=use_task_labels, shuffle=shuffle)
+    return my_nc_benchmark
+
 
 
 class BaseStrategyTest(unittest.TestCase):
@@ -346,14 +372,13 @@ class StrategyTest(unittest.TestCase):
         self.run_strategy(scenario, strategy)
 
     def test_icarl(self):
-        model, _, _, scenario = self.init_sit()
-        optimizer = SGD(model.parameters(), lr=.2)
+        model, optimizer, criterion, scenario = self.init_sit()
 
         strategy = ICaRL(
-            model.features, model.classifier, optimizer, 2000,
-            buffer_transform=None,
+            model.features, model.classifier, optimizer, 20,
+            buffer_transform=None, criterion=criterion,
             fixed_memory=True, train_mb_size=10,
-            train_epochs=1, eval_mb_size=50,
+            train_epochs=2, eval_mb_size=50,
             device=self.device,)
 
         self.run_strategy(scenario, strategy)

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -14,13 +14,8 @@ import unittest
 import os
 import sys
 
-from torch.nn.init import kaiming_normal_, zeros_
-
-from avalanche.benchmarks import nc_benchmark
-from sklearn.model_selection import train_test_split
 from torch.optim import SGD
 from torch.nn import CrossEntropyLoss, Linear
-from torch.utils.data import TensorDataset
 
 from avalanche.logging import TextLogger
 from avalanche.models import SimpleMLP
@@ -34,28 +29,7 @@ from avalanche.training.strategies.icarl import ICaRL
 from avalanche.training.utils import get_last_fc_layer
 from avalanche.evaluation.metrics import StreamAccuracy
 
-# from tests.unit_tests_utils import get_fast_scenario
-from sklearn.datasets import make_classification
-
-def get_fast_scenario(use_task_labels=False, shuffle=True):
-    n_samples_per_class = 100
-    dataset = make_classification(
-        n_samples=10 * n_samples_per_class,
-        n_classes=10,
-        n_features=6, n_informative=6, n_redundant=0)
-
-    X = torch.from_numpy(dataset[0]).float()
-    y = torch.from_numpy(dataset[1]).long()
-
-    train_X, test_X, train_y, test_y = train_test_split(
-        X, y, train_size=0.6, shuffle=True, stratify=y)
-
-    train_dataset = TensorDataset(train_X, train_y)
-    test_dataset = TensorDataset(test_X, test_y)
-    my_nc_benchmark = nc_benchmark(train_dataset, test_dataset, 5,
-                                   task_labels=use_task_labels, shuffle=shuffle)
-    return my_nc_benchmark
-
+from tests.unit_tests_utils import get_fast_scenario
 
 
 class BaseStrategyTest(unittest.TestCase):


### PR DESCRIPTION
Implementation of iCaRL algorithm with an Avalanche plugin.

Issues:
- Should I add to Avalanche the ResNet, data augmentation and main.py needed to reproduce the paper results?
- There are some utilities classes needed by the plugin that are currently stored inside the same file (e.g. DistillationLoss, NCMClassifier). Maybe they could be moved somewhere else.
- Still working to avoid having to pass `diff_transform` to the plugin (the difference between test_transform and train_transform). It should be easy but some of the solution I've tried led to a decrease in performances.

Apart from that the plugin works and achieves the results reported by the paper.