### PR TITLE
Updated the old Dead Link to ImageFolder docs

### DIFF
--- a/notebooks/from-zero-to-hero-tutorial/03_benchmarks.ipynb
+++ b/notebooks/from-zero-to-hero-tutorial/03_benchmarks.ipynb
@@ -121,7 +121,7 @@
    "id": "employed-psychiatry",
    "metadata": {},
    "source": [
-    "Of course also the basic utilities `ImageFolder` and `DatasetFolder` can be used. These are two classes that you can use to create a Pytorch Dataset directly from your files \\(following a particular structure\\). You can read more about these in the Pytorch official documentation [here](https://pytorch.org/docs/stable/torchvision/datasets.html#imagefolder).\n",
+    "Of course also the basic utilities `ImageFolder` and `DatasetFolder` can be used. These are two classes that you can use to create a Pytorch Dataset directly from your files \\(following a particular structure\\). You can read more about these in the Pytorch official documentation [here](https://pytorch.org/vision/stable/datasets.html#torchvision.datasets.ImageFolder).\n",
     "\n",
     "We also provide an additional `FilelistDataset` and `AvalancheDataset` classes. The former to construct a dataset from a filelist [\\(caffe style\\)](https://ceciliavision.wordpress.com/2016/03/08/caffedata-layer/) pointing to files anywhere on the disk. The latter to augment the basic Pytorch Dataset functionalities with an extention to better deal with a stack of transformations to be used during train and test."
    ]


### PR DESCRIPTION
Old Link Leads to a 404:
https://pytorch.org/docs/stable/torchvision/datasets.html#imagefolder
The new link appears to be:
https://pytorch.org/vision/stable/datasets.html#torchvision.datasets.ImageFolder