### PR TITLE
[training] Warn if using disabled callbacks in strategies

### DIFF
--- a/avalanche/training/strategies/base_strategy.py
+++ b/avalanche/training/strategies/base_strategy.py
@@ -619,7 +619,10 @@ class BaseStrategy:
                 callback = getattr(plugin, disabled_callback_name)
                 callback_class = callback.__qualname__.split('.')[0]
                 if callback_class not in (
-                    "StrategyPlugin", "PluginMetric", "EvaluationPlugin"
+                    "StrategyPlugin",
+                    "PluginMetric",
+                    "EvaluationPlugin",
+                    "GenericPluginMetric",
                 ):
                     logger.warning(
                         f"{plugin.__class__.__name__} seems to use "

--- a/avalanche/training/strategies/deep_slda.py
+++ b/avalanche/training/strategies/deep_slda.py
@@ -12,6 +12,8 @@ from avalanche.models import FeatureExtractorBackbone
 
 
 class StreamingLDA(BaseStrategy):
+    DISABLED_CALLBACKS = ("before_backward", "after_backward")
+
     """
     Deep Streaming Linear Discriminant Analysis.
     This strategy does not use backpropagation.

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -20,7 +20,7 @@ from torch.nn import CrossEntropyLoss, Linear
 from avalanche.logging import TextLogger
 from avalanche.models import SimpleMLP
 from avalanche.training.plugins import EvaluationPlugin, StrategyPlugin, \
-    LwFPlugin
+    LwFPlugin, ReplayPlugin
 from avalanche.training.strategies import Naive, Replay, CWRStar, \
     GDumb, LwF, AGEM, GEM, EWC, \
     SynapticIntelligence, JointTraining, CoPE, StreamingLDA, BaseStrategy
@@ -245,7 +245,8 @@ class StrategyTest(unittest.TestCase):
         with self.assertLogs('avalanche.training.strategies', "WARNING") as cm:
             StreamingLDA(model, criterion, input_size=10,
                          output_layer_name='features', num_classes=10,
-                         plugins=[LwFPlugin()])
+                         plugins=[LwFPlugin(), ReplayPlugin()])
+        self.assertEqual(1, len(cm.output))
         self.assertIn(
             "LwFPlugin seems to use the callback before_backward"
             " which is disabled by StreamingLDA",

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -19,11 +19,11 @@ from torch.nn import CrossEntropyLoss, Linear
 
 from avalanche.logging import TextLogger
 from avalanche.models import SimpleMLP
-from avalanche.training.plugins import EvaluationPlugin, StrategyPlugin
+from avalanche.training.plugins import EvaluationPlugin, StrategyPlugin, \
+    LwFPlugin
 from avalanche.training.strategies import Naive, Replay, CWRStar, \
     GDumb, LwF, AGEM, GEM, EWC, \
     SynapticIntelligence, JointTraining, CoPE, StreamingLDA, BaseStrategy
-from avalanche.training.strategies.ar1 import AR1
 from avalanche.training.strategies.cumulative import Cumulative
 from avalanche.training.strategies.strategy_wrappers import PNNStrategy
 from avalanche.training.strategies.icarl import ICaRL
@@ -239,6 +239,19 @@ class StrategyTest(unittest.TestCase):
                                 train_epochs=1, device=self.device,
                                 train_mb_size=7)
         self.run_strategy(my_nc_benchmark, strategy)
+
+    def test_warning_slda_lwf(self):
+        model, _, criterion, my_nc_benchmark = self.init_sit()
+        with self.assertLogs('avalanche.training.strategies', "WARNING") as cm:
+            StreamingLDA(model, criterion, input_size=10,
+                         output_layer_name='features', num_classes=10,
+                         plugins=[LwFPlugin()])
+        self.assertIn(
+            "LwFPlugin seems to use the callback before_backward"
+            " which is disabled by StreamingLDA",
+            cm.output[0]
+        )
+
 
     def test_lwf(self):
         # SIT scenario

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -253,7 +253,6 @@ class StrategyTest(unittest.TestCase):
             cm.output[0]
         )
 
-
     def test_lwf(self):
         # SIT scenario
         model, optimizer, criterion, my_nc_benchmark = self.init_sit()


### PR DESCRIPTION
This adresses the part about the disabled callbacks of #659 

> Disable callbacks
A big limitation of the plugin system is that the set of callbacks is fixed. Some strategies may skip some stages and break plugins as a result. The only example up to now is DeepSLDA, which does not use backprop, but there may be others in the future. It would be better if we could somehow add and remove callbacks for custom strategies. If a plugin implements a callback that the strategy does not support, it should raise an error.

Still need to do something more custom for the `GenericPluginMetric`, otherwise we will get a lot of false warnings, because it redefines (but not necessarily use, depending on the arguments passed) a lot of callbacks.