### PR TITLE
Allow one lambda for experience in SI

### DIFF
--- a/avalanche/training/plugins/synaptic_intelligence.py
+++ b/avalanche/training/plugins/synaptic_intelligence.py
@@ -1,6 +1,6 @@
 import warnings
 from fnmatch import fnmatch
-from typing import Sequence, Any, Set, List, Tuple, Dict, TYPE_CHECKING
+from typing import Sequence, Any, Set, List, Tuple, Dict, Union, TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -39,13 +39,17 @@ class SynapticIntelligencePlugin(StrategyPlugin):
     achieve the S.I. regularization effect.
     """
 
-    def __init__(self, si_lambda: float, eps: float = 0.0000001,
+    def __init__(self, si_lambda: Union[float, Sequence[float]],
+                 eps: float = 0.0000001,
                  excluded_parameters: Sequence['str'] = None,
                  device: Any = 'as_strategy'):
         """
         Creates an instance of the Synaptic Intelligence plugin.
 
         :param si_lambda: Synaptic Intelligence lambda term.
+            If list, one lambda for each experience. If the list has less
+            elements than the number of experiences, last lambda will be
+            used for the remaining experiences.
         :param eps: Synaptic Intelligence damping parameter.
         :param device: The device to use to run the S.I. experiences.
             Defaults to "as_strategy", which means that the `device` field of
@@ -61,7 +65,8 @@ class SynapticIntelligencePlugin(StrategyPlugin):
 
         if excluded_parameters is None:
             excluded_parameters = []
-        self.si_lambda: float = si_lambda
+        self.si_lambda = si_lambda if isinstance(si_lambda, (list, tuple)) \
+            else [si_lambda]
         self.eps: float = eps
         self.excluded_parameters: Set[str] = set(excluded_parameters)
         self.ewc_data: EwcDataType = (dict(), dict())
@@ -91,9 +96,16 @@ class SynapticIntelligencePlugin(StrategyPlugin):
 
     def before_backward(self, strategy: 'BaseStrategy', **kwargs):
         super().before_backward(strategy, **kwargs)
+
+        exp_id = strategy.clock.train_exp_counter
+        try:
+            si_lamb = self.si_lambda[exp_id]
+        except IndexError:  # less than one lambda per experience, take last
+            si_lamb = self.si_lambda[-1]
+
         syn_loss = SynapticIntelligencePlugin.compute_ewc_loss(
             strategy.model, self.ewc_data, self.excluded_parameters,
-            lambd=self.si_lambda, device=self.device(strategy))
+            lambd=si_lamb, device=self.device(strategy))
 
         if syn_loss is not None:
             strategy.loss += syn_loss.to(strategy.device)

--- a/avalanche/training/strategies/strategy_wrappers.py
+++ b/avalanche/training/strategies/strategy_wrappers.py
@@ -524,8 +524,8 @@ class SynapticIntelligence(BaseStrategy):
     """
 
     def __init__(self, model: Module, optimizer: Optimizer, criterion,
-                 si_lambda: float, eps: float = 0.0000001,
-                 train_mb_size: int = 1,
+                 si_lambda: Union[float, Sequence[float]],
+                 eps: float = 0.0000001, train_mb_size: int = 1,
                  train_epochs: int = 1, eval_mb_size: int = 1, device='cpu',
                  plugins: Optional[Sequence['StrategyPlugin']] = None,
                  evaluator=default_logger, eval_every=-1):
@@ -536,6 +536,9 @@ class SynapticIntelligence(BaseStrategy):
         :param optimizer: PyTorch optimizer.
         :param criterion: loss function.
         :param si_lambda: Synaptic Intelligence lambda term.
+            If list, one lambda for each experience. If the list has less
+            elements than the number of experiences, last lambda will be
+            used for the remaining experiences.
         :param eps: Synaptic Intelligence damping parameter.
         :param train_mb_size: mini-batch size for training.
         :param train_epochs: number of training epochs.


### PR DESCRIPTION
SI, like LwF, accepts one lambda for each experience.
If the number of experiences is greater than the number of lambdas, last lambda will be used for the remaining experiences.