### PR TITLE
Implement early-stopping

### DIFF
--- a/avalanche/training/plugins/early_stopping.py
+++ b/avalanche/training/plugins/early_stopping.py
@@ -1,0 +1,57 @@
+import operator
+from copy import deepcopy
+
+from avalanche.training.plugins import StrategyPlugin
+
+
+class EarlyStoppingPlugin(StrategyPlugin):
+    def __init__(self, patience: int, val_stream_name: str,
+                 metric_name: str = 'Top1_Acc_Stream', mode: str = 'max'):
+        """
+        Simple plugin stopping the training when the accuracy on the
+        corresponding validation metric stopped progressing for a few epochs.
+        The state of the best model is saved after each improvement on the
+        given metric and is loaded back into the model before stopping the
+        training procedure.
+
+        :param patience: Number of epochs to wait before stopping the training.
+        :param val_stream_name: Name of the validation stream to search in the
+        metrics. The corresponding stream will be used to keep track of the
+        evolution of the performance of a model.
+        :param metric_name: The name of the metric to watch as it will be
+        reported in the evaluator.
+        :param mode: Must be "max" or "min". max (resp. min) means that the
+        given metric should me maximized (resp. minimized).
+        """
+        super().__init__()
+        self.val_stream_name = val_stream_name
+        self.patience = patience
+        self.metric_name = metric_name
+        self.metric_key = f'{self.metric_name}/eval_phase/' \
+                          f'{self.val_stream_name}'
+        if mode not in ('max', 'min'):
+            raise ValueError(f'Mode must be "max" or "min", got {mode}.')
+        self.operator = operator.gt if mode == 'max' else operator.lt
+
+        self.best_state = None  # Contains the best parameters
+        self.best_val = None
+        self.best_epoch = None
+
+    def before_training(self, strategy, **kwargs):
+        self.best_state = None
+        self.best_val = None
+        self.best_epoch = None
+
+    def before_training_epoch(self, strategy, **kwargs):
+        self._update_best(strategy)
+        if strategy.epoch - self.best_epoch >= self.patience:
+            strategy.model.load_state_dict(self.best_state)
+            strategy.stop_training()
+
+    def _update_best(self, strategy):
+        res = strategy.evaluator.get_last_metrics()
+        val_acc = res.get(self.metric_key)
+        if self.best_val is None or self.operator(val_acc, self.best_val):
+            self.best_state = deepcopy(strategy.model.state_dict())
+            self.best_val = val_acc
+            self.best_epoch = strategy.epoch

--- a/avalanche/training/strategies/base_strategy.py
+++ b/avalanche/training/strategies/base_strategy.py
@@ -269,11 +269,12 @@ class BaseStrategy:
 
         self.epoch = 0
         for self.epoch in range(self.train_epochs):
+            self.before_training_epoch(**kwargs)
+
             if self._stop_training:  # Early stopping
                 self._stop_training = False
                 break
 
-            self.before_training_epoch(**kwargs)
             self.training_epoch(**kwargs)
             self.after_training_epoch(**kwargs)
             self._periodic_eval(eval_streams, do_final=False)

--- a/examples/all_mnist_early_stopping.py
+++ b/examples/all_mnist_early_stopping.py
@@ -1,0 +1,91 @@
+################################################################################
+# Copyright (c) 2021 ContinualAI.                                              #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 20-11-2020                                                             #
+# Author(s): Vincenzo Lomonaco                                                 #
+# E-mail: contact@continualai.org                                              #
+# Website: avalanche.continualai.org                                           #
+################################################################################
+
+"""
+Same example as in all_mnist.py, but using early stopping to dynamically stop
+the training procedure when the model converged instead of training for a
+fixed number of epochs.
+IMPORTANT: In this example we use the test set to detect when the
+generalization error stops decreasing. In practice, one should *never* use
+the test set for early stopping, but rather measure the generalization
+performance on a held-out validation set.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import torch
+import argparse
+from torch.nn import CrossEntropyLoss
+from torch.optim import SGD
+
+from avalanche.benchmarks.classic import PermutedMNIST, RotatedMNIST, \
+    SplitMNIST
+from avalanche.models import SimpleMLP
+from avalanche.training.plugins.early_stopping import EarlyStoppingPlugin
+from avalanche.training.strategies import Naive
+
+
+def main(args):
+    # Device config
+    device = torch.device(f"cuda:{args.cuda}"
+                          if torch.cuda.is_available() and
+                          args.cuda >= 0 else "cpu")
+
+    # model
+    model = SimpleMLP(num_classes=10)
+
+    # Here we show all the MNIST variation we offer in the "classic" benchmarks
+    if args.mnist_type == 'permuted':
+        scenario = PermutedMNIST(n_experiences=5, seed=1)
+    elif args.mnist_type == 'rotated':
+        scenario = RotatedMNIST(
+            n_experiences=5, rotations_list=[30, 60, 90, 120, 150], seed=1)
+    else:
+        scenario = SplitMNIST(n_experiences=5, seed=1)
+
+    # Than we can extract the parallel train and test streams
+    train_stream = scenario.train_stream
+    test_stream = scenario.test_stream
+
+    # Prepare for training & testing
+    optimizer = SGD(model.parameters(), lr=0.001, momentum=0.9)
+    criterion = CrossEntropyLoss()
+
+    # Continual learning strategy with default logger
+    cl_strategy = Naive(
+        model, optimizer, criterion, train_mb_size=32, train_epochs=100,
+        eval_mb_size=32, device=device, eval_every=1,
+        plugins=[EarlyStoppingPlugin(args.patience, 'test_stream')])
+
+    # train and test loop
+    results = []
+    for train_task, test_task in zip(train_stream, test_stream):
+        print("Current Classes: ", train_task.classes_in_this_experience)
+        cl_strategy.train(train_task, eval_streams=[test_task])
+        results.append(cl_strategy.eval(test_stream))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--mnist_type', type=str, default='split',
+                        choices=['rotated', 'permuted', 'split'],
+                        help='Choose between MNIST variations: '
+                             'rotated, permuted or split.')
+    parser.add_argument('--cuda', type=int, default=0,
+                        help='Select zero-indexed cuda device. -1 to use CPU.')
+    parser.add_argument('--patience', type=int, default=3,
+                        help='Number of epochs to wait without generalization'
+                             'improvements before stopping the training .')
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
Implementation of #664.

Maybe we could add the option to define the patience in terms of iterations instead of epochs, but I think that it can't be easily implemented for now since there is no simple way to keep track of the iteration count in the current training procedure.