### PR TITLE
Added helper method to convert nn.Modules to multi-head models

### DIFF
--- a/avalanche/models/__init__.py
+++ b/avalanche/models/__init__.py
@@ -17,3 +17,4 @@ from .slda_resnet import SLDAResNetModel
 from .icarl_resnet import *
 from .ncm_classifier import NCMClassifier
 from .base_model import BaseModel
+from .helper_method import as_multitask

--- a/avalanche/models/helper_method.py
+++ b/avalanche/models/helper_method.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import torch
+import torch.nn as nn
+
+from avalanche.models.dynamic_modules import MultiTaskModule, MultiHeadClassifier
+
+class MultiTaskDecorator(MultiTaskModule):
+    """ 
+    Encapsulates an existing nn.Module to make it subclass MultiTaskModule,
+    the user should still be able to interact with the encapsulated module as if
+    it was the module itself. 
+    
+    The only things that change are the following, the classifier from the
+    given model will be replaced by a MultiHeadClassifier, and the forward()
+    implementation will be overwritten by one that accepts task labels. 
+    The encapsulated module will then be automatically extended to
+    fit new classes during calls to model.adaptation()
+    """
+    def __init__(self, model: nn.Module, classifier_name: str):
+        """
+        :param model: pytorch nn.Module that does not support multitask
+        :param classifier_name: attribute name of the existing classification
+                                layer inside the module 
+        """
+        self.__dict__['_initialized'] = False
+        super().__init__()
+        self.model = model
+        self.classifier_name = classifier_name
+
+        old_classifier = getattr(model, classifier_name)
+
+        if isinstance(old_classifier, nn.Linear):
+            in_size = old_classifier.in_features 
+            out_size = old_classifier.out_features 
+            # Replace old classifier by empty block
+            setattr(self.model, classifier_name, nn.Sequential())
+        elif isinstance(old_classifier, nn.Sequential):
+            in_size = old_classifier[-1].in_features 
+            out_size = old_classifier[-1].out_features 
+            del old_classifier[-1]
+        else:
+            raise NotImplementedError(f"Cannot handle the following type \
+            of classification layer {type(old_classifier)}")
+
+        # Set new classifier
+        setattr(self, classifier_name, MultiHeadClassifier(in_size, out_size))
+
+        self._initialized = True
+
+    def forward_single_task(self, x: torch.Tensor, task_label: int):  
+        out = self.model(x)
+        return getattr(self, self.classifier_name)(out.view(out.size(0), -1), 
+        task_labels=task_label)
+
+    def __getattr__(self, name):
+        # Override pytorch impl from nn.Module
+
+        # Its a bit particular since pytorch nn.Module does not
+        # keep some attributes in a classical manner in self.__dict__
+        # rather it puts them into _parameters, _buffers and
+        # _modules attributes. We have to add these lines to avoid recursion
+        if name == 'model':
+            return self.__dict__['_modules']['model']
+        if name == self.classifier_name:
+            return self.__dict__['_modules'][self.classifier_name]
+
+        # If its a different attribute, return the one from the model
+        return getattr(self.model, name)
+
+    def __setattr__(self, name, value):
+        # During initialization, use pytorch routine
+        if not self.__dict__['_initialized'] or name in self.__dict__:
+            super().__setattr__(name, value)
+        else:
+            return setattr(self.model, name, value) 
+
+def as_multitask(model: nn.Module, classifier_name: str) -> MultiTaskModule:
+    """ 
+    Wraps around a model to make it a multitask model 
+
+    :param model: model to be converted into MultiTaskModule
+    :param classifier_name: the name of the attribute containing 
+                            the classification layer (nn.Linear). It can also be
+                            an instance of nn.Sequential containing multiple
+                            layers as long as the classification layer is the
+                            last layer.
+    :return the decorated model, now subclassing MultiTaskModule, and
+    accepting task_labels as forward() method argument
+    """
+    return MultiTaskDecorator(model, classifier_name)
+
+__all__ = ['as_multitask']

