### PR TITLE
Fix import error in Python 3.9

### DIFF
--- a/avalanche/benchmarks/utils/avalanche_dataset.py
+++ b/avalanche/benchmarks/utils/avalanche_dataset.py
@@ -157,8 +157,6 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
             the value of the second element returned by `__getitem__`.
             The adapter is used to adapt the values of the targets field only.
         """
-        super().__init__()
-
         if transform_groups is not None and (
                 transform is not None or target_transform is not None):
             raise ValueError('transform_groups can\'t be used with transform'

--- a/avalanche/benchmarks/utils/dataset_utils.py
+++ b/avalanche/benchmarks/utils/dataset_utils.py
@@ -246,8 +246,6 @@ class SequenceDataset(IDatasetWithTargets[T_co, TTargetType]):
             means that the second sequence (usually containing the "y" values)
             will be used for the targets field.
         """
-        super().__init__()
-
         if len(sequences) < 1:
             raise ValueError('At least one sequence must be passed')
 

--- a/avalanche/evaluation/metric_definitions.py
+++ b/avalanche/evaluation/metric_definitions.py
@@ -87,7 +87,7 @@ class PluginMetric(Metric[TResult], StrategyCallbacks['MetricResult'], ABC):
         Child classes can safely invoke this (super) constructor as the first
         experience.
         """
-        super().__init__()
+        pass
 
     @abstractmethod
     def result(self, **kwargs) -> Optional[TResult]:

--- a/avalanche/evaluation/metrics/accuracy.py
+++ b/avalanche/evaluation/metrics/accuracy.py
@@ -44,7 +44,6 @@ class Accuracy(Metric[float]):
         value of 0. The metric can be updated by using the `update` method
         while the running accuracy can be retrieved using the `result` method.
         """
-        super().__init__()
         self._mean_accuracy = defaultdict(Mean)
         """
         The mean utility that will be used to store the running accuracy

--- a/avalanche/evaluation/metrics/forgetting_bwt.py
+++ b/avalanche/evaluation/metrics/forgetting_bwt.py
@@ -39,8 +39,6 @@ class Forgetting(Metric[Union[float, None, Dict[int, float]]]):
         Creates an instance of the standalone Forgetting metric
         """
 
-        super().__init__()
-
         self.initial: Dict[int, float] = dict()
         """
         The initial value for each key.

--- a/avalanche/evaluation/metrics/forward_transfer.py
+++ b/avalanche/evaluation/metrics/forward_transfer.py
@@ -40,8 +40,6 @@ class ForwardTransfer(Metric[Union[float, None, Dict[int, float]]]):
         Creates an instance of the standalone Forward Transfer metric
         """
 
-        super().__init__()
-
         self.initial: Dict[int, float] = dict()
         """
         The initial value for each key. This is the accuracy at 

--- a/avalanche/evaluation/metrics/labels_repartition.py
+++ b/avalanche/evaluation/metrics/labels_repartition.py
@@ -35,7 +35,6 @@ class LabelsRepartition(Metric):
     Metric used to monitor the labels repartition.
     """
     def __init__(self):
-        super().__init__()
         self.task2label2count: Dict[int, Dict[int, int]] = {}
         self.class_order = None
         self.reset()

--- a/avalanche/evaluation/metrics/mean.py
+++ b/avalanche/evaluation/metrics/mean.py
@@ -29,7 +29,6 @@ class Mean(Metric[float]):
         The metric can be updated by using the `update` method while the mean
         can be retrieved using the `result` method.
         """
-        super().__init__()
         self.summed: float = 0.0
         self.weight: float = 0.0
 
@@ -101,7 +100,6 @@ class Sum(Metric[float]):
         The metric can be updated by using the `update` method while the sum
         can be retrieved using the `result` method.
         """
-        super().__init__()
         self.summed: float = 0.0
 
     def update(self, value: SupportsFloat) -> None:

--- a/avalanche/evaluation/metrics/mean_scores.py
+++ b/avalanche/evaluation/metrics/mean_scores.py
@@ -45,7 +45,6 @@ class MeanScores(Metric):
     """
 
     def __init__(self):
-        super().__init__()
         self.label2mean: Dict[int, Mean] = defaultdict(Mean)
         self.reset()
 


### PR DESCRIPTION
Under python 3.9 just importing the module causes an error "Protocols cannot be initialized".
The given error is found inside typing_extensions and warns the user about an invalid use of [protocols](https://www.python.org/dev/peps/pep-0544/): instantiation.

https://github.com/python/typing/blob/68e7cb7c90a1932e04fde6808a3ca9d3818fd64c/typing_extensions/src_py3/typing_extensions.py#L1157-L1159

It is clear that instantiating an object of a Protocol class bears no meaning since the protocol only details abstract specificiations and thus cannot be instantiated and this is enforced by typing_extensions when building a generic protocol class:

https://github.com/python/typing/blob/68e7cb7c90a1932e04fde6808a3ca9d3818fd64c/typing_extensions/src_py3/typing_extensions.py#L1233-L1251

To better understand the issue consider as example the class Accuracy in `avalanche/evaluation/metrics/accuracy.py` which inherits from Metric[float] defined in `avalanche/evaluation/metric_definitions.py`, itself inheriting from Protocol[T] where T is a typevariable.
https://github.com/ContinualAI/avalanche/blob/master/avalanche/evaluation/metrics/accuracy.py#L22-L52
Clearly line 47 `super().__init__()` is uncorrect in this setting, since Metric[float] being a protocol there is no initialization to be done.

This PR solves the issue by removing all such `super().__init__()` lines from classes whose MRO would call a Protocol `__init__` method. Be warned that such lines have been found by grepping sources so that the list may be incomplete, but at least tests do pass and the module can be imported.