### PR TITLE
evaluation can receive metric values from anywhere

### DIFF
--- a/tests/training/test_plugins.py
+++ b/tests/training/test_plugins.py
@@ -16,10 +16,11 @@ from torch.utils.data.dataloader import DataLoader
 from avalanche.benchmarks import nc_benchmark, GenericCLScenario, \
     benchmark_with_validation_stream
 from avalanche.benchmarks.utils.data_loader import TaskBalancedDataLoader
+from avalanche.evaluation.metric_results import MetricValue
 from avalanche.evaluation.metrics import Mean
 from avalanche.logging import TextLogger
 from avalanche.models import BaseModel
-from avalanche.training.plugins import StrategyPlugin
+from avalanche.training.plugins import StrategyPlugin, EvaluationPlugin
 from avalanche.training.plugins.lr_scheduling import LRSchedulerPlugin
 from avalanche.training.strategies import Naive
 
@@ -540,6 +541,16 @@ class _PlainMLP(nn.Module, BaseModel):
         x = x.view(x.size(0), self._input_size)
         x = self.features(x)
         return x
+
+
+class EvaluationPluginTest(unittest.TestCase):
+    def test_publish_metric(self):
+        ep = EvaluationPlugin()
+        mval = MetricValue(self, 'metric', 1.0, 0)
+        ep.publish_metric_value(mval)
+
+        # check key exists
+        assert len(ep.get_all_metrics()['metric'][1]) == 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a small feature to the EvaluationPlugin that allows to compute metrics outside MetricPlugins.
For example, let's assume that a strategy computes a loss function with many regularization terms, and we want to log each one separately. This is possible with the new API:

```
    # This is a strategy method, not a metric plugin.
    def criterion(self):
        if self.is_training:
            pred = self.teacher_targets.detach().max(dim=1)[1]
            loss_activation = -self.teacher_features.abs().mean()
            loss_ce = F.cross_entropy(self.teacher_targets, pred)
            loss = loss_ce * self.oh + loss_activation * self.a
            
           # Metric is logged here.
            xp = self.clock.train_iterations
            mval = MetricValue(origin=self, name='loss_ce', value=loss_ce.item(), x_plot=xp)
            self.evaluator.publish_metric_value(mval)
            mval = MetricValue(origin=self, name='loss_a', value=loss_activation.item(), x_plot=xp)
            self.evaluator.publish_metric_value(mval)
```

Doing the same with metric plugins is possible but much more verbose.