### PR TITLE
OpenLORIS GDrive Links Changed to Avl VPS

### DIFF
--- a/avalanche/benchmarks/datasets/openloris/openloris.py
+++ b/avalanche/benchmarks/datasets/openloris/openloris.py
@@ -43,7 +43,7 @@ class OpenLORIS(DownloadableDataset):
         for name in data2download:
             if self.verbose:
                 print("Downloading " + name[1] + "...")
-            file = self._download_file(name[1], name[0])
+            file = self._download_file(name[1], name[0], name[2])
             if name[1].endswith('.zip'):
                 if self.verbose:
                     print(f'Extracting {name[0]}...')
@@ -95,7 +95,7 @@ class OpenLORIS(DownloadableDataset):
     def _download_error_message(self) -> str:
         base_url = openloris_data.base_gdrive_url
         all_urls = [
-            base_url + name_url[1] for name_url in openloris_data.filename
+            base_url + name_url[1] for name_url in openloris_data.avl_vps_data
         ]
 
         base_msg = \
@@ -113,11 +113,11 @@ class OpenLORIS(DownloadableDataset):
     def _check_integrity(self):
         """ Checks if the data is already available and intact """
 
-        for name, googledrive_id in openloris_data.filename:
+        for name, url, md5 in openloris_data.avl_vps_data:
             filepath = self.root / name
             if not filepath.is_file():
                 if self.verbose:
-                    print('[CUB200] Error checking integrity of:',
+                    print('[OpenLORIS] Error checking integrity of:',
                           str(filepath))
                 return False
         return True

--- a/avalanche/benchmarks/datasets/openloris/openloris.py
+++ b/avalanche/benchmarks/datasets/openloris/openloris.py
@@ -13,7 +13,6 @@
 
 import pickle as pkl
 
-import gdown
 from torchvision.datasets.folder import default_loader
 from torchvision.transforms import ToTensor
 
@@ -39,15 +38,18 @@ class OpenLORIS(DownloadableDataset):
         self._load_dataset()
 
     def _download_dataset(self) -> None:
-        for name in openloris_data.filename:
-            filepath = self.root / name[0]
-            if not filepath.exists():
+        data2download = openloris_data.avl_vps_data
+
+        for name in data2download:
+            if self.verbose:
+                print("Downloading " + name[1] + "...")
+            file = self._download_file(name[1], name[0])
+            if name[1].endswith('.zip'):
                 if self.verbose:
-                    print('[OpenLoris] Start downloading {}...'.format(name[0]))
-                url = openloris_data.base_gdrive_url + name[1]
-                gdown.download(url, str(filepath), quiet=False)
-                gdown.cached_download(url, str(filepath))
-            self._extract_archive(filepath)
+                    print(f'Extracting {name[0]}...')
+                self._extract_archive(file)
+                if self.verbose:
+                    print('Extraction completed!')
 
     def _load_metadata(self) -> bool:
         if not self._check_integrity():

--- a/avalanche/benchmarks/datasets/openloris/openloris_data.py
+++ b/avalanche/benchmarks/datasets/openloris/openloris_data.py
@@ -13,7 +13,7 @@
 
 
 base_gdrive_url = "https://drive.google.com/u/0/uc?id="
-filename = [
+gdrive_data = [
     ('train.zip',
      '11jgiPB2Z9WRI3bW6VSN8fJZgwFl5mLsF'),
     ('valid.zip',
@@ -29,9 +29,25 @@ filename = [
     ('batches_filelists.zip',
      '1r0gbo5_Qlzrdet1GPIrJpVSGRgFU7NEp')
 ]
-
+avl_vps_data = [
+    ('train.zip',
+     'http://vps.continualai.org/data/openloris/train.zip'),
+    ('valid.zip',
+     'http://vps.continualai.org/data/openloris/valid.zip'),
+    ('test.zip',
+     'http://vps.continualai.org/data/openloris/test.zip'),
+    ('LUP.pkl',
+     'http://vps.continualai.org/data/openloris/LUP.pkl'),
+    ('Paths.pkl',
+     'http://vps.continualai.org/data/openloris/Paths.pkl'),
+    ('Labels.pkl',
+     'http://vps.continualai.org/data/openloris/Labels.pkl'),
+    ('batches_filelists.zip',
+     'http://vps.continualai.org/data/openloris/batches_filelists.zip')
+]
 
 __all__ = [
     'base_gdrive_url',
-    'filename'
+    'gdrive_data',
+    'avl_vps_data'
 ]

--- a/avalanche/benchmarks/datasets/openloris/openloris_data.py
+++ b/avalanche/benchmarks/datasets/openloris/openloris_data.py
@@ -31,19 +31,26 @@ gdrive_data = [
 ]
 avl_vps_data = [
     ('train.zip',
-     'http://vps.continualai.org/data/openloris/train.zip'),
-    ('valid.zip',
-     'http://vps.continualai.org/data/openloris/valid.zip'),
+     'http://vps.continualai.org/data/openloris/train.zip',
+     '91c5748e86a7552d346dbe73713b8867'),
+    ('validation.zip',
+     'http://vps.continualai.org/data/openloris/validation.zip',
+     'c9fd4f72e24d724b3208d032401db068'),
     ('test.zip',
-     'http://vps.continualai.org/data/openloris/test.zip'),
+     'http://vps.continualai.org/data/openloris/test.zip',
+     '9a87a4a6ffc16d3daa9249fe032ae734'),
     ('LUP.pkl',
-     'http://vps.continualai.org/data/openloris/LUP.pkl'),
+     'http://vps.continualai.org/data/openloris/LUP.pkl',
+     'c157c44fe7b9de9017cb555bb86f1530'),
     ('Paths.pkl',
-     'http://vps.continualai.org/data/openloris/Paths.pkl'),
+     'http://vps.continualai.org/data/openloris/Paths.pkl',
+     '468b7a942a143439ee6b8bfec952aca2'),
     ('Labels.pkl',
-     'http://vps.continualai.org/data/openloris/Labels.pkl'),
+     'http://vps.continualai.org/data/openloris/Labels.pkl',
+     'cb7dca60a3fc10a05b21e9ea2f3a8d93'),
     ('batches_filelists.zip',
-     'http://vps.continualai.org/data/openloris/batches_filelists.zip')
+     'http://vps.continualai.org/data/openloris/batches_filelists.zip',
+     '32baf71c525eb018d6912412763bda1d')
 ]
 
 __all__ = [


### PR DESCRIPTION
This PR closes #617. It uses the new continualai vps with openloris mirrors to download the data.
This still needs to be tested since the vps is currently down. 