### PR TITLE
Standardization of classic benchmarks

### DIFF
--- a/avalanche/benchmarks/classic/ccifar100.py
+++ b/avalanche/benchmarks/classic/ccifar100.py
@@ -10,12 +10,14 @@
 ################################################################################
 
 import random
-from typing import Sequence, Optional
-from os.path import expanduser
+from pathlib import Path
+from typing import Sequence, Optional, Union, Any
 from torchvision.datasets import CIFAR100
 from torchvision import transforms
 
-from avalanche.benchmarks.datasets import CIFAR10
+from avalanche.benchmarks.classic.classic_benchmarks_utils import \
+    check_vision_benchmark
+from avalanche.benchmarks.datasets import CIFAR10, default_dataset_location
 from avalanche.benchmarks.utils.avalanche_dataset import \
     concat_datasets_sequentially
 from avalanche.benchmarks import nc_benchmark, NCScenario
@@ -35,13 +37,17 @@ _default_cifar100_eval_transform = transforms.Compose([
 ])
 
 
-def SplitCIFAR100(n_experiences: int,
-                  first_exp_with_half_classes: bool = False,
-                  return_task_id=False,
-                  seed: Optional[int] = None,
-                  fixed_class_order: Optional[Sequence[int]] = None,
-                  train_transform=_default_cifar100_train_transform,
-                  eval_transform=_default_cifar100_eval_transform):
+def SplitCIFAR100(
+        n_experiences: int,
+        *,
+        first_exp_with_half_classes: bool = False,
+        return_task_id=False,
+        seed: Optional[int] = None,
+        fixed_class_order: Optional[Sequence[int]] = None,
+        shuffle: bool = True,
+        train_transform: Optional[Any] = _default_cifar100_train_transform,
+        eval_transform: Optional[Any] = _default_cifar100_eval_transform,
+        dataset_root: Union[str, Path] = None):
     """
     Creates a CL scenario using the CIFAR100 dataset.
 
@@ -85,6 +91,8 @@ def SplitCIFAR100(n_experiences: int,
         order. If None, value of ``seed`` will be used to define the class
         order. If non-None, ``seed`` parameter will be ignored.
         Defaults to None.
+    :param shuffle: If true, the class order in the incremental experiences is
+        randomly shuffled. Default to false.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -97,10 +105,12 @@ def SplitCIFAR100(n_experiences: int,
         comprehensive list of possible transformations).
         If no transformation is passed, the default test transformation
         will be used.
+    :param dataset_root: The root path of the dataset. Defaults to None, which
+        means that the default location for 'cifar100' will be used.
 
     :returns: A properly initialized :class:`NCScenario` instance.
     """
