### PR TITLE
Calculate loss before backpropogation

### DIFF
--- a/avalanche/training/plugins/synaptic_intelligence.py
+++ b/avalanche/training/plugins/synaptic_intelligence.py
@@ -87,8 +87,8 @@ class SynapticIntelligencePlugin(StrategyPlugin):
             strategy.model, self.ewc_data, self.syn_data,
             self.excluded_parameters)
 
-    def after_backward(self, strategy: 'BaseStrategy', **kwargs):
-        super().after_backward(strategy, **kwargs)
+    def before_backward(self, strategy: 'BaseStrategy', **kwargs):
+        super().before_backward(strategy, **kwargs)
         syn_loss = SynapticIntelligencePlugin.compute_ewc_loss(
             strategy.model, self.ewc_data, self.excluded_parameters,
             lambd=self.si_lambda, device=self.device(strategy))


### PR DESCRIPTION
Results are no longer identical when the seed is identical implying that the surrogate loss (regularisation) is being used. However since it does not perform as well as I would expect I'm a little concerned that I might not have fixed it.

![image](https://user-images.githubusercontent.com/37557393/132113419-f9c69979-86b5-49c1-b895-847404b8b72e.png)
![image](https://user-images.githubusercontent.com/37557393/132113428-796a51eb-7238-40c7-8c2a-3092eb42423a.png)

#734 