### PR TITLE
Add support for gym.Env experiences  

### DIFF
--- a/avalanche/benchmarks/scenarios/generic_cl_scenario.py
+++ b/avalanche/benchmarks/scenarios/generic_cl_scenario.py
@@ -6,7 +6,12 @@ from typing import Generic, TypeVar, Union, Sequence, Callable, Optional, \
 
 import warnings
 from torch.utils.data.dataset import Dataset
-from gym import Env
+try:
+    from gym import Env
+except ImportError:
+    # empty class to make sure everything below works without changes
+    class Env:
+        pass
 
 from avalanche.benchmarks.scenarios.generic_definitions import \
     TExperience, ScenarioStream, TScenarioStream, Experience, TScenario

--- a/avalanche/benchmarks/scenarios/generic_cl_scenario.py
+++ b/avalanche/benchmarks/scenarios/generic_cl_scenario.py
@@ -22,7 +22,8 @@ TGenericScenarioStream = TypeVar('TGenericScenarioStream',
 
 RLStreamDataOrigin = Union[Env, Sequence[Env]]
 TStreamDataOrigin = Union[AvalancheDataset, Sequence[AvalancheDataset],
-                          Tuple[Iterable[AvalancheDataset], int], RLStreamDataOrigin]
+                          Tuple[Iterable[AvalancheDataset], int], 
+                          RLStreamDataOrigin]
 TStreamTaskLabels = Optional[Sequence[Union[int, Set[int]]]]
 TOriginDataset = Optional[Dataset]
 
@@ -438,7 +439,8 @@ class GenericCLScenario(Generic[TExperience]):
             exp_data = [exp_data]
             is_lazy = False
             stream_length = 1
-        elif isinstance(exp_data, Env) or all([isinstance(e, Env) for e in exp_data]):
+        elif isinstance(exp_data, Env) or \
+                all([isinstance(e, Env) for e in exp_data]):
             return StreamDef(exp_data, None, None, False)
         else:
             # Standard def

--- a/avalanche/benchmarks/scenarios/generic_cl_scenario.py
+++ b/avalanche/benchmarks/scenarios/generic_cl_scenario.py
@@ -6,6 +6,7 @@ from typing import Generic, TypeVar, Union, Sequence, Callable, Optional, \
 
 import warnings
 from torch.utils.data.dataset import Dataset
+from gym import Env
 
 from avalanche.benchmarks.scenarios.generic_definitions import \
     TExperience, ScenarioStream, TScenarioStream, Experience, TScenario
@@ -19,8 +20,9 @@ TGenericExperience = TypeVar('TGenericExperience', bound='GenericExperience')
 TGenericScenarioStream = TypeVar('TGenericScenarioStream',
                                  bound='GenericScenarioStream')
 
+RLStreamDataOrigin = Union[Env, Sequence[Env]]
 TStreamDataOrigin = Union[AvalancheDataset, Sequence[AvalancheDataset],
-                          Tuple[Iterable[AvalancheDataset], int]]
+                          Tuple[Iterable[AvalancheDataset], int], RLStreamDataOrigin]
 TStreamTaskLabels = Optional[Sequence[Union[int, Set[int]]]]
 TOriginDataset = Optional[Dataset]
 
@@ -436,6 +438,8 @@ class GenericCLScenario(Generic[TExperience]):
             exp_data = [exp_data]
             is_lazy = False
             stream_length = 1
+        elif isinstance(exp_data, Env) or all([isinstance(e, Env) for e in exp_data]):
+            return StreamDef(exp_data, None, None, False)
         else:
             # Standard def
             stream_length = len(exp_data)

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,3 +31,4 @@ dependencies:
 - pip:
     - pytorchcv
     - gdown
+    - gym

--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,4 @@ dependencies:
 - pip:
     - pytorchcv
     - gdown
+    - gym


### PR DESCRIPTION
This change is aimed at supporting [Avalanche-RL](https://github.com/ContinualAI/avalanche-rl/) fork by including `gym.Env` as a possible data type to be contained within experiences.
It enables Avalanche RL to utilize Avalanche benchmark module as a direct dependency without touching its source code.

I should also mention that OpenAI `gym` would now become a required dependency for Avalanche as well.

I'm very open to discuss this kind of change and evaluate any alternative options that I may overlooked in order to support benchmarks with `gym.Env` experiences .