### PR TITLE
Support for lazily created streams

### DIFF
--- a/avalanche/benchmarks/generators/benchmark_generators.py
+++ b/avalanche/benchmarks/generators/benchmark_generators.py
@@ -335,6 +335,7 @@ dataset_benchmark = create_multi_dataset_generic_benchmark
 filelist_benchmark = create_generic_benchmark_from_filelists
 paths_benchmark = create_generic_benchmark_from_paths
 tensors_benchmark = create_generic_benchmark_from_tensor_lists
+lazy_benchmark = create_lazy_generic_benchmark
 
 
 def _one_dataset_per_exp_class_order(

--- a/avalanche/benchmarks/scenarios/generic_definitions.py
+++ b/avalanche/benchmarks/scenarios/generic_definitions.py
@@ -64,13 +64,11 @@ class Experience(Protocol[TScenario, TScenarioStream]):
     original stream and may be unrelated to the order in which the strategy will
     encounter experiences.
     """
-    @property
-    @abstractmethod
-    def dataset(self) -> AvalancheDataset:
-        """
-        The dataset containing the patterns available in this experience.
-        """
-        ...
+
+    dataset: AvalancheDataset
+    """
+    The dataset containing the patterns available in this experience.
+    """
 
     @property
     @abstractmethod

--- a/avalanche/benchmarks/scenarios/lazy_dataset_sequence.py
+++ b/avalanche/benchmarks/scenarios/lazy_dataset_sequence.py
@@ -1,0 +1,218 @@
+################################################################################
+# Copyright (c) 2021 ContinualAI.                                              #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 15-06-2021                                                             #
+# Author(s): Lorenzo Pellegrini                                                #
+# E-mail: contact@continualai.org                                              #
+# Website: avalanche.continualai.org                                           #
+################################################################################
+
+from collections import defaultdict
+from typing import Sequence, Iterable, Dict, Optional, Iterator
+
+from avalanche.benchmarks.utils import AvalancheDataset
+
+
+class LazyDatasetSequence(Sequence[AvalancheDataset]):
+    """
+    A lazily initialized sequence of datasets.
+
+    This class provides a way to lazily generate and store the datasets
+    linked to each experience. This class uses a generator to get the sequence
+    of datasets but it can also be used with a more classic statically
+    initialized Sequence (like a list).
+
+    This class will also keep track of the targets and task labels field of the
+    generated datasets.
+    """
+
+    def __init__(
+            self,
+            experience_generator: Iterable[AvalancheDataset],
+            stream_length: int):
+        self._exp_source: Optional[Iterable[AvalancheDataset]] = \
+            experience_generator
+        """
+        The source of the experiences stream, as an Iterable.
+        
+        Can be a simple Sequence or a Generator.
+        
+        This field is kept for reference and debugging. The actual generator
+        is kept in the `_exp_generator` field, which stores the iterator.
+        
+        This field is None when if all the experiences have been loaded.
+        """
+
+        self._next_exp_id: int = 0
+        """
+        The ID of the next experience that will be generated.
+        """
+
+        self._loaded_experiences: Dict[int, AvalancheDataset] = dict()
+        """
+        The sequence of experiences obtained from the generator.
+        """
+
+        self._stream_length: int = stream_length
+        """
+        The length of the stream.
+        """
+        try:
+            self._exp_generator: Optional[Iterator[AvalancheDataset]] = iter(
+                self._exp_source
+            )
+        except TypeError as e:
+            if callable(self._exp_source):
+                # https://stackoverflow.com/a/17092033
+                raise ValueError(
+                    'The provided generator is not iterable. When using a '
+                    'generator function based on "yield", remember to pass the'
+                    ' result of that function, not the '
+                    'function itself!') from None
+            raise e
+        """
+        The experience generator, as an Iterator.
+        
+        This field is None when if all the experiences have been loaded.
+        """
+
+        self.targets_field_sequence: Dict[int, Optional[Sequence]] = \
+            defaultdict(lambda: None)
+        """
+        A dictionary mapping each experience to its `targets` field.
+        
+        This dictionary contains the targets field of datasets generated up to
+        now, including the ones of dropped experiences.
+        """
+
+        self.task_labels_field_sequence: Dict[int, Optional[Sequence[int]]] = \
+            defaultdict(lambda: None)
+        """
+        A dictionary mapping each experience to its `targets_task_labels` field.
+
+        This dictionary contains the task labels of datasets generated up to
+        now, including the ones of dropped experiences.
+        """
+
+    def __len__(self) -> int:
+        """
+        Gets the length of the stream (number of experiences).
+
+        :return: The length of the stream.
+        """
+        return self._stream_length
+
+    def __getitem__(self, exp_idx: int) -> AvalancheDataset:
+        """
+        Gets the dataset associated to an experience.
+
+        :param exp_idx: The ID of the experience.
+        :return: The dataset associated to the experience.
+        """
+        exp_idx = int(exp_idx)  # Handle single element tensors
+        self.load_all_experiences(exp_idx)
+        if exp_idx not in self._loaded_experiences:
+            raise RuntimeError(f'Experience {exp_idx} has been dropped')
+
+        return self._loaded_experiences[exp_idx]
+
+    def get_experience_if_loaded(self, exp_idx: int) -> \
+            Optional[AvalancheDataset]:
+        """
+        Gets the dataset associated to an experience.
+
+        Differently from `__getitem__`, this will return None if the experience
+        has not been (lazily) loaded yet.
+
+        :param exp_idx: The ID of the experience.
+        :return: The dataset associated to the experience or None if the
+            experience has not been loaded yet or if it has been dropped.
+        """
+        exp_idx = int(exp_idx)  # Handle single element tensors
+        if exp_idx >= len(self):
+            raise IndexError(f'The stream doesn\'t contain {exp_idx+1}'
+                             f'experiences')
+
+        return self._loaded_experiences.get(exp_idx, None)
+
+    def drop_previous_experiences(self, to_exp: int) -> None:
+        """
+        Drop the reference to experiences up to a certain experience ID
+        (inclusive).
+
+        This means that experiences with ID [0, from_exp] will be released.
+        Beware that the associated object will be valid until all the references
+        to it are dropped.
+
+        :param to_exp: The ID of the last exp to drop (inclusive). If None,
+            the whole stream will be loaded. Can be a negative number, in
+            which case this method doesn't have any effect. Can be greater
+            or equal to the stream length, in which case all currently loaded
+            experiences will be dropped.
+        :return: None
+        """
+
+        to_exp = int(to_exp)  # Handle single element tensors
+        if to_exp < 0:
+            return
+
+        to_exp = min(to_exp, len(self)-1)
+
+        for exp_id in range(0, to_exp+1):
+            if exp_id in self._loaded_experiences:
+                del self._loaded_experiences[exp_id]
+
+    def load_all_experiences(self, to_exp: int = None) -> None:
+        """
+        Load all experiences up to a certain experience ID (inclusive).
+
+        Beware that this won't re-load any already dropped experience.
+
+        :param to_exp: The ID of the last exp to load (inclusive). If None,
+            the whole stream will be loaded.
+        :return: None
+        """
+        if to_exp is None:
+            to_exp = len(self) - 1
+        else:
+            to_exp = int(to_exp)  # Handle single element tensors
+
+        if to_exp >= len(self):
+            raise IndexError(f'The stream doesn\'t contain {to_exp+1}'
+                             f'experiences')
+
+        if self._next_exp_id > to_exp:
+            # Nothing to do
+            return
+
+        for exp_id in range(self._next_exp_id, to_exp+1):
+            try:
+                generated_exp: AvalancheDataset = next(self._exp_generator)
+            except StopIteration:
+                raise RuntimeError(
+                    f'Unexpected end of stream. The generator was supposed to '
+                    f'generate {len(self)} experiences, but an error occurred '
+                    f'while generating experience {exp_id}.')
+
+            if not isinstance(generated_exp, AvalancheDataset):
+                raise ValueError(
+                    'All experience datasets must be subclasses of'
+                    ' AvalancheDataset')
+
+            self._loaded_experiences[exp_id] = generated_exp
+            self.targets_field_sequence[exp_id] = generated_exp.targets
+            self.task_labels_field_sequence[exp_id] = \
+                generated_exp.targets_task_labels
+            self._next_exp_id += 1
+
+        if self._next_exp_id == len(self):
+            # Release all references to the generator
+            self._exp_generator = None
+            self._exp_source = None
+
+
+__all__ = [
+    'LazyDatasetSequence'
+]

--- a/avalanche/benchmarks/scenarios/new_instances/ni_scenario.py
+++ b/avalanche/benchmarks/scenarios/new_instances/ni_scenario.py
@@ -403,19 +403,6 @@ class NIScenario(GenericCLScenario['NIExperience']):
             complete_test_set_only=True,
             experience_factory=NIExperience)
 
-    # TODO: remove
-    # @property
-    # def classes_in_experience(self) -> Sequence[Set[int]]:
-    #     if self._classes_in_exp is None:
-    #         self._classes_in_exp = []
-    #         for exp_id in range(self.n_experiences):
-    #             self._classes_in_exp.append(set())
-    #             exp_s = self.exp_structure[exp_id]
-    #             for class_id, n_patterns_of_class in enumerate(exp_s):
-    #                 if n_patterns_of_class > 0:
-    #                     self._classes_in_exp[exp_id].add(class_id)
-    #     return self._classes_in_exp
-
     def get_reproducibility_data(self) -> Dict[str, Any]:
         reproducibility_data = {
             'exps_patterns_assignment': self.train_exps_patterns_assignment,

--- a/tests/test_generic_cl_scenario.py
+++ b/tests/test_generic_cl_scenario.py
@@ -1,10 +1,13 @@
 import unittest
+import weakref
+import gc
 
 import torch
 
-from avalanche.benchmarks import dataset_benchmark, Experience, \
-    GenericExperience
-from avalanche.benchmarks.utils import AvalancheTensorDataset
+from avalanche.benchmarks import dataset_benchmark, \
+    GenericExperience, GenericCLScenario
+from avalanche.benchmarks.utils import AvalancheTensorDataset, \
+    AvalancheDatasetType
 
 
 class GenericCLScenarioTests(unittest.TestCase):
@@ -138,6 +141,303 @@ class GenericCLScenarioTests(unittest.TestCase):
         other_0_classes_max = max(other_0_classes)
         self.assertGreaterEqual(other_0_classes_min, 400)
         self.assertLess(other_0_classes_max, 600)
+
+    def test_lazy_scenario(self):
+        train_exps, test_exps, other_stream_exps = self._make_tensor_datasets()
+
+        def train_gen():
+            # Lazy generator of the training stream
+            for dataset in train_exps:
+                yield dataset
+
+        def test_gen():
+            # Lazy generator of the test stream
+            for dataset in test_exps:
+                yield dataset
+
+        def other_gen():
+            # Lazy generator of the "other" stream
+            for dataset in other_stream_exps:
+                yield dataset
+
+        benchmark_instance = GenericCLScenario(
+            stream_definitions=dict(
+                train=((train_gen(), len(train_exps)), [
+                    train_exps[0].targets_task_labels,
+                    train_exps[1].targets_task_labels
+                ]),
+                test=((test_gen(), len(test_exps)), [
+                    test_exps[0].targets_task_labels
+                ]),
+                other=((other_gen(), len(other_stream_exps)), [
+                    other_stream_exps[0].targets_task_labels
+                ])))
+
+        # --- START: Test classes timeline before first experience ---
+        current_classes, prev_classes, cumulative_classes, future_classes = \
+            benchmark_instance.get_classes_timeline(0)
+        self.assertIsNone(current_classes)
+        self.assertSetEqual(set(), set(prev_classes))
+        self.assertIsNone(cumulative_classes)
+        self.assertIsNone(future_classes)
+        # --- END: Test classes timeline before first experience ---
+
+        train_exp_0: GenericExperience = benchmark_instance.train_stream[0]
+        # --- START: Test classes timeline at first experience ---
+        current_classes, prev_classes, cumulative_classes, future_classes = \
+            benchmark_instance.get_classes_timeline(0)
+
+        self.assertSetEqual(set(train_exps[0].targets), set(current_classes))
+        self.assertSetEqual(set(), set(prev_classes))
+        self.assertSetEqual(set(train_exps[0].targets), set(cumulative_classes))
+        self.assertIsNone(future_classes)
+
+        current_classes, prev_classes, cumulative_classes, future_classes = \
+            benchmark_instance.get_classes_timeline(1)
+
+        self.assertIsNone(current_classes)
+        self.assertSetEqual(set(train_exps[0].targets), set(prev_classes))
+        # None because we didn't load exp 0 yet
+        self.assertIsNone(cumulative_classes)
+        self.assertSetEqual(set(), set(future_classes))
+        # --- END: Test classes timeline at first experience ---
+
+        train_exp_1: GenericExperience = benchmark_instance.train_stream[1]
+        # --- START: Test classes timeline at second experience ---
+        # Check if get_classes_timeline(0) is consistent
+        current_classes, prev_classes, cumulative_classes, future_classes = \
+            benchmark_instance.get_classes_timeline(0)
+
+        self.assertSetEqual(set(train_exps[0].targets), set(current_classes))
+        self.assertSetEqual(set(), set(prev_classes))
+        self.assertSetEqual(set(train_exps[0].targets), set(cumulative_classes))
+        # We now have access to future classes!
+        self.assertSetEqual(set(train_exps[1].targets), set(future_classes))
+
+        current_classes, prev_classes, cumulative_classes, future_classes = \
+            benchmark_instance.get_classes_timeline(1)
+
+        self.assertSetEqual(set(train_exps[1].targets), set(current_classes))
+        self.assertSetEqual(set(train_exps[0].targets), set(prev_classes))
+        self.assertSetEqual(
+            set(train_exps[0].targets).union(set(train_exps[1].targets)),
+            set(cumulative_classes))
+        self.assertSetEqual(set(), set(future_classes))
+        # --- END: Test classes timeline at second experience ---
+
+        train_0_classes = train_exp_0.classes_in_this_experience
+        train_1_classes = train_exp_1.classes_in_this_experience
+        train_0_classes_min = min(train_0_classes)
+        train_1_classes_min = min(train_1_classes)
+        train_0_classes_max = max(train_0_classes)
+        train_1_classes_max = max(train_1_classes)
+        self.assertGreaterEqual(train_0_classes_min, 0)
+        self.assertLess(train_0_classes_max, 70)
+        self.assertGreaterEqual(train_1_classes_min, 0)
+        self.assertLess(train_1_classes_max, 100)
+
+        with self.assertRaises(IndexError):
+            train_exp_2: GenericExperience = benchmark_instance.train_stream[2]
+
+        test_exp_0: GenericExperience = benchmark_instance.test_stream[0]
+        test_0_classes = test_exp_0.classes_in_this_experience
+        test_0_classes_min = min(test_0_classes)
+        test_0_classes_max = max(test_0_classes)
+        self.assertGreaterEqual(test_0_classes_min, 100)
+        self.assertLess(test_0_classes_max, 200)
+
+        with self.assertRaises(IndexError):
+            test_exp_1: GenericExperience = benchmark_instance.test_stream[1]
+
+        other_exp_0: GenericExperience = benchmark_instance.other_stream[0]
+        other_0_classes = other_exp_0.classes_in_this_experience
+        other_0_classes_min = min(other_0_classes)
+        other_0_classes_max = max(other_0_classes)
+        self.assertGreaterEqual(other_0_classes_min, 400)
+        self.assertLess(other_0_classes_max, 600)
+
+        with self.assertRaises(IndexError):
+            other_exp_1: GenericExperience = benchmark_instance.other_stream[1]
+
+    def test_lazy_scenario_drop_old_ones(self):
+        train_exps, test_exps, other_stream_exps = self._make_tensor_datasets()
+
+        train_dataset_exp_0_weak_ref = weakref.ref(train_exps[0])
+        train_dataset_exp_1_weak_ref = weakref.ref(train_exps[1])
+
+        train_gen = GenericCLScenarioTests._generate_stream(train_exps)
+        test_gen = GenericCLScenarioTests._generate_stream(test_exps)
+        other_gen = GenericCLScenarioTests._generate_stream(other_stream_exps)
+
+        benchmark_instance = GenericCLScenario(
+            stream_definitions=dict(
+                train=((train_gen, len(train_exps)), [
+                    train_exps[0].targets_task_labels,
+                    train_exps[1].targets_task_labels
+                ]),
+                test=((test_gen, len(test_exps)), [
+                    test_exps[0].targets_task_labels
+                ]),
+                other=((other_gen, len(other_stream_exps)), [
+                    other_stream_exps[0].targets_task_labels
+                ])))
+
+        # --- START: Test classes timeline before first experience ---
+        current_classes, prev_classes, cumulative_classes, future_classes = \
+            benchmark_instance.get_classes_timeline(0)
+        self.assertIsNone(current_classes)
+        self.assertSetEqual(set(), set(prev_classes))
+        self.assertIsNone(cumulative_classes)
+        self.assertIsNone(future_classes)
+        # --- END: Test classes timeline before first experience ---
+
+        train_exp_0: GenericExperience = benchmark_instance.train_stream[0]
+        # --- START: Test classes timeline at first experience ---
+        current_classes, prev_classes, cumulative_classes, future_classes = \
+            benchmark_instance.get_classes_timeline(0)
+
+        self.assertSetEqual(set(train_exps[0].targets), set(current_classes))
+        self.assertSetEqual(set(), set(prev_classes))
+        self.assertSetEqual(set(train_exps[0].targets), set(cumulative_classes))
+        self.assertIsNone(future_classes)
+
+        current_classes, prev_classes, cumulative_classes, future_classes = \
+            benchmark_instance.get_classes_timeline(1)
+
+        self.assertIsNone(current_classes)
+        self.assertSetEqual(set(train_exps[0].targets), set(prev_classes))
+        # None because we didn't load exp 0 yet
+        self.assertIsNone(cumulative_classes)
+        self.assertSetEqual(set(), set(future_classes))
+        # --- END: Test classes timeline at first experience ---
+
+        # Check if it works when the previous experience is dropped
+        benchmark_instance.train_stream.drop_previous_experiences(0)
+        train_exp_1: GenericExperience = benchmark_instance.train_stream[1]
+        # --- START: Test classes timeline at second experience ---
+        # Check if get_classes_timeline(0) is consistent
+        current_classes, prev_classes, cumulative_classes, future_classes = \
+            benchmark_instance.get_classes_timeline(0)
+
+        self.assertSetEqual(set(train_exps[0].targets), set(current_classes))
+        self.assertSetEqual(set(), set(prev_classes))
+        self.assertSetEqual(set(train_exps[0].targets), set(cumulative_classes))
+        # We now have access to future classes!
+        self.assertSetEqual(set(train_exps[1].targets), set(future_classes))
+
+        current_classes, prev_classes, cumulative_classes, future_classes = \
+            benchmark_instance.get_classes_timeline(1)
+
+        self.assertSetEqual(set(train_exps[1].targets), set(current_classes))
+        self.assertSetEqual(set(train_exps[0].targets), set(prev_classes))
+        self.assertSetEqual(
+            set(train_exps[0].targets).union(set(train_exps[1].targets)),
+            set(cumulative_classes))
+        self.assertSetEqual(set(), set(future_classes))
+        # --- END: Test classes timeline at second experience ---
+
+        train_0_classes = train_exp_0.classes_in_this_experience
+        train_1_classes = train_exp_1.classes_in_this_experience
+        train_0_classes_min = min(train_0_classes)
+        train_1_classes_min = min(train_1_classes)
+        train_0_classes_max = max(train_0_classes)
+        train_1_classes_max = max(train_1_classes)
+        self.assertGreaterEqual(train_0_classes_min, 0)
+        self.assertLess(train_0_classes_max, 70)
+        self.assertGreaterEqual(train_1_classes_min, 0)
+        self.assertLess(train_1_classes_max, 100)
+
+        with self.assertRaises(IndexError):
+            train_exp_2: GenericExperience = benchmark_instance.train_stream[2]
+
+        test_exp_0: GenericExperience = benchmark_instance.test_stream[0]
+        test_0_classes = test_exp_0.classes_in_this_experience
+        test_0_classes_min = min(test_0_classes)
+        test_0_classes_max = max(test_0_classes)
+        self.assertGreaterEqual(test_0_classes_min, 100)
+        self.assertLess(test_0_classes_max, 200)
+
+        with self.assertRaises(IndexError):
+            test_exp_1: GenericExperience = benchmark_instance.test_stream[1]
+
+        other_exp_0: GenericExperience = benchmark_instance.other_stream[0]
+        other_0_classes = other_exp_0.classes_in_this_experience
+        other_0_classes_min = min(other_0_classes)
+        other_0_classes_max = max(other_0_classes)
+        self.assertGreaterEqual(other_0_classes_min, 400)
+        self.assertLess(other_0_classes_max, 600)
+
+        with self.assertRaises(IndexError):
+            other_exp_1: GenericExperience = benchmark_instance.other_stream[1]
+
+        train_exps = None
+        train_exp_0 = None
+        train_exp_1 = None
+        train_0_classes = None
+        train_1_classes = None
+        train_gen = None
+
+        # The generational GC is needed, ref-count is not enough here
+        gc.collect()
+
+        # This will check that the train dataset of exp0 has been garbage
+        # collected correctly
+        self.assertIsNone(train_dataset_exp_0_weak_ref())
+        self.assertIsNotNone(train_dataset_exp_1_weak_ref())
+
+        benchmark_instance.train_stream.drop_previous_experiences(1)
+        gc.collect()
+
+        # This will check that exp1 has been garbage collected correctly
+        self.assertIsNone(train_dataset_exp_0_weak_ref())
+        self.assertIsNone(train_dataset_exp_1_weak_ref())
+
+        with self.assertRaises(Exception):
+            exp_0 = benchmark_instance.train_stream[0]
+
+        with self.assertRaises(Exception):
+            exp_1 = benchmark_instance.train_stream[1]
+
+    def _make_tensor_datasets(self):
+        train_exps = []
+
+        tensor_x = torch.rand(200, 3, 28, 28)
+        tensor_y = torch.randint(0, 70, (200,))
+        tensor_t = torch.randint(0, 5, (200,))
+        train_exps.append(AvalancheTensorDataset(
+            tensor_x, tensor_y, task_labels=tensor_t,
+            dataset_type=AvalancheDatasetType.CLASSIFICATION))
+
+        tensor_x = torch.rand(200, 3, 28, 28)
+        tensor_y = torch.randint(0, 100, (200,))
+        tensor_t = torch.randint(0, 5, (200,))
+        train_exps.append(AvalancheTensorDataset(
+            tensor_x, tensor_y, task_labels=tensor_t,
+            dataset_type=AvalancheDatasetType.CLASSIFICATION))
+
+        test_exps = []
+        test_x = torch.rand(200, 3, 28, 28)
+        test_y = torch.randint(100, 200, (200,))
+        test_t = torch.randint(0, 5, (200,))
+        test_exps.append(AvalancheTensorDataset(
+            test_x, test_y, task_labels=test_t,
+            dataset_type=AvalancheDatasetType.CLASSIFICATION))
+
+        other_stream_exps = []
+        other_x = torch.rand(200, 3, 28, 28)
+        other_y = torch.randint(400, 600, (200,))
+        other_t = torch.randint(0, 5, (200,))
+        other_stream_exps.append(AvalancheTensorDataset(
+            other_x, other_y, task_labels=other_t,
+            dataset_type=AvalancheDatasetType.CLASSIFICATION))
+
+        return train_exps, test_exps, other_stream_exps
+
+    @staticmethod
+    def _generate_stream(dataset_list):
+        # Lazy generator of a stream
+        for dataset in dataset_list:
+            yield dataset
 
 
 if __name__ == '__main__':

--- a/tests/test_high_level_generators.py
+++ b/tests/test_high_level_generators.py
@@ -13,8 +13,8 @@ from avalanche.benchmarks import dataset_benchmark, filelist_benchmark, \
     benchmark_with_validation_stream
 from avalanche.benchmarks.scenarios.generic_benchmark_creation import \
     create_lazy_generic_benchmark
-from avalanche.benchmarks.utils import AvalancheDataset, AvalancheTensorDataset, \
-    AvalancheDatasetType
+from avalanche.benchmarks.utils import AvalancheDataset, \
+    AvalancheTensorDataset, AvalancheDatasetType
 from tests.unit_tests_utils import common_setups
 
 


### PR DESCRIPTION
This PR introduces the support for lazy streams (discussed in #600)

This PR introduces some changes on the internals of `GenericCLScenario` and adds proper helpers to support the creation of streams based on generator expressions or functions.

This also introduces the support for dropping the references to previous experiences to allow for a more fine-grained memory management (to be documented).

Beware that the helper used to create data incremental benchmarks and the helper used to create a validation stream will still work in non-lazy mode (will load all experiences at once). This behavior will be fixed in the future.

The behavior for non-lazy benchmarks will not be affected by these changes.