### PR TITLE
FIX config type in WandBLogger by accepting a plain dictionary as input

### DIFF
--- a/avalanche/logging/wandb_logger.py
+++ b/avalanche/logging/wandb_logger.py
@@ -93,7 +93,7 @@ class WandBLogger(StrategyLogger):
         self.init_kwargs = {"project": self.project_name, "name": self.run_name, 
                             "sync_tensorboard": self.sync_tfboard, 
                             "dir": self.dir, "save_code": self.save_code, 
-                            "config": vars(self.config)}
+                            "config": self.config}
         if self.params:
             self.init_kwargs.update(self.params)
 

--- a/examples/wandb_logger.py
+++ b/examples/wandb_logger.py
@@ -74,7 +74,7 @@ def main(args):
 
     interactive_logger = InteractiveLogger()
     wandb_logger = WandBLogger(project_name=args.project, run_name=args.run, 
-                               config=args)
+                               config=vars(args))
 
     eval_plugin = EvaluationPlugin(
         accuracy_metrics(


### PR DESCRIPTION
WandBLogger now accepts as input a dictionary which can be helpful for cases where the hyperparameters are loaded as a dictionary from a file.