--- a/avalanche/models/helper_method.py
+++ b/avalanche/models/helper_method.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn as nn
 
 from avalanche.models.dynamic_modules import MultiTaskModule, \
-MultiHeadClassifier
+                                             MultiHeadClassifier
 
 
 class MultiTaskDecorator(MultiTaskModule):
@@ -34,15 +34,15 @@ class MultiTaskDecorator(MultiTaskModule):
         if isinstance(old_classifier, nn.Linear):
             in_size = old_classifier.in_features 
             out_size = old_classifier.out_features 
-            old_params = [torch.clone(p.data) for p in \
-            old_classifier.parameters()]
+            old_params = [torch.clone(p.data) for p in 
+                          old_classifier.parameters()]
             # Replace old classifier by empty block
             setattr(self.model, classifier_name, nn.Sequential())
         elif isinstance(old_classifier, nn.Sequential):
             in_size = old_classifier[-1].in_features 
             out_size = old_classifier[-1].out_features 
-            old_params = [torch.clone(p.data) for p in \
-            old_classifier[-1].parameters()]
+            old_params = [torch.clone(p.data) for p in 
+                          old_classifier[-1].parameters()]
             del old_classifier[-1]
         else:
             raise NotImplementedError(f"Cannot handle the following type \
@@ -52,7 +52,7 @@ class MultiTaskDecorator(MultiTaskModule):
         setattr(self, classifier_name, MultiHeadClassifier(in_size, out_size))
 
         for param, param_old in \
-        zip(getattr(self, classifier_name).parameters(), old_params):
+                zip(getattr(self, classifier_name).parameters(), old_params):
             param.data = param_old
 
         self._initialized = True
@@ -60,7 +60,7 @@ class MultiTaskDecorator(MultiTaskModule):
     def forward_single_task(self, x: torch.Tensor, task_label: int):  
         out = self.model(x)
         return getattr(self, self.classifier_name)(out.view(out.size(0), -1), 
-        task_labels=task_label)
+                                                   task_labels=task_label)
 
     def __getattr__(self, name):
         # Override pytorch impl from nn.Module

--- a/avalanche/models/helper_method.py
+++ b/avalanche/models/helper_method.py
@@ -2,13 +2,15 @@
 import torch
 import torch.nn as nn
 
-from avalanche.models.dynamic_modules import MultiTaskModule, MultiHeadClassifier
+from avalanche.models.dynamic_modules import MultiTaskModule, \
+MultiHeadClassifier
+
 
 class MultiTaskDecorator(MultiTaskModule):
     """ 
     Encapsulates an existing nn.Module to make it subclass MultiTaskModule,
-    the user should still be able to interact with the encapsulated module as if
-    it was the module itself. 
+    the user should still be able to interact with the encapsulated module 
+    as if it was the module itself. 
     
     The only things that change are the following, the classifier from the
     given model will be replaced by a MultiHeadClassifier, and the forward()
@@ -32,18 +34,26 @@ class MultiTaskDecorator(MultiTaskModule):
         if isinstance(old_classifier, nn.Linear):
             in_size = old_classifier.in_features 
             out_size = old_classifier.out_features 
+            old_params = [torch.clone(p.data) for p in \
+            old_classifier.parameters()]
             # Replace old classifier by empty block
             setattr(self.model, classifier_name, nn.Sequential())
         elif isinstance(old_classifier, nn.Sequential):
             in_size = old_classifier[-1].in_features 
             out_size = old_classifier[-1].out_features 
+            old_params = [torch.clone(p.data) for p in \
+            old_classifier[-1].parameters()]
             del old_classifier[-1]
         else:
             raise NotImplementedError(f"Cannot handle the following type \
             of classification layer {type(old_classifier)}")
 
-        # Set new classifier
+        # Set new classifier and initialize to previous param values
         setattr(self, classifier_name, MultiHeadClassifier(in_size, out_size))
+
+        for param, param_old in \
+        zip(getattr(self, classifier_name).parameters(), old_params):
+            param.data = param_old
 
         self._initialized = True
 
@@ -74,19 +84,21 @@ class MultiTaskDecorator(MultiTaskModule):
         else:
             return setattr(self.model, name, value) 
 
+
 def as_multitask(model: nn.Module, classifier_name: str) -> MultiTaskModule:
     """ 
     Wraps around a model to make it a multitask model 
 
     :param model: model to be converted into MultiTaskModule
     :param classifier_name: the name of the attribute containing 
