### PR TITLE
Fix setup.py problems: change outdated url, add modules to install_requires list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
                 "Research",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/vlomonaco/avalanche",
+    url="https://github.com/ContinualAI/avalanche",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
@@ -47,6 +47,9 @@ setuptools.setup(
         'wandb',
         'tensorboard',
         'pycocotools',
-        'tqdm'
+        'tqdm',
+        'torch',
+        'torchvision',
+        'gdown',
     ]
 )


### PR DESCRIPTION
The PR fixes a couple of problems in the `setup.py` file.

*First* the url to the repository was outdated, pointing at github.com/vlomonaco/avalanche which is currently extremely behind master branch.

*Second* it changes the `python_requires` to include the newly released [Python 3.10 version](https://www.python.org/downloads/release/python-3100/).

*Third* it adds to the list of `install_requires` many modules that must be installed in order to `import avalanche`, under penalty of ModuleNotFoundError.
Those are `torch`, `torchvision`, `gdown`.

As a sidenote the list of currently installed modules is huge, and I would consider setting those as [extras](http://peak.telecommunity.com/DevCenter/setuptools#declaring-extras-optional-features-with-their-own-dependencies) and import them only in code that actually uses them using a standard try/catch clause to warn the user that a certain feature is only available when installing additional dependencies.