### PR TITLE
CORe50 Mini Option Added

### DIFF
--- a/avalanche/benchmarks/classic/core50.py
+++ b/avalanche/benchmarks/classic/core50.py
@@ -42,6 +42,7 @@ def CORe50(root=expanduser("~") + "/.avalanche/data/core50/",
            scenario="nicv2_391",
            run=0,
            object_lvl=True,
+           mini=False,
            train_transform=None,
            eval_transform=None):
     """
@@ -63,7 +64,7 @@ def CORe50(root=expanduser("~") + "/.avalanche/data/core50/",
     generators. It is recommended to check the tutorial of the "benchmark" API,
     which contains usage examples ranging from "basic" to "advanced".
 
-    :param root: Path indicating where to store the dataset and related
+    :param root: Absolute path indicating where to store the dataset and related
         metadata. By default they will be stored in
         "~/.avalanche/datasets/core50/data/".
     :param scenario: CORe50 main scenario. It can be chosen between 'ni', 'nc',
@@ -72,6 +73,8 @@ def CORe50(root=expanduser("~") + "/.avalanche/data/core50/",
         ordering. Must be a number between 0 and 9.
     :param object_lvl: True for a 50-way classification at the object level.
         False if you want to use the categories as classes. Default to True.
+    :param mini: True for processing reduced 32x32 images instead of the
+        original 128x128. Default to False.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -91,12 +94,16 @@ def CORe50(root=expanduser("~") + "/.avalanche/data/core50/",
                                         "'nic', 'nicv2_79', 'nicv2_196' or " \
                                         "'nicv2_391'."
     if root is None:
-        core_data = CORE50_DATA()
+        core_data = CORE50_DATA(mini=mini)
     else:
-        core_data = CORE50_DATA(root)
+        core_data = CORE50_DATA(data_folder=root, mini=mini)
 
     root = core_data.data_folder
-    root_img = root + "core50_128x128/"
+    if mini:
+        bp = "core50_32x32/"
+    else:
+        bp = "core50_128x128/"
+    root_img = root + bp
 
     if object_lvl:
         suffix = "/"

--- a/avalanche/benchmarks/datasets/core50/core50.py
+++ b/avalanche/benchmarks/datasets/core50/core50.py
@@ -35,7 +35,8 @@ class CORe50(Dataset):
 
     def __init__(self, root=expanduser("~")+"/.avalanche/data/core50/",
                  train=True, transform=ToTensor(), target_transform=None,
-                 loader=pil_loader, download=True, object_level=True):
+                 loader=pil_loader, download=True, mini=False,
+                 object_level=True):
         """
 
         :param root: root for the datasets data.
@@ -46,6 +47,8 @@ class CORe50(Dataset):
         :param loader: data loader method from disk.
         :param download: boolean to automatically download data. Default to
             True.
+        :param mini: boolean to use the 32x32 version instead of the 128x128.
+            Default to False.
         :param object_level: if the classification is objects based or
             category based: 50 or 10 way classification problem. Default to True
             (50-way object classification problem)
@@ -57,6 +60,7 @@ class CORe50(Dataset):
         self.root = root
         self.loader = loader
         self.object_level = object_level
+        self.mini = mini
         self.log = logging.getLogger("avalanche")
 
         # any scenario and run is good here since we want just to load the
@@ -66,7 +70,7 @@ class CORe50(Dataset):
         nbatch = 8
 
         if download:
-            self.core_data = CORE50_DATA(data_folder=root)
+            self.core_data = CORE50_DATA(data_folder=root, mini=mini)
 
         self.log.info("Loading paths...")
         with open(os.path.join(root, 'paths.pkl'), 'rb') as f:
@@ -114,10 +118,15 @@ class CORe50(Dataset):
                 class.
         """
 
+        if self.mini:
+            bp = "core50_32x32"
+        else:
+            bp = "core50_128x128"
+
         target = self.targets[index]
         img = self.loader(
             os.path.join(
-                self.root, "core50_128x128", self.paths[index]
+                self.root, bp, self.paths[index]
             )
         )
         if self.transform is not None:


### PR DESCRIPTION
This PR expands CORe50 functionalities partially addressing #547.

In particular:

* It adds support to work with a CORe50 32x32 as raw data (no on-the-fly transformations). This both for the classic benchmark and the core dataset to be used with generators.
* Faster automatic download if the mini option is enabled (no need to download the 128x128 version). 128x128 images can still be download with setting the "extra" param to True in `download_core50(self, extra=False)`.