-                            the classification layer (nn.Linear). It can also be
-                            an instance of nn.Sequential containing multiple
+                            the classification layer (nn.Linear). It can also 
+                            be an instance of nn.Sequential containing multiple
                             layers as long as the classification layer is the
                             last layer.
     :return the decorated model, now subclassing MultiTaskModule, and
     accepting task_labels as forward() method argument
     """
     return MultiTaskDecorator(model, classifier_name)
+
 
 __all__ = ['as_multitask']

--- a/tests/test_helper_method.py
+++ b/tests/test_helper_method.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+import torch
+import torch.nn as nn
+from torch.optim import SGD
+import unittest
+
+from avalanche.models.dynamic_modules import MultiTaskModule, MultiHeadClassifier
+from avalanche.models import SimpleCNN, SimpleMLP
+from avalanche.models.helper_method import as_multitask
+from avalanche.training.strategies import Naive
+
+from tests.unit_tests_utils import common_setups, get_fast_benchmark
+
+class ConversionMethodTests(unittest.TestCase):
+    def setUp(self):
+        common_setups()
+        self.benchmark = get_fast_benchmark(use_task_labels=True, shuffle=True)
+
+    def test_modules(self):
+        modules = [(SimpleMLP(input_size=32*32*3), 'classifier'), (SimpleCNN(), 'classifier')]
+        for m in modules:self._test_modules(*m)
+
+    def test_integration(self):
+        modules = [(SimpleMLP(input_size=6), 'classifier')]
+        for m in modules:self._test_integration(*m)
+
+    def _test_modules(self, module, clf_name):
+        old_param_total = sum([torch.numel(p) for p in module.parameters()])
+
+        module = as_multitask(module, clf_name)
+        self.assertIsInstance(module, MultiTaskModule)
+        self.assertIsInstance(getattr(module, clf_name), MultiHeadClassifier)
+    
+        test_input = torch.ones(5, 3, 32, 32)
+        task_labels = torch.zeros(5, dtype=torch.long)
+    
+        # One task label
+        output = module(test_input, task_labels=0)
+    
+        # Several ones
+        output = module(test_input, task_labels=task_labels)
+    
+        # Change attribute
+        module.non_module_attribute = 10
+        self.assertEqual(module.model.non_module_attribute, 10)
+    
+        module.non_module_attribute += 5
+    
+        # Extract params and state dict
+        new_param_total = sum([torch.numel(p) for p in module.parameters()])
+        self.assertEqual(new_param_total, old_param_total)
+        state = module.state_dict()
+    
+        # Functions returning references
+        module = module.train()
+        self.assertIsInstance(module, MultiTaskModule)
+        self.assertTrue(module.training)
+        module = module.eval()
+        self.assertIsInstance(module, MultiTaskModule)
+        self.assertFalse(module.training)
+        module = module.cuda()
+        self.assertIsInstance(module, MultiTaskModule)
+
+    def _test_integration(self, module, clf_name):
+        module = as_multitask(module, clf_name)
+        optimizer = SGD(module.parameters(), lr=0.05, 
+        momentum=0.9, weight_decay=0.0002)
+        
+        strategy = Naive(module, optimizer, 
+        train_mb_size=32, eval_mb_size=32, device='cpu')
+
+        for t, experience in enumerate(self.benchmark.train_stream):
+            strategy.train(experience)
+            strategy.eval(self.benchmark.test_stream[:t+1])

--- a/tests/test_helper_method.py
+++ b/tests/test_helper_method.py
@@ -3,13 +3,15 @@ import torch
 import torch.nn as nn
 from torch.optim import SGD
 import unittest
+import copy
 
-from avalanche.models.dynamic_modules import MultiTaskModule, MultiHeadClassifier
-from avalanche.models import SimpleCNN, SimpleMLP
-from avalanche.models.helper_method import as_multitask
+from avalanche.models.dynamic_modules import MultiTaskModule, \
+MultiHeadClassifier
+from avalanche.models import SimpleCNN, SimpleMLP, as_multitask
 from avalanche.training.strategies import Naive
 
 from tests.unit_tests_utils import common_setups, get_fast_benchmark
+
 
 class ConversionMethodTests(unittest.TestCase):
     def setUp(self):
@@ -17,12 +19,49 @@ class ConversionMethodTests(unittest.TestCase):
         self.benchmark = get_fast_benchmark(use_task_labels=True, shuffle=True)
 
     def test_modules(self):
-        modules = [(SimpleMLP(input_size=32*32*3), 'classifier'), (SimpleCNN(), 'classifier')]
-        for m in modules:self._test_modules(*m)
+        modules = [(SimpleMLP(input_size=32*32*3), 'classifier'),
+        (SimpleCNN(), 'classifier')]
+        for m in modules: 
+            self._test_modules(*m)
+
+    def test_outputs(self):
+        modules = [(SimpleMLP(input_size=32*32*3), 'classifier'),
+        (SimpleCNN(), 'classifier')]
+        for m in modules: 
+            self._test_outputs(*m)
 
     def test_integration(self):
         modules = [(SimpleMLP(input_size=6), 'classifier')]
-        for m in modules:self._test_integration(*m)
+        for m in modules: 
+            self._test_integration(*m)
+
+    def test_initialisation(self):
+        module = SimpleMLP()
+        old_classifier_weight = torch.clone(module.classifier.weight)
+        old_classifier_bias = torch.clone(module.classifier.bias)
+        module = as_multitask(module, 'classifier')
+        new_classifier_weight = \
+        torch.clone(module.classifier.classifiers['0'].classifier.weight)
+        new_classifier_bias = \
+        torch.clone(module.classifier.classifiers['0'].classifier.bias)
+        self.assertTrue(torch.equal(old_classifier_weight, 
+        new_classifier_weight))
+        self.assertTrue(torch.equal(old_classifier_bias, 
+        new_classifier_bias))
+
+    def _test_outputs(self, module, clf_name):
+        test_input = torch.rand(10, 3, 32, 32)
+        module_singletask = copy.deepcopy(module)
+        module_multitask = as_multitask(module, clf_name)
+
+        # Put in eval mode to deactivate dropouts
+        module_singletask.eval()
+        module_multitask.eval()
+
+        out_single_task = module_singletask(test_input)
+        out_multi_task = module_multitask(test_input, task_labels=0)
+        self.assertTrue(torch.equal(out_single_task, 
+        out_multi_task))
 
     def _test_modules(self, module, clf_name):
         old_param_total = sum([torch.numel(p) for p in module.parameters()])
@@ -72,3 +111,5 @@ class ConversionMethodTests(unittest.TestCase):
         for t, experience in enumerate(self.benchmark.train_stream):
             strategy.train(experience)
             strategy.eval(self.benchmark.test_stream[:t+1])
+
+

--- a/tests/test_helper_method.py
+++ b/tests/test_helper_method.py
@@ -6,7 +6,7 @@ import unittest
 import copy
 
 from avalanche.models.dynamic_modules import MultiTaskModule, \
-MultiHeadClassifier
+                                             MultiHeadClassifier
 from avalanche.models import SimpleCNN, SimpleMLP, as_multitask
 from avalanche.training.strategies import Naive
 
@@ -20,13 +20,13 @@ class ConversionMethodTests(unittest.TestCase):
 
     def test_modules(self):
         modules = [(SimpleMLP(input_size=32*32*3), 'classifier'),
-        (SimpleCNN(), 'classifier')]
+                   (SimpleCNN(), 'classifier')]
         for m in modules: 
             self._test_modules(*m)
 
     def test_outputs(self):
         modules = [(SimpleMLP(input_size=32*32*3), 'classifier'),
-        (SimpleCNN(), 'classifier')]
+                   (SimpleCNN(), 'classifier')]
         for m in modules: 
             self._test_outputs(*m)
 
@@ -41,13 +41,13 @@ class ConversionMethodTests(unittest.TestCase):
         old_classifier_bias = torch.clone(module.classifier.bias)
         module = as_multitask(module, 'classifier')
         new_classifier_weight = \
-        torch.clone(module.classifier.classifiers['0'].classifier.weight)
+            torch.clone(module.classifier.classifiers['0'].classifier.weight)
         new_classifier_bias = \
-        torch.clone(module.classifier.classifiers['0'].classifier.bias)
+            torch.clone(module.classifier.classifiers['0'].classifier.bias)
         self.assertTrue(torch.equal(old_classifier_weight, 
-        new_classifier_weight))
+                        new_classifier_weight))
         self.assertTrue(torch.equal(old_classifier_bias, 
-        new_classifier_bias))
+                        new_classifier_bias))
 
     def _test_outputs(self, module, clf_name):
         test_input = torch.rand(10, 3, 32, 32)
@@ -61,7 +61,7 @@ class ConversionMethodTests(unittest.TestCase):
         out_single_task = module_singletask(test_input)
         out_multi_task = module_multitask(test_input, task_labels=0)
         self.assertTrue(torch.equal(out_single_task, 
-        out_multi_task))
+                        out_multi_task))
 
     def _test_modules(self, module, clf_name):
         old_param_total = sum([torch.numel(p) for p in module.parameters()])
@@ -103,13 +103,11 @@ class ConversionMethodTests(unittest.TestCase):
     def _test_integration(self, module, clf_name):
         module = as_multitask(module, clf_name)
         optimizer = SGD(module.parameters(), lr=0.05, 
-        momentum=0.9, weight_decay=0.0002)
+                        momentum=0.9, weight_decay=0.0002)
         
         strategy = Naive(module, optimizer, 
-        train_mb_size=32, eval_mb_size=32, device='cpu')
+                         train_mb_size=32, eval_mb_size=32, device='cpu')
 
         for t, experience in enumerate(self.benchmark.train_stream):
             strategy.train(experience)
             strategy.eval(self.benchmark.test_stream[:t+1])
-
-

--- a/tests/test_helper_method.py
+++ b/tests/test_helper_method.py
@@ -107,8 +107,9 @@ class ConversionMethodTests(unittest.TestCase):
         module = module.eval()
         self.assertIsInstance(module, MultiTaskModule)
         self.assertFalse(module.training)
-        module = module.cuda()
-        self.assertIsInstance(module, MultiTaskModule)
+        if self.device == 'cuda':
+            module = module.cuda()
+            self.assertIsInstance(module, MultiTaskModule)
 
     def _test_integration(self, module, clf_name):
         module = as_multitask(module, clf_name)


### PR DESCRIPTION
I left both the method and the test in separate files for now, let me know if you want me to integrate them to existing ones.

I think its working quite well, however they are few things to be aware of.

In particular, one thing I could not get around ( but I don't think I should ), is to make pytorch return a state_dict totally ignoring the MultiTaskDecorator class. So the state dict it returns contains the two "modules" from this class which are the "model" object and the "classifier". In any case, if a user wants to load a state dict from a multi head model he won't be able to load it into the non-multi head equivalent so I don't think this is a problem. 

Another related problem will appear when accessing the names of the modules, since now calling something like model.named_modules() will return the names prepended with "model", i.e "model.layer1.weight" instead of just "layer1.weight" . Unless the user is relying on these exact names it won't affect the behavior.

However, accessing and changing the values of model attributes ( be it modules or non modules ) is possible in a transparent manner ( accessing an attribute of the decorator directly gives a reference to the one of the underlying model ).  That way it won't add another layer of complexity in case the user wants to interact with its model attributes during training.

Test wise, I put some very basic tests but I think I will add some more, in particular I would want to test the interaction with plugins that access or change model attributes during training (I'm open to suggestions). 