### PR TITLE
Added Less-Forgetful Learning LFL Plugin

### DIFF
--- a/avalanche/models/__init__.py
+++ b/avalanche/models/__init__.py
@@ -16,3 +16,4 @@ from .utils import *
 from .slda_resnet import SLDAResNetModel
 from .icarl_resnet import *
 from .ncm_classifier import NCMClassifier
+from .base_model import BaseModel

--- a/avalanche/models/base_model.py
+++ b/avalanche/models/base_model.py
@@ -11,4 +11,3 @@ class BaseModel(ABC):
         """
         Get features from model given input
         """
-

--- a/avalanche/models/base_model.py
+++ b/avalanche/models/base_model.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+
+
+class BaseModel(ABC):
+    """
+    A base abstract class for models
+    """
+
+    @abstractmethod
+    def get_features(self, x):
+        """
+        Get features from model given input
+        """
+

--- a/avalanche/models/simple_mlp.py
+++ b/avalanche/models/simple_mlp.py
@@ -13,9 +13,10 @@ import torch.nn as nn
 
 from avalanche.models.dynamic_modules import MultiTaskModule, \
     MultiHeadClassifier
+from avalanche.models.base_model import BaseModel
 
 
-class SimpleMLP(nn.Module):
+class SimpleMLP(nn.Module, BaseModel):
     def __init__(self, num_classes=10, input_size=28 * 28,
                  hidden_size=512, hidden_layers=1, drop_rate=0.5):
         super().__init__()
@@ -39,6 +40,12 @@ class SimpleMLP(nn.Module):
         x = x.view(x.size(0), self._input_size)
         x = self.features(x)
         x = self.classifier(x)
+        return x
+
+    def get_features(self, x):
+        x = x.contiguous()
+        x = x.view(x.size(0), self._input_size)
+        x = self.features(x)
         return x
 
 

--- a/avalanche/training/plugins/__init__.py
+++ b/avalanche/training/plugins/__init__.py
@@ -11,3 +11,4 @@ from .strategy_plugin import StrategyPlugin
 from .synaptic_intelligence import SynapticIntelligencePlugin
 from .gss_greedy import GSS_greedyPlugin
 from .cope import CoPEPlugin, PPPloss
+from .lfl import LFLPlugin

--- a/avalanche/training/plugins/lfl.py
+++ b/avalanche/training/plugins/lfl.py
@@ -1,0 +1,74 @@
+import copy
+
+import torch
+
+from avalanche.training.plugins.strategy_plugin import StrategyPlugin
+from avalanche.training.utils import get_last_fc_layer, freeze_everything
+
+
+class LFLPlugin(StrategyPlugin):
+
+    def __init__(self, lambda_e):
+        """
+        :param lambda_e: Euclidean loss hyper parameter
+        """
+        super().__init__()
+
+        self.lambda_e = lambda_e
+        self.prev_model = None
+
+    def _euclidean_loss(self, features, prev_features):
+        """
+        Compute euclidean loss
+        """
+        return torch.nn.functional.mse_loss(features, prev_features)
+
+    def penalty(self, x, model, lambda_e):
+        """
+        Compute weighted euclidean loss
+        """
+        if self.prev_model is None:
+            return 0
+        else:
+            features, prev_features = self.compute_features(model, x)
+            dist_loss = self._euclidean_loss(features, prev_features)
+            return lambda_e * dist_loss
+
+    def compute_features(self, model, x):
+        """
+        Compute features from prev model and current model
+        """
+        model.eval()
+        self.prev_model.eval()
+
+        x = x.contiguous()
+        x = x.view(x.size(0), 28*28)
+        features = model.features(x)
+        prev_features = self.prev_model.features(x)
+
+        return features, prev_features
+
+    def before_backward(self, strategy, **kwargs):
+        """
+        Add euclidean loss between prev and current features
+        """
+        lambda_e = self.lambda_e[strategy.training_exp_counter] \
+            if isinstance(self.lambda_e, (list, tuple)) else self.lambda_e
+
+        penalty = self.penalty(strategy.mb_x, strategy.model, lambda_e)
+        strategy.loss += penalty
+
+    def after_training_exp(self, strategy, **kwargs):
+        """
+        Save a copy of the model after each experience
+        and freeze the prev model and freeze the last layer of current model
+        """
+
+        self.prev_model = copy.deepcopy(strategy.model)
+
+        freeze_everything(self.prev_model)
+
+        last_fc_name, last_fc = get_last_fc_layer(strategy.model)
+
+        for param in last_fc.parameters():
+            param.requires_grad = False