-    cifar_train, cifar_test = _get_cifar100_dataset()
+    cifar_train, cifar_test = _get_cifar100_dataset(dataset_root)
 
     if return_task_id:
         return nc_benchmark(
@@ -110,6 +120,7 @@ def SplitCIFAR100(n_experiences: int,
             task_labels=True,
             seed=seed,
             fixed_class_order=fixed_class_order,
+            shuffle=shuffle,
             per_exp_classes={0: 50} if first_exp_with_half_classes else None,
             class_ids_from_zero_in_each_exp=True,
             train_transform=train_transform,
@@ -122,6 +133,7 @@ def SplitCIFAR100(n_experiences: int,
             task_labels=False,
             seed=seed,
             fixed_class_order=fixed_class_order,
+            shuffle=shuffle,
             per_exp_classes={0: 50} if first_exp_with_half_classes else None,
             train_transform=train_transform,
             eval_transform=eval_transform)
@@ -129,10 +141,13 @@ def SplitCIFAR100(n_experiences: int,
 
 def SplitCIFAR110(
         n_experiences: int,
+        *,
         seed: Optional[int] = None,
         fixed_class_order: Optional[Sequence[int]] = None,
-        train_transform=_default_cifar100_train_transform,
-        eval_transform=_default_cifar100_eval_transform) -> NCScenario:
+        train_transform: Optional[Any] = _default_cifar100_train_transform,
+        eval_transform: Optional[Any] = _default_cifar100_eval_transform,
+        dataset_root_cifar10: Union[str, Path] = None,
+        dataset_root_cifar100: Union[str, Path] = None) -> NCScenario:
     """
     Creates a CL scenario using both the CIFAR100 and CIFAR10 datasets.
 
@@ -184,12 +199,18 @@ def SplitCIFAR110(
         comprehensive list of possible transformations).
         If no transformation is passed, the default test transformation
         will be used.
+    :param dataset_root_cifar10: The root path of the CIFAR-10 dataset.
+        Defaults to None, which means that the default location for
+        'cifar10' will be used.
+    :param dataset_root_cifar100: The root path of the CIFAR-100 dataset.
+        Defaults to None, which means that the default location for
+        'cifar100' will be used.
 
     :returns: A properly initialized :class:`NCScenario` instance.
     """
 
-    cifar10_train, cifar10_test = _get_cifar10_dataset()
-    cifar100_train, cifar100_test = _get_cifar100_dataset()
+    cifar10_train, cifar10_test = _get_cifar10_dataset(dataset_root_cifar10)
+    cifar100_train, cifar100_test = _get_cifar100_dataset(dataset_root_cifar100)
 
     cifar_10_100_train, cifar_10_100_test, _ = concat_datasets_sequentially(
         [cifar10_train, cifar100_train], [cifar10_test, cifar100_test]
@@ -219,24 +240,38 @@ def SplitCIFAR110(
         eval_transform=eval_transform)
 
 
-def _get_cifar10_dataset():
-    train_set = CIFAR10(expanduser("~") + "/.avalanche/data/cifar10/",
-                        train=True, download=True)
+def _get_cifar10_dataset(dataset_root):
+    if dataset_root is None:
+        dataset_root = default_dataset_location('cifar10')
 
-    test_set = CIFAR10(expanduser("~") + "/.avalanche/data/cifar10/",
-                       train=False, download=True)
+    train_set = CIFAR10(dataset_root, train=True, download=True)
+    test_set = CIFAR10(dataset_root, train=False, download=True)
+
+    return train_set, test_set
+
+
+def _get_cifar100_dataset(dataset_root):
+    if dataset_root is None:
+        dataset_root = default_dataset_location('cifar100')
+
+    train_set = CIFAR100(dataset_root, train=True, download=True)
+    test_set = CIFAR100(dataset_root, train=False, download=True)
 
     return train_set, test_set
 
 
-def _get_cifar100_dataset():
-    train_set = CIFAR100(expanduser("~") + "/.avalanche/data/cifar100/",
-                         train=True, download=True)
+if __name__ == "__main__":
+    import sys
 
-    test_set = CIFAR100(expanduser("~") + "/.avalanche/data/cifar100/",
-                        train=False, download=True)
+    print('Split 100')
+    benchmark_instance = SplitCIFAR100(5)
+    check_vision_benchmark(benchmark_instance)
 
-    return train_set, test_set
+    print('Split 110')
+    benchmark_instance = SplitCIFAR110(5)
+    check_vision_benchmark(benchmark_instance)
+
+    sys.exit(0)
 
 
 __all__ = [

--- a/avalanche/benchmarks/classic/cfashion_mnist.py
+++ b/avalanche/benchmarks/classic/cfashion_mnist.py
@@ -158,4 +158,3 @@ if __name__ == "__main__":
     benchmark_instance = SplitFMNIST(n_experiences=10)
     check_vision_benchmark(benchmark_instance)
     sys.exit(0)
-

--- a/avalanche/benchmarks/classic/cinaturalist.py
+++ b/avalanche/benchmarks/classic/cinaturalist.py
@@ -8,9 +8,13 @@
 # E-mail: contact@continualai.org                                              #
 # Website: continualai.org                                                     #
 ################################################################################
+from pathlib import Path
+from typing import Union, Any, Optional
 
-
-from avalanche.benchmarks.datasets import INATURALIST2018
+from avalanche.benchmarks.classic.classic_benchmarks_utils import \
+    check_vision_benchmark
+from avalanche.benchmarks.datasets import INATURALIST2018, \
+    default_dataset_location
 from avalanche.benchmarks import nc_benchmark
 
 from torchvision import transforms
@@ -33,13 +37,15 @@ _default_eval_transform = transforms.Compose([
 ])
 
 
-def SplitInaturalist(root,
-                     super_categories=None,
-                     return_task_id=False,
-                     download=False,
-                     seed=0,
-                     train_transform=_default_train_transform,
-                     eval_transform=_default_eval_transform):
+def SplitInaturalist(
+        *,
+        super_categories=None,
+        return_task_id=False,
+        download=False,
+        seed=0,
+        train_transform: Optional[Any] = _default_train_transform,
+        eval_transform: Optional[Any] = _default_eval_transform,
+        dataset_root: Union[str, Path] = None):
     """
     Creates a CL scenario using the iNaturalist2018 dataset.
     A selection of supercategories (by default 10) define the experiences.
@@ -82,7 +88,6 @@ def SplitInaturalist(root,
     generators. It is recommended to check the tutorial of the "benchmark" API,
     which contains usage examples ranging from "basic" to "advanced".
 
-    :param root: Base path where Inaturalist data is stored.
     :param super_categories: The list of supercategories which define the
     tasks, i.e. each task consists of all classes in a super-category.
     :param download: If true and the dataset is not present in the computer,
@@ -104,6 +109,9 @@ def SplitInaturalist(root,
         comprehensive list of possible transformations).
         If no transformation is passed, the default test transformation
         will be used.
+    :param dataset_root: The root path of the dataset.
+        Defaults to None, which means that the default location for
+        'inatuarlist2018' will be used.
 
     :returns: A properly initialized :class:`NCScenario` instance.
     """
@@ -115,7 +123,7 @@ def SplitInaturalist(root,
             'Insecta', 'Mammalia', 'Mollusca', 'Plantae', 'Reptilia']
 
     train_set, test_set = _get_inaturalist_dataset(
-        root, super_categories, download=download)
+        dataset_root, super_categories, download=download)
     per_exp_classes, fixed_class_order = _get_split(super_categories, train_set)
 
     if return_task_id:
@@ -145,11 +153,16 @@ def SplitInaturalist(root,
         )
 
 
-def _get_inaturalist_dataset(root, super_categories, download):
-    train_set = INATURALIST2018(root, split="train", supcats=super_categories,
-                                download=download)
-    test_set = INATURALIST2018(root, split="val", supcats=super_categories,
-                               download=download)
+def _get_inaturalist_dataset(dataset_root, super_categories, download):
+    if dataset_root is None:
+        dataset_root = default_dataset_location('inatuarlist2018')
+
+    train_set = INATURALIST2018(
+        dataset_root, split="train", supcats=super_categories,
+        download=download)
+    test_set = INATURALIST2018(
+        dataset_root, split="val", supcats=super_categories,
+        download=download)
 
     return train_set, test_set
 
@@ -169,14 +182,10 @@ __all__ = [
     'SplitInaturalist'
 ]
 
+
 if __name__ == "__main__":
-    import os
+    import sys
 
-    # Must define root manually to avoid automatic 120G download
-    your_root = os.path.expanduser("~") + "/.avalanche/data/inatuarlist2018/"
-    scenario = SplitInaturalist(your_root)
-
-    for exp in scenario.train_stream:
-        print("experience: ", exp.current_experience)
-        print("classes number: ", len(exp.classes_in_this_experience))
-        print("classes: ", exp.classes_in_this_experience)
+    benchmark_instance = SplitInaturalist()
+    check_vision_benchmark(benchmark_instance, show_without_transforms=False)
+    sys.exit(0)

--- a/avalanche/benchmarks/classic/classic_benchmarks_utils.py
+++ b/avalanche/benchmarks/classic/classic_benchmarks_utils.py
@@ -1,0 +1,37 @@
+from torchvision.transforms import ToPILImage, ToTensor
+
+from avalanche.benchmarks.utils import AvalancheDataset
+
+
+def check_vision_benchmark(benchmark_instance, show_without_transforms=True):
+    from matplotlib import pyplot as plt
+    from torch.utils.data.dataloader import DataLoader
+    dataset: AvalancheDataset
+
+    print('The benchmark instance contains',
+          len(benchmark_instance.train_stream), 'training experiences.')
+
+    for i, exp in enumerate(benchmark_instance.train_stream):
+        dataset, t = exp.dataset, exp.task_label
+        if show_without_transforms:
+            dataset = dataset.replace_transforms(ToTensor(), None)
+
+        dl = DataLoader(dataset, batch_size=300)
+
+        print('Train experience', exp.current_experience)
+        for mb in dl:
+            x, y, *other = mb
+            print('X tensor:', x.shape)
+            print('Y tensor:', y.shape)
+            if len(other) > 0:
+                print('T tensor:', other[0].shape)
+            img = ToPILImage()(x[0])
+            plt.title('Experience: ' + str(exp.current_experience))
+            plt.imshow(img)
+            plt.show()
+            break  # Show only an image for each experience
+
+
+__all__ = [
+    'check_vision_benchmark'
+]

--- a/avalanche/benchmarks/classic/cmnist.py
+++ b/avalanche/benchmarks/classic/cmnist.py
@@ -8,10 +8,8 @@
 # E-mail: contact@continualai.org                                              #
 # Website: avalanche.continualai.org                                           #
 ################################################################################
-
-
+from pathlib import Path
 from typing import Optional, Sequence, Union, Any
-from os.path import expanduser
 import torch
 from PIL.Image import Image
 from torch import Tensor
@@ -21,6 +19,9 @@ from torchvision.transforms import ToTensor, ToPILImage, Compose, Normalize, \
 import numpy as np
 
 from avalanche.benchmarks import NCScenario, nc_benchmark
+from avalanche.benchmarks.classic.classic_benchmarks_utils import \
+    check_vision_benchmark
+from avalanche.benchmarks.datasets import default_dataset_location
 from avalanche.benchmarks.utils import AvalancheDataset
 
 _default_mnist_train_transform = Compose([
@@ -65,11 +66,14 @@ class PixelsPermutation(object):
 
 def SplitMNIST(
         n_experiences: int,
+        *,
         return_task_id=False,
         seed: Optional[int] = None,
         fixed_class_order: Optional[Sequence[int]] = None,
-        train_transform=_default_mnist_train_transform,
-        eval_transform=_default_mnist_eval_transform):
+        shuffle: bool = True,
+        train_transform: Optional[Any] = _default_mnist_train_transform,
+        eval_transform: Optional[Any] = _default_mnist_eval_transform,
+        dataset_root: Union[str, Path] = None):
     """
     Creates a CL scenario using the MNIST dataset.
 
@@ -107,6 +111,8 @@ def SplitMNIST(
         order. If None, value of ``seed`` will be used to define the class
         order. If non-None, ``seed`` parameter will be ignored.
         Defaults to None.
+    :param shuffle: If true, the class order in the incremental experiences is
+        randomly shuffled. Default to false.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -119,11 +125,13 @@ def SplitMNIST(
         comprehensive list of possible transformations).
         If no transformation is passed, the default test transformation
         will be used.
+    :param dataset_root: The root path of the dataset. Defaults to None, which
+        means that the default location for 'mnist' will be used.
 
     :returns: A properly initialized :class:`NCScenario` instance.
     """
 
-    mnist_train, mnist_test = _get_mnist_dataset()
+    mnist_train, mnist_test = _get_mnist_dataset(dataset_root)
 
     if return_task_id:
         return nc_benchmark(
@@ -133,6 +141,7 @@ def SplitMNIST(
             task_labels=True,
             seed=seed,
             fixed_class_order=fixed_class_order,
+            shuffle=shuffle,
             class_ids_from_zero_in_each_exp=True,
             train_transform=train_transform,
             eval_transform=eval_transform)
@@ -144,15 +153,18 @@ def SplitMNIST(
             task_labels=False,
             seed=seed,
             fixed_class_order=fixed_class_order,
+            shuffle=shuffle,
             train_transform=train_transform,
             eval_transform=eval_transform)
 
 
 def PermutedMNIST(
         n_experiences: int,
+        *,
         seed: Optional[int] = None,
-        train_transform: Any = _default_mnist_train_transform,
-        eval_transform: Any = _default_mnist_eval_transform) -> NCScenario:
+        train_transform: Optional[Any] = _default_mnist_train_transform,
+        eval_transform: Optional[Any] = _default_mnist_eval_transform,
+        dataset_root: Union[str, Path] = None) -> NCScenario:
     """
     Creates a Permuted MNIST scenario.
 
@@ -193,6 +205,8 @@ def PermutedMNIST(
         documentation for a comprehensive list of possible transformations).
         If no transformation is passed, the default test transformation
         will be used.
+    :param dataset_root: The root path of the dataset. Defaults to None, which
+        means that the default location for 'mnist' will be used.
 
     :returns: A properly initialized :class:`NCScenario` instance.
     """
@@ -201,7 +215,7 @@ def PermutedMNIST(
     list_test_dataset = []
     rng_permute = np.random.RandomState(seed)
 
-    mnist_train, mnist_test = _get_mnist_dataset()
+    mnist_train, mnist_test = _get_mnist_dataset(dataset_root)
 
     # for every incremental experience
     for _ in range(n_experiences):
@@ -244,10 +258,12 @@ def PermutedMNIST(
 
 def RotatedMNIST(
         n_experiences: int,
+        *,
         seed: Optional[int] = None,
         rotations_list: Optional[Sequence[int]] = None,
-        train_transform=_default_mnist_train_transform,
-        eval_transform=_default_mnist_eval_transform) -> NCScenario:
+        train_transform: Optional[Any] = _default_mnist_train_transform,
+        eval_transform: Optional[Any] = _default_mnist_eval_transform,
+        dataset_root: Union[str, Path] = None) -> NCScenario:
     """
     Creates a Rotated MNIST scenario.
 
@@ -294,6 +310,8 @@ def RotatedMNIST(
         documentation for a comprehensive list of possible transformations).
         If no transformation is passed, the default test transformation
         will be used.
+    :param dataset_root: The root path of the dataset. Defaults to None, which
+        means that the default location for 'mnist' will be used.
 
     :returns: A properly initialized :class:`NCScenario` instance.
     """
@@ -311,7 +329,7 @@ def RotatedMNIST(
     list_test_dataset = []
     rng_rotate = np.random.RandomState(seed)
 
-    mnist_train, mnist_test = _get_mnist_dataset()
+    mnist_train, mnist_test = _get_mnist_dataset(dataset_root)
 
     # for every incremental experience
     for exp in range(n_experiences):
@@ -354,11 +372,14 @@ def RotatedMNIST(
         eval_transform=eval_transform)
 
 
-def _get_mnist_dataset():
-    train_set = MNIST(root=expanduser("~") + "/.avalanche/data/mnist/",
+def _get_mnist_dataset(dataset_root):
+    if dataset_root is None:
+        dataset_root = default_dataset_location('mnist')
+
+    train_set = MNIST(root=dataset_root,
                       train=True, download=True)
 
-    test_set = MNIST(root=expanduser("~") + "/.avalanche/data/mnist/",
+    test_set = MNIST(root=dataset_root,
                      train=False, download=True)
 
     return train_set, test_set
@@ -372,13 +393,21 @@ __all__ = [
 
 
 if __name__ == "__main__":
-    import matplotlib.pyplot as plt
-    import numpy as np
-    from PIL import Image
+    import sys
 
-    scenario = PermutedMNIST(5, train_transform=None, eval_transform=None)
-    for i, (img, label) in enumerate(scenario.train_stream[0].dataset):
-        plt.imshow(np.asarray(img))
-        plt.show()
-        if ((i+1) % 5) == 0:
-            break
+    print('Split MNIST')
+    benchmark_instance = SplitMNIST(
+        5, train_transform=None, eval_transform=None)
+    check_vision_benchmark(benchmark_instance)
+
+    print('Permuted MNIST')
+    benchmark_instance = PermutedMNIST(
+        5, train_transform=None, eval_transform=None)
+    check_vision_benchmark(benchmark_instance)
+
+    print('Rotated MNIST')
+    benchmark_instance = RotatedMNIST(
+        5, train_transform=None, eval_transform=None)
+    check_vision_benchmark(benchmark_instance)
+
+    sys.exit(0)

--- a/avalanche/benchmarks/classic/core50.py
+++ b/avalanche/benchmarks/classic/core50.py
@@ -15,7 +15,8 @@ number of configuration parameters."""
 from pathlib import Path
 from typing import Union, Optional, Any
 
-from torchvision.transforms import ToTensor
+from torchvision.transforms import ToTensor, Normalize, Compose, \
+    RandomHorizontalFlip
 
 from avalanche.benchmarks.classic.classic_benchmarks_utils import \
     check_vision_benchmark
@@ -43,14 +44,29 @@ scen2dirs = {
 }
 
 
+normalize = Normalize(mean=[0.485, 0.456, 0.406],
+                      std=[0.229, 0.224, 0.225])
+
+_default_train_transform = Compose([
+    ToTensor(),
+    RandomHorizontalFlip(),
+    normalize
+])
+
+_default_eval_transform = Compose([
+    ToTensor(),
+    normalize
+])
+
+
 def CORe50(
         *,
         scenario: str = "nicv2_391",
         run: int = 0,
         object_lvl: bool = True,
         mini: bool = False,
-        train_transform: Optional[Any] = None,
-        eval_transform: Optional[Any] = None,
+        train_transform: Optional[Any] = _default_train_transform,
+        eval_transform: Optional[Any] = _default_eval_transform,
         dataset_root: Union[str, Path] = None):
     """
     Creates a CL scenario for CORe50.
@@ -144,9 +160,6 @@ __all__ = [
 if __name__ == "__main__":
     import sys
 
-    benchmark_instance = CORe50(scenario="nicv2_79",
-                                train_transform=ToTensor(),
-                                eval_transform=ToTensor(),
-                                mini=True)
+    benchmark_instance = CORe50(scenario="nicv2_79", mini=False)
     check_vision_benchmark(benchmark_instance)
     sys.exit(0)

--- a/avalanche/benchmarks/classic/openloris.py
+++ b/avalanche/benchmarks/classic/openloris.py
@@ -12,12 +12,17 @@
 """ This module contains the high-level OpenLORIS scenario/factor generator.
 It basically returns a iterable scenario object ``GenericCLScenario`` given
 a number of configuration parameters."""
+from pathlib import Path
+from typing import Union, Any, Optional
+from typing_extensions import Literal
 
+from avalanche.benchmarks.classic.classic_benchmarks_utils import \
+    check_vision_benchmark
 from avalanche.benchmarks.datasets.openloris import OpenLORIS as \
     OpenLORISDataset
 from avalanche.benchmarks.scenarios.generic_benchmark_creation import \
     create_generic_benchmark_from_filelists
-from os.path import expanduser
+
 
 nbatch = {
     'clutter': 9,
@@ -36,10 +41,13 @@ fac2dirs = {
 }
 
 
-def OpenLORIS(root=expanduser("~") + "/.avalanche/data/openloris/",
-              factor="clutter",
-              train_transform=None,
-              eval_transform=None):
+def OpenLORIS(
+        *,
+        factor: Literal['clutter', 'illumination',
+                        'occlusion', 'pixel', 'mixture-iros'] = "clutter",
+        train_transform: Optional[Any] = None,
+        eval_transform: Optional[Any] = None,
+        dataset_root: Union[str, Path] = None):
     """
     Creates a CL scenario for OpenLORIS.
 
@@ -61,7 +69,6 @@ def OpenLORIS(root=expanduser("~") + "/.avalanche/data/openloris/",
     generators. It is recommended to check the tutorial of the "benchmark" API,
     which contains usage examples ranging from "basic" to "advanced".
 
-    :param root: Base path where OpenLORIS data is stored.
     :param factor: OpenLORIS main factors, indicating different environmental
         variations. It can be chosen between 'clutter', 'illumination',
         'occlusion', 'pixel', or 'mixture-iros'. The first three factors are
@@ -75,6 +82,9 @@ def OpenLORIS(root=expanduser("~") + "/.avalanche/data/openloris/",
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
         comprehensive list of possible transformations). Defaults to None.
+    :param dataset_root: The root path of the dataset.
+        Defaults to None, which means that the default location for
+        'openloris' will be used.
 
     :returns: a properly initialized :class:`GenericCLScenario` instance.
     """
@@ -84,18 +94,19 @@ def OpenLORIS(root=expanduser("~") + "/.avalanche/data/openloris/",
                                       "'illumination', 'occlusion', " \
                                       "'pixel', or 'mixture-iros'."
 
-    dataset = OpenLORISDataset(root)
+    # Dataset created just to download it
+    dataset = OpenLORISDataset(dataset_root, download=True)
 
     filelists_bp = fac2dirs[factor] + "/"
     train_failists_paths = []
     for i in range(nbatch[factor]):
         train_failists_paths.append(
-            root + filelists_bp + "train_batch_" +
-            str(i).zfill(2) + ".txt")
+            dataset_root / filelists_bp / ("train_batch_" +
+                                           str(i).zfill(2) + ".txt"))
 
     factor_obj = create_generic_benchmark_from_filelists(
-        root, train_failists_paths,
-        [root + filelists_bp + "test.txt"],
+        dataset_root, train_failists_paths,
+        [dataset_root / filelists_bp / "test.txt"],
         task_labels=[0 for _ in range(nbatch[factor])],
         complete_test_set_only=True,
         train_transform=train_transform,
@@ -109,19 +120,9 @@ __all__ = [
 ]
 
 if __name__ == "__main__":
-
-    # this below can be taken as a usage example or a simple test script
     import sys
-    from torch.utils.data.dataloader import DataLoader
 
-    factor = OpenLORIS(factor="clutter")
-    for i, batch in enumerate(factor.train_stream):
-        print(i, batch)
-        dataset, t = batch.dataset, batch.task_label
-        dl = DataLoader(dataset, batch_size=128)
-
-        for mb in dl:
-            x, y = mb
-            print(x.shape)
-            print(y.shape)
-        sys.exit(0)
+    # Untested!
+    benchmark_instance = OpenLORIS()
+    check_vision_benchmark(benchmark_instance)
+    sys.exit(0)

--- a/avalanche/benchmarks/classic/stream51.py
+++ b/avalanche/benchmarks/classic/stream51.py
@@ -8,7 +8,8 @@
 # E-mail: contact@continualai.org                                              #
 # Website: www.continualai.org                                                 #
 ################################################################################
-from os.path import expanduser
+from pathlib import Path
+from typing import Union
 
 from typing_extensions import Literal
 
@@ -56,14 +57,19 @@ def _adjust_bbox(img_shapes, bbox, ratio=1.1):
     return [bbox[3], bbox[1], bbox[2] - bbox[3], bbox[0] - bbox[1]]
 
 
-def CLStream51(root: str = expanduser("~") + "/.avalanche/data/stream51/",
-               scenario: Literal[
-                   'iid', 'class_iid', 'instance',
-                   'class_instance'] = "class_instance",
-               seed=10, eval_num=None, bbox_crop=True, ratio: float = 1.10,
-               download=True,
-               train_transform=_default_stream51_transform,
-               eval_transform=_default_stream51_transform):
+def CLStream51(
+        *,
+        scenario: Literal[
+            'iid', 'class_iid', 'instance',
+            'class_instance'] = "class_instance",
+        seed=10,
+        eval_num=None,
+        bbox_crop=True,
+        ratio: float = 1.10,
+        download=True,
+        train_transform=_default_stream51_transform,
+        eval_transform=_default_stream51_transform,
+        dataset_root: Union[str, Path] = None):
     """
     Creates a CL scenario for Stream-51.
 
@@ -85,9 +91,6 @@ def CLStream51(root: str = expanduser("~") + "/.avalanche/data/stream51/",
     generators. It is recommended to check the tutorial of the "benchmark" API,
     which contains usage examples ranging from "basic" to "advanced".
 
-    :param root: Path indicating where to store the dataset and related
-        metadata. By default they will be stored in
-        "~/.avalanche/datasets/stream51/data/".
     :param scenario: A string defining which Stream-51 scenario to return.
         Can be chosen between 'iid', 'class_iid', 'instance', and
         'class_instance'. Defaults to 'class_instance'.
@@ -116,15 +119,19 @@ def CLStream51(root: str = expanduser("~") + "/.avalanche/data/stream51/",
         comprehensive list of possible transformations).
         If no transformation is passed, the default eval transformation
         will be used.
+    :param dataset_root: The root path of the dataset.
+        Defaults to None, which means that the default location for
+        'stream51' will be used.
 
     :returns: A properly initialized :class:`GenericCLScenario` instance.
     """
 
     # get train and test sets and order them by scenario
-    train_set = Stream51(root, train=True, download=download)
-    test_set = Stream51(root, train=False, download=download)
+    train_set = Stream51(root=dataset_root, train=True, download=download)
+    test_set = Stream51(root=dataset_root, train=False, download=download)
     samples = Stream51.make_dataset(train_set.samples, ordering=scenario,
                                     seed=seed)
+    dataset_root = train_set.root
 
     # set appropriate train parameters
     train_set.samples = samples
@@ -153,7 +160,7 @@ def CLStream51(root: str = expanduser("~") + "/.avalanche/data/stream51/",
         for i in range(num_tasks):
             end = min(start + eval_num, len(train_set))
             train_filelists_paths.append(
-                [(os.path.join(root, train_set.samples[j][-1]),
+                [(os.path.join(dataset_root, train_set.samples[j][-1]),
                   train_set.samples[j][0],
                   _adjust_bbox(train_set.samples[j][-3],
                                train_set.samples[j][-2],
@@ -162,12 +169,12 @@ def CLStream51(root: str = expanduser("~") + "/.avalanche/data/stream51/",
             start = end
 
         # use all test data for instance ordering
-        test_filelists_paths = [(os.path.join(root, test_set.samples[j][-1]),
-                                 test_set.samples[j][0],
-                                 _adjust_bbox(test_set.samples[j][-3],
-                                              test_set.samples[j][-2],
-                                              ratio)) for
-                                j in range(len(test_set))]
+        test_filelists_paths = \
+            [(os.path.join(dataset_root, test_set.samples[j][-1]),
+              test_set.samples[j][0],
+              _adjust_bbox(test_set.samples[j][-3],
+                           test_set.samples[j][-2],
+                           ratio)) for j in range(len(test_set))]
         test_ood_filelists_paths = None  # no ood testing for instance ordering
     elif scenario == 'class_instance':
         # break files into task lists based on classes
@@ -195,19 +202,19 @@ def CLStream51(root: str = expanduser("~") + "/.avalanche/data/stream51/",
                 else:
                     test_ood_files.append(ix)
             test_filelists_paths.append(
-                [(os.path.join(root, test_set.samples[j][-1]),
+                [(os.path.join(dataset_root, test_set.samples[j][-1]),
                   test_set.samples[j][0],
                   _adjust_bbox(test_set.samples[j][-3], test_set.samples[j][-2],
                                ratio)) for j in
                  test_files])
             test_ood_filelists_paths.append(
-                [(os.path.join(root, test_set.samples[j][-1]),
+                [(os.path.join(dataset_root, test_set.samples[j][-1]),
                   test_set.samples[j][0],
                   _adjust_bbox(test_set.samples[j][-3], test_set.samples[j][-2],
                                ratio)) for j in
                  test_ood_files])
             train_filelists_paths.append(
-                [(os.path.join(root, train_set.samples[j][-1]),
+                [(os.path.join(dataset_root, train_set.samples[j][-1]),
                   train_set.samples[j][0],
                   _adjust_bbox(train_set.samples[j][-3],
                                train_set.samples[j][-2],
@@ -244,8 +251,6 @@ __all__ = [
 ]
 
 if __name__ == "__main__":
-
-    # this code can be taken as a usage example or a simple test script
     from torch.utils.data.dataloader import DataLoader
     from torchvision import transforms
     import matplotlib.pyplot as plt

--- a/avalanche/benchmarks/datasets/core50/core50.py
+++ b/avalanche/benchmarks/datasets/core50/core50.py
@@ -23,7 +23,7 @@ from torchvision.datasets.folder import default_loader
 from torchvision.transforms import ToTensor
 
 from avalanche.benchmarks.datasets.core50 import core50_data
-from avalanche.benchmarks.datasets import get_default_dataset_location
+from avalanche.benchmarks.datasets import default_dataset_location
 from avalanche.benchmarks.datasets.downloadable_dataset import \
     DownloadableDataset
 
@@ -33,7 +33,7 @@ class CORe50Dataset(DownloadableDataset):
 
     def __init__(
             self,
-            root: Union[str, Path] = get_default_dataset_location('core50'),
+            root: Union[str, Path] = None,
             *,
             train=True, transform=None, target_transform=None,
             loader=default_loader, download=True, mini=False,
@@ -42,7 +42,8 @@ class CORe50Dataset(DownloadableDataset):
         """
         Creates an instance of the CORe50 dataset.
 
-        :param root: root for the datasets data.
+        :param root: root for the datasets data. Defaults to None, which means
+        that the default location for 'core50' will be used.
         :param train: train or test split.
         :param transform: eventual transformations to be applied.
         :param target_transform: eventual transformation to be applied to the
@@ -56,6 +57,9 @@ class CORe50Dataset(DownloadableDataset):
             category based: 50 or 10 way classification problem. Default to True
             (50-way object classification problem)
         """
+
+        if root is None:
+            root = default_dataset_location('core50')
 
         super(CORe50Dataset, self).__init__(
             root, download=download, verbose=True)

--- a/avalanche/benchmarks/datasets/cub200/cub200.py
+++ b/avalanche/benchmarks/datasets/cub200/cub200.py
@@ -26,7 +26,7 @@ import os
 from collections import OrderedDict
 from torchvision.datasets.folder import default_loader
 
-from avalanche.benchmarks.datasets import get_default_dataset_location, \
+from avalanche.benchmarks.datasets import default_dataset_location, \
     DownloadableDataset
 from avalanche.benchmarks.utils import PathsDataset
 
@@ -47,15 +47,15 @@ class CUB200(PathsDataset, DownloadableDataset):
 
     def __init__(
             self,
-            root: Union[str, Path] =
-            get_default_dataset_location('CUB_200_2011'),
+            root: Union[str, Path] = None,
             *,
             train=True, transform=None, target_transform=None,
             loader=default_loader, download=True):
         """
 
         :param root: root dir where the dataset can be found or downloaded.
-            Default to '~/.avalanche/data/CUB_200_2011'.
+            Defaults to None, which means that the default location for
+            'CUB_200_2011' will be used.
         :param train: train or test subset of the original dataset. Default
             to True.
         :param transform: eventual input data transformations to apply.
@@ -67,6 +67,9 @@ class CUB200(PathsDataset, DownloadableDataset):
         :param download: default set to True. If the data is already
             downloaded it will skip the download.
         """
+
+        if root is None:
+            root = default_dataset_location('CUB_200_2011')
 
         self.train = train
 

--- a/avalanche/benchmarks/datasets/dataset_utils.py
+++ b/avalanche/benchmarks/datasets/dataset_utils.py
@@ -12,7 +12,7 @@
 from pathlib import Path
 
 
-def get_default_dataset_location(dataset_name: str) -> Path:
+def default_dataset_location(dataset_name: str) -> Path:
     """
     Return the default location of a dataset.
 
@@ -27,5 +27,5 @@ def get_default_dataset_location(dataset_name: str) -> Path:
 
 
 __all__ = [
-    'get_default_dataset_location'
+    'default_dataset_location'
 ]

--- a/avalanche/benchmarks/datasets/downloadable_dataset.py
+++ b/avalanche/benchmarks/datasets/downloadable_dataset.py
@@ -21,7 +21,7 @@ from torchvision.datasets.utils import download_and_extract_archive, \
     extract_archive, download_url, check_integrity
 
 from avalanche.benchmarks.datasets.dataset_utils import \
-    get_default_dataset_location
+    default_dataset_location
 
 
 class DownloadableDataset(Dataset[T_co], ABC):
@@ -78,7 +78,7 @@ class DownloadableDataset(Dataset[T_co], ABC):
 
         :param root: The root path where the dataset will be downloaded.
             Consider passing a path obtained by calling
-            `get_default_dataset_location` with the name of the dataset.
+            `default_dataset_location` with the name of the dataset.
         :param download: If True, the dataset will be downloaded if needed.
             If False and the dataset can't be loaded from the provided root
             path, an error will be raised when calling the `_load_dataset`
@@ -343,7 +343,7 @@ class SimpleDownloadableDataset(DownloadableDataset[T_co], ABC):
 
         :param root_or_dataset_name: The root path where the dataset will be
             downloaded. If a directory name is passed, then the root obtained by
-            calling `get_default_dataset_location` will be used (recommended).
+            calling `default_dataset_location` will be used (recommended).
             To check if this parameter is a path, the constructor will check if
             it contains the '\' or '/' characters or if it is a Path instance.
         :param url: The url of the archive.
@@ -367,7 +367,7 @@ class SimpleDownloadableDataset(DownloadableDataset[T_co], ABC):
         if is_path:
             root = Path(root_or_dataset_name)
         else:
-            root = get_default_dataset_location(root_or_dataset_name)
+            root = default_dataset_location(root_or_dataset_name)
 
         super(SimpleDownloadableDataset, self).__init__(
             root, download=download, verbose=verbose)

--- a/avalanche/benchmarks/datasets/openloris/openloris.py
+++ b/avalanche/benchmarks/datasets/openloris/openloris.py
@@ -12,23 +12,41 @@
 """ OpenLoris Pytorch Dataset """
 
 import pickle as pkl
+from pathlib import Path
+from typing import Union
 
 import gdown
 from torchvision.datasets.folder import default_loader
 from torchvision.transforms import ToTensor
 
 from avalanche.benchmarks.datasets import DownloadableDataset, \
-    get_default_dataset_location
+    default_dataset_location
 from avalanche.benchmarks.datasets.openloris import openloris_data
 
 
 class OpenLORIS(DownloadableDataset):
     """ OpenLORIS Pytorch Dataset """
 
-    def __init__(self, root=get_default_dataset_location('openloris'),
+    def __init__(self, root: Union[str, Path] = None,
                  *,
                  train=True, transform=None, target_transform=None,
                  loader=default_loader, download=True):
+        """
+        Creates an instance of the OpenLORIS dataset.
+
+        :param root: The directory where the dataset can be found or downloaded.
+            Defaults to None, which means that the default location for
+            'openloris' will be used.
+        :param train: If True, the training set will be returned. If False,
+            the test set will be returned.
+        :param transform: The transformations to apply to the X values.
+        :param target_transform: The transformations to apply to the Y values.
+        :param loader: The image loader to use.
+        :param download: If True, the dataset will be downloaded if needed.
+        """
+
+        if root is None:
+            root = default_dataset_location('openloris')
 
         self.train = train  # training set or test set
         self.transform = transform

--- a/avalanche/benchmarks/datasets/stream51/stream51.py
+++ b/avalanche/benchmarks/datasets/stream51/stream51.py
@@ -16,6 +16,8 @@ import os
 import shutil
 import json
 import random
+from pathlib import Path
+from typing import Union
 
 from torchvision.datasets.folder import default_loader
 from zipfile import ZipFile
@@ -23,17 +25,33 @@ from zipfile import ZipFile
 from torchvision.transforms import ToTensor
 
 from avalanche.benchmarks.datasets import DownloadableDataset, \
-    get_default_dataset_location
+    default_dataset_location
 from avalanche.benchmarks.datasets.stream51 import stream51_data
 
 
 class Stream51(DownloadableDataset):
     """ Stream-51 Pytorch Dataset """
 
-    def __init__(self, root=get_default_dataset_location('stream51'),
+    def __init__(self, root: Union[str, Path] = None,
                  *,
                  train=True, transform=None,
                  target_transform=None, loader=default_loader, download=True):
+        """
+        Creates an instance of the Stream-51 dataset.
+
+        :param root: The directory where the dataset can be found or downloaded.
+            Defaults to None, which means that the default location for
+            'stream51' will be used.
+        :param train: If True, the training set will be returned. If False,
+            the test set will be returned.
+        :param transform: The transformations to apply to the X values.
+        :param target_transform: The transformations to apply to the Y values.
+        :param loader: The image loader to use.
+        :param download: If True, the dataset will be downloaded if needed.
+        """
+
+        if root is None:
+            root = default_dataset_location('stream51')
 
         self.train = train  # training set or test set
         self.transform = transform

--- a/avalanche/benchmarks/datasets/tiny_imagenet/tiny_imagenet.py
+++ b/avalanche/benchmarks/datasets/tiny_imagenet/tiny_imagenet.py
@@ -19,7 +19,7 @@ from torchvision.datasets.folder import default_loader
 from torchvision.transforms import ToTensor
 
 from avalanche.benchmarks.datasets import SimpleDownloadableDataset, \
-    get_default_dataset_location
+    default_dataset_location
 
 
 class TinyImagenet(SimpleDownloadableDataset):
@@ -31,8 +31,7 @@ class TinyImagenet(SimpleDownloadableDataset):
 
     def __init__(
             self,
-            root: Union[str, Path] =
-            get_default_dataset_location('tinyimagenet'),
+            root: Union[str, Path] = None,
             *,
             train: bool = True,
             transform=None,
@@ -42,7 +41,9 @@ class TinyImagenet(SimpleDownloadableDataset):
         """
         Creates an instance of the Tiny Imagenet dataset.
 
-        :param root: folder in which to download dataset.
+        :param root: folder in which to download dataset. Defaults to None,
+            which means that the default location for 'tinyimagenet' will be
+            used.
         :param train: True for training set, False for test set.
         :param transform: Pytorch transformation function for x.
         :param target_transform: Pytorch transformation function for y.
@@ -50,6 +51,10 @@ class TinyImagenet(SimpleDownloadableDataset):
         :param bool download: If True, the dataset will be  downloaded if
             needed.
         """
+
+        if root is None:
+            root = default_dataset_location('tinyimagenet')
+
         self.transform = transform
         self.target_transform = target_transform
         self.train = train

--- a/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_classes/nc_scenario.py
@@ -266,8 +266,9 @@ class NCScenario(GenericCLScenario['NCExperience']):
             # by the number of experiences
             if self.n_classes % n_experiences > 0:
                 raise ValueError(
-                    'Invalid number of experiences: classes contained in '
-                    'dataset cannot be divided by n_experiences')
+                    f'Invalid number of experiences: classes contained in '
+                    f'dataset ({self.n_classes}) cannot be divided by '
+                    f'n_experiences ({n_experiences})')
             self.n_classes_per_exp = \
                 [self.n_classes // n_experiences] * n_experiences
 

--- a/tests/test_avalanche_dataset.py
+++ b/tests/test_avalanche_dataset.py
@@ -1232,7 +1232,7 @@ class AvalancheDatasetTests(unittest.TestCase):
                                             all_targets[leaf_range]))
 
             self.assertTrue(torch.equal(tensor_y,
-                                        torch.tensor(all_targets)[-d_sz:]))
+                                        all_targets[-d_sz:]))
 
         self.assertEqual(d_sz * dataset_hierarchy_depth + d_sz, len(leaf))
 

--- a/tests/test_nc_sit_scenario.py
+++ b/tests/test_nc_sit_scenario.py
@@ -8,7 +8,7 @@ from torch import Tensor
 from torchvision.datasets import MNIST
 from torchvision.transforms import ToTensor
 
-from avalanche.benchmarks.datasets import CIFAR100, get_default_dataset_location
+from avalanche.benchmarks.datasets import CIFAR100, default_dataset_location
 from avalanche.benchmarks.scenarios.new_classes import NCExperience
 from avalanche.benchmarks.utils import AvalancheSubset, AvalancheDataset
 from avalanche.benchmarks.scenarios.new_classes.nc_utils import \
@@ -358,10 +358,10 @@ class SITTests(unittest.TestCase):
         self.assertIsInstance(ds_test_train[0][0], Tensor)
 
     def test_nc_benchmark_classes_in_exp_range(self):
-        train_set = CIFAR100(get_default_dataset_location('cifar100'),
+        train_set = CIFAR100(default_dataset_location('cifar100'),
                              train=True, download=True)
 
-        test_set = CIFAR100(get_default_dataset_location('cifar100'),
+        test_set = CIFAR100(default_dataset_location('cifar100'),
                             train=False, download=True)
 
         benchmark_instance = nc_benchmark(


### PR DESCRIPTION
This PR completes the standardization of classic benchmarks. Parameter names should now be uniform across all classic benchmarks.

A small utility function has been added to quickly check if a benchmark is implemented correctly. All benchmarks now have a `__main__` section with a small test using that utility function.

This also fixes an unreported issue with PermutedOmniglot.

Closes #557