### PR TITLE
Add Experience-Change Logging to WandBLogger

### DIFF
--- a/avalanche/logging/wandb_logger.py
+++ b/avalanche/logging/wandb_logger.py
@@ -28,7 +28,6 @@ from matplotlib.pyplot import Figure
 from avalanche.evaluation.metric_results import AlternativeValues, \
     MetricValue, TensorImage
 from avalanche.logging import StrategyLogger
-from avalanche.training.strategies import BaseStrategy
 
 
 class WandBLogger(StrategyLogger):

--- a/avalanche/logging/wandb_logger.py
+++ b/avalanche/logging/wandb_logger.py
@@ -11,7 +11,7 @@
 """ This module handles all the functionalities related to the logging of
 Avalanche experiments using Weights & Biases. """
 
-from typing import Union, List
+from typing import Union, List, TYPE_CHECKING
 from pathlib import Path
 import os
 import errno
@@ -28,6 +28,10 @@ from matplotlib.pyplot import Figure
 from avalanche.evaluation.metric_results import AlternativeValues, \
     MetricValue, TensorImage
 from avalanche.logging import StrategyLogger
+
+if TYPE_CHECKING:
+    from avalanche.evaluation.metric_results import MetricValue
+    from avalanche.training.strategies import BaseStrategy
 
 
 class WandBLogger(StrategyLogger):

--- a/avalanche/logging/wandb_logger.py
+++ b/avalanche/logging/wandb_logger.py
@@ -117,7 +117,7 @@ class WandBLogger(StrategyLogger):
         for val in metric_values:
             self.log_metric(val, 'after_training_exp')
 
-        self.wandb.log({"Experience": self.exp_count},
+        self.wandb.log({"TrainingExperience": self.exp_count},
                        step=self.step)
         self.exp_count += 1
 

--- a/avalanche/logging/wandb_logger.py
+++ b/avalanche/logging/wandb_logger.py
@@ -28,6 +28,7 @@ from matplotlib.pyplot import Figure
 from avalanche.evaluation.metric_results import AlternativeValues, \
     MetricValue, TensorImage
 from avalanche.logging import StrategyLogger
+from avalanche.training.strategies import BaseStrategy
 
 
 class WandBLogger(StrategyLogger):


### PR DESCRIPTION
This PR adds experience-change logging to the WandB logger by explicitly setting the step in `wandb.log(.)`.   This can be useful to have more meaningful visualizations in some of the plots.

Example:
![Screenshot 2022-01-09 at 18 28 44](https://user-images.githubusercontent.com/11629528/148693981-fd3016b5-b9ad-497b-92e3-eface643a94b.png)

is mapped to:
![Screenshot 2022-01-09 at 18 28 08](https://user-images.githubusercontent.com/11629528/148693964-8a30db4c-e81e-496d-a7fe-d144143ccfa2.png)
)