--- a/avalanche/training/plugins/lfl.py
+++ b/avalanche/training/plugins/lfl.py
@@ -8,6 +8,17 @@ from avalanche.models.base_model import BaseModel
 
 
 class LFLPlugin(StrategyPlugin):
+    """
+    Less-Forgetful Learning (LFL) Plugin
+    LFL satisfies two properties to mitigate catastrophic forgetting.
+    1) To keep the decision boundaries unchanged
+    2) The feature space should not change much on target(new) data
+    LFL uses euclidean loss between features from current and previous version
+    of model as regularization to maintain the feature space and avoid
+    catastrophic forgetting.
+    Refer paper https://arxiv.org/pdf/1607.00122.pdf for more details
+    This plugin does not use task identities.
+    """
 
     def __init__(self, lambda_e):
         """
@@ -72,7 +83,7 @@ class LFLPlugin(StrategyPlugin):
         for param in last_fc.parameters():
             param.requires_grad = False
 
-    def before_training(self, strategy: 'BaseStrategy', **kwargs):
+    def before_training(self, strategy, **kwargs):
         """
         Check if the model is an instance of base class to ensure get_features()
         is implemented

--- a/avalanche/training/strategies/strategy_wrappers.py
+++ b/avalanche/training/strategies/strategy_wrappers.py
@@ -629,6 +629,7 @@ class LFL(BaseStrategy):
                  evaluator: EvaluationPlugin = default_logger, eval_every=-1):
         """ Less Forgetful Learning strategy.
             See LFL plugin for details.
+            Refer Paper: https://arxiv.org/pdf/1607.00122.pdf
             This strategy does not use task identities.
 
         :param model: The model.

--- a/avalanche/training/strategies/strategy_wrappers.py
+++ b/avalanche/training/strategies/strategy_wrappers.py
@@ -634,8 +634,8 @@ class LFL(BaseStrategy):
         :param model: The model.
         :param optimizer: The optimizer to use.
         :param criterion: The loss criterion to use.
-        :param lambda_e: euclidean loss hyper parameter. It can be either a float
-                number or a list containing lambda_e for each experience.
+        :param lambda_e: euclidean loss hyper parameter. It can be either a
+                float number or a list containing lambda_e for each experience.
         :param train_mb_size: The train minibatch size. Defaults to 1.
         :param train_epochs: The number of training epochs. Defaults to 1.
         :param eval_mb_size: The eval minibatch size. Defaults to 1.

--- a/examples/lfl_mnist.py
+++ b/examples/lfl_mnist.py
@@ -1,0 +1,84 @@
+import torch
+import argparse
+from avalanche.benchmarks import PermutedMNIST
+from avalanche.training.strategies import LFL
+from avalanche.models import SimpleMLP
+from avalanche.evaluation.metrics import forgetting_metrics, \
+    accuracy_metrics, loss_metrics
+from avalanche.logging import InteractiveLogger
+from avalanche.training.plugins import EvaluationPlugin
+
+
+"""
+This example tests Less-Forgetful Learning on Permuted MNIST.
+The performance with default arguments should give an accuracy
+of more than 88% on all tasks.
+"""
+
+
+def main(args):
+    model = SimpleMLP(hidden_size=args.hs)
+    optimizer = torch.optim.SGD(model.parameters(), lr=args.lr)
+    criterion = torch.nn.CrossEntropyLoss()
+
+    # check if selected GPU is available or use CPU
+    assert args.cuda == -1 or args.cuda >= 0, "cuda must be -1 or >= 0."
+    device = torch.device(f"cuda:{args.cuda}"
+                          if torch.cuda.is_available() and
+                          args.cuda >= 0 else "cpu")
+    print(f'Using device: {device}')
+
+    # create Permuted MNIST scenario
+    scenario = PermutedMNIST(n_experiences=4)
+
+    interactive_logger = InteractiveLogger()
+    eval_plugin = EvaluationPlugin(
+        accuracy_metrics(
+            minibatch=True, epoch=True, experience=True, stream=True),
+        loss_metrics(minibatch=True, epoch=True, experience=True, stream=True),
+        forgetting_metrics(experience=True),
+        loggers=[interactive_logger])
+
+    # create strategy
+    assert len(args.lambda_e) == 1 or len(args.lambda_e) == 5,\
+        'Lambda_e must be a non-empty list.'
+    lambda_e = args.lambda_e[0] if len(args.lambda_e) == 1 \
+        else args.lambda_e
+
+    strategy = LFL(model, optimizer, criterion, lambda_e=lambda_e,
+                   train_epochs=args.epochs, device=device,
+                   train_mb_size=args.minibatch_size, evaluator=eval_plugin)
+
+    # train on the selected scenario with the chosen strategy
+    print('Starting experiment...')
+    results = []
+    for train_batch_info in scenario.train_stream:
+        print("Start training on experience ",
+              train_batch_info.current_experience)
+
+        strategy.train(train_batch_info, num_workers=0)
+        print("End training on experience ",
+              train_batch_info.current_experience)
+        print('Computing accuracy on the test set')
+        results.append(strategy.eval(scenario.test_stream[:]))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--lambda_e', nargs='+', type=float,
+                        default=[0.0001],
+                        help='Penalty hyperparameter for LFL. It can be either'
+                             'a list with multiple elements (one lambda_e per '
+                             'experience) or a list of one element (same lambda_e '
+                             'for all experiences).')
+    parser.add_argument('--lr', type=float, default=1e-2, help='Learning rate.')
+    parser.add_argument('--hs', type=int, default=256, help='MLP hidden size.')
+    parser.add_argument('--epochs', type=int, default=3,
+                        help='Number of training epochs.')
+    parser.add_argument('--minibatch_size', type=int, default=128,
+                        help='Minibatch size.')
+    parser.add_argument('--cuda', type=int, default=0,
+                        help='Specify GPU id to use. Use CPU if -1.')
+    args = parser.parse_args()
+
+    main(args)

--- a/examples/lfl_mnist.py
+++ b/examples/lfl_mnist.py
@@ -69,8 +69,8 @@ if __name__ == '__main__':
                         default=[0.0001],
                         help='Penalty hyperparameter for LFL. It can be either'
                              'a list with multiple elements (one lambda_e per '
-                             'experience) or a list of one element (same lambda_e '
-                             'for all experiences).')
+                             'experience) or a list of one element (same '
+                             'lambda_e for all experiences).')
     parser.add_argument('--lr', type=float, default=1e-2, help='Learning rate.')
     parser.add_argument('--hs', type=int, default=256, help='MLP hidden size.')
     parser.add_argument('--epochs', type=int, default=3,

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -22,7 +22,7 @@ from avalanche.models import SimpleMLP
 from avalanche.training.plugins import EvaluationPlugin, StrategyPlugin, \
     LwFPlugin, ReplayPlugin
 from avalanche.training.strategies import Naive, Replay, CWRStar, \
-    GDumb, LwF, AGEM, GEM, EWC, \
+    GDumb, LwF, AGEM, GEM, EWC, LFL, \
     SynapticIntelligence, JointTraining, CoPE, StreamingLDA, BaseStrategy
 from avalanche.training.strategies.cumulative import Cumulative
 from avalanche.training.strategies.joint_training import AlreadyTrainedError
@@ -429,6 +429,22 @@ class StrategyTest(unittest.TestCase):
             train_epochs=2, eval_mb_size=50,
             device=self.device,)
 
+        self.run_strategy(benchmark, strategy)
+
+    def test_lfl(self):
+
+        # SIT scenario
+        model, optimizer, criterion, my_nc_benchmark = self.init_sit()
+        strategy = LFL(model, optimizer, criterion, lambda_e=0.0001,
+                       train_mb_size=10, device=self.device,
+                       eval_mb_size=50, train_epochs=2)
+        self.run_strategy(my_nc_benchmark, strategy)
+
+        # MT scenario
+        strategy = LFL(model, optimizer, criterion, lambda_e=0.0001,
+                       train_mb_size=10, device=self.device,
+                       eval_mb_size=50, train_epochs=2)
+        benchmark = self.load_benchmark(use_task_labels=True)
         self.run_strategy(benchmark, strategy)
 
     def load_benchmark(self, use_task_labels=False):


### PR DESCRIPTION
I have implemented the LFL plugin from the paper [Less-Forgetful Learning](https://arxiv.org/abs/1607.00122) along with the strategy wrapper, and an example.

The LFL algorithm requires computing penalty euclidean loss with current and previous model features. To avoid model-specific modifications in the plugin (i.e flattening the input in case of MLP model), I have created a base abstract class `BaseModel `which requires implementing `get_features()` in its subclasses, as suggested by @AndreaCossu on Slack. 

Currently, I have only made the `SimpleMLP` class inherit this `BaseModel` for the example and test cases to work. The plugin will check if the model is an instance of this base class and will raise NotImplementedError if it is not. 

Kindly let me know if the implementation seems okay.
Thank you! :) 