### PR TITLE
Correct mistake in ewc.py

### DIFF
--- a/avalanche/training/plugins/ewc.py
+++ b/avalanche/training/plugins/ewc.py
@@ -109,7 +109,7 @@ class EWCPlugin(StrategyPlugin):
         Compute EWC importance matrix for each parameter
         """
 
-        model.train()
+        model.eval()
 
         # list of list
         importances = zerolike_params_dict(model)


### PR DESCRIPTION
This PR corrects a mistake that causes over-estimation of EWC Results. This is a common bug found in multiple github repos that implement EWC.

**The bug**:

For models such as AlexNet, SimpleCNN that do not have `batchnorm` layers, a forward pass through the model will not alter any parameters.

But for other models such as ResNet variants, there are batch norm layers. The forward pass causes change of batchnorm mean and standard deviation.

In this context, the `compute_importances` **should not** change the parameters. I observed the models before and after this function, and observed that it did. This also increases the results by `3-4%` sometimes.

**The fix**:

I have put a `model.eval()` so that the batchnorm stats are fixed and frozen.