### PR TITLE
Fixed isinstance on Base Strategy to enable benchmarks with task label per pattern

### DIFF
--- a/avalanche/evaluation/metrics/accuracy.py
+++ b/avalanche/evaluation/metrics/accuracy.py
@@ -9,7 +9,7 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from typing import TYPE_CHECKING, List
+from typing import List
 
 import torch
 from torch import Tensor

--- a/avalanche/evaluation/metrics/confusion_matrix.py
+++ b/avalanche/evaluation/metrics/confusion_matrix.py
@@ -246,7 +246,8 @@ class StreamConfusionMatrix(PluginMetric[Tensor]):
                  normalize: Literal['true', 'pred', 'all'] = None,
                  save_image: bool = True,
                  image_creator: Callable[[Tensor, Sequence], Image] =
-                 default_cm_image_creator, absolute_class_order: bool = False):
+                 default_cm_image_creator,
+                 absolute_class_order: bool = False):
         """
         Creates an instance of the Stream Confusion Matrix metric.
 

--- a/avalanche/training/strategies/base_strategy.py
+++ b/avalanche/training/strategies/base_strategy.py
@@ -218,12 +218,12 @@ class BaseStrategy:
         self.model.to(self.device)
 
         # Normalize training and eval data.
-        if isinstance(experiences, Experience):
+        if not isinstance(experiences, Sequence):
             experiences = [experiences]
         if eval_streams is None:
             eval_streams = [experiences]
         for i, exp in enumerate(eval_streams):
-            if isinstance(exp, Experience):
+            if not isinstance(exp, Sequence):
                 eval_streams[i] = [exp]
 
         self.before_training(**kwargs)
@@ -322,7 +322,7 @@ class BaseStrategy:
         self.is_training = False
         self.model.eval()
 
-        if isinstance(exp_list, Experience):
+        if not isinstance(exp_list, Sequence):
             exp_list = [exp_list]
 
         self.before_eval(**kwargs)

--- a/tests/test_avalanche_dataset.py
+++ b/tests/test_avalanche_dataset.py
@@ -315,16 +315,21 @@ class AvalancheDatasetTests(unittest.TestCase):
             subset_task11 = dataset.task_set[11]
 
     def test_avalanche_tensor_dataset_task_labels_train(self):
-        tr_ds = [AvalancheTensorDataset(torch.randn(10, 4), torch.randint(0, 3, (10,)),
-                                        dataset_type=AvalancheDatasetType.CLASSIFICATION,
-                                        task_labels=torch.randint(0, 5, (10,)).tolist()) for i in range(3)]
-        ts_ds = [AvalancheTensorDataset(torch.randn(10, 4), torch.randint(0, 3, (10,)),
-                                        dataset_type=AvalancheDatasetType.CLASSIFICATION,
-                                        task_labels=torch.randint(0, 5, (10,)).tolist()) for i in range(3)]
+        tr_ds = [AvalancheTensorDataset(
+            torch.randn(10, 4),
+            torch.randint(0, 3, (10,)),
+            dataset_type=AvalancheDatasetType.CLASSIFICATION,
+            task_labels=torch.randint(0, 5, (10,)).tolist()) for i in range(3)]
+        ts_ds = [AvalancheTensorDataset(
+            torch.randn(10, 4), torch.randint(0, 3, (10,)),
+            dataset_type=AvalancheDatasetType.CLASSIFICATION,
+            task_labels=torch.randint(0, 5, (10,)).tolist()) for i in range(3)]
         scenario = dataset_benchmark(train_datasets=tr_ds, test_datasets=ts_ds)
         model = SimpleMLP(input_size=4, num_classes=3)
-        cl_strategy = Naive(model, SGD(model.parameters(), lr=0.001, momentum=0.9),
-                            CrossEntropyLoss(), train_mb_size=5, train_epochs=1, eval_mb_size=5,
+        cl_strategy = Naive(model, SGD(model.parameters(), lr=0.001,
+                                       momentum=0.9),
+                            CrossEntropyLoss(), train_mb_size=5,
+                            train_epochs=1, eval_mb_size=5,
                             device='cpu', evaluator=None)
         exp = []
         for i, experience in enumerate(scenario.train_stream):

--- a/tests/test_avalanche_dataset.py
+++ b/tests/test_avalanche_dataset.py
@@ -1,7 +1,11 @@
 import unittest
 
 from os.path import expanduser
-
+from avalanche.models import SimpleMLP
+from torch.optim import SGD
+from torch.nn import CrossEntropyLoss
+from avalanche.training.strategies import Naive
+from avalanche.benchmarks.generators import dataset_benchmark
 import PIL
 import torch
 from PIL import ImageChops
@@ -309,6 +313,24 @@ class AvalancheDatasetTests(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             subset_task11 = dataset.task_set[11]
+
+    def test_avalanche_tensor_dataset_task_labels_train(self):
+        tr_ds = [AvalancheTensorDataset(torch.randn(10, 4), torch.randint(0, 3, (10,)),
+                                        dataset_type=AvalancheDatasetType.CLASSIFICATION,
+                                        task_labels=torch.randint(0, 5, (10,)).tolist()) for i in range(3)]
+        ts_ds = [AvalancheTensorDataset(torch.randn(10, 4), torch.randint(0, 3, (10,)),
+                                        dataset_type=AvalancheDatasetType.CLASSIFICATION,
+                                        task_labels=torch.randint(0, 5, (10,)).tolist()) for i in range(3)]
+        scenario = dataset_benchmark(train_datasets=tr_ds, test_datasets=ts_ds)
+        model = SimpleMLP(input_size=4, num_classes=3)
+        cl_strategy = Naive(model, SGD(model.parameters(), lr=0.001, momentum=0.9),
+                            CrossEntropyLoss(), train_mb_size=5, train_epochs=1, eval_mb_size=5,
+                            device='cpu', evaluator=None)
+        exp = []
+        for i, experience in enumerate(scenario.train_stream):
+            exp.append(i)
+            cl_strategy.train(experience)
+        self.assertEqual(len(exp), 3)
 
     def test_avalanche_dataset_task_labels_inheritance(self):
         dataset_mnist = MNIST(root=expanduser("~") + "/.avalanche/data/mnist/",


### PR DESCRIPTION
This closes #657 , implementing @lrzpellegrini 's suggestion. 

The `isinstance(experience, Experience)` call is modified to `not isinstance(experience, Sequence)`.