### PR TITLE
Add new options to ReplayPlugin and ReplayDataLoader

### DIFF
--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -25,7 +25,7 @@ from avalanche.benchmarks.utils import AvalancheDataset
 
 
 def _default_collate_mbatches_fn(mbatches):
-    """Combines multiple mini-batches together.
+    """ Combines multiple mini-batches together.
 
     Concatenates each tensor in the mini-batches along dimension 0 (usually this
     is the batch size).
@@ -41,16 +41,13 @@ def _default_collate_mbatches_fn(mbatches):
 
 
 class TaskBalancedDataLoader:
-    """Task-balanced data loader for Avalanche's datasets."""
+    """ Task-balanced data loader for Avalanche's datasets."""
 
-    def __init__(
-        self,
-        data: AvalancheDataset,
-        oversample_small_tasks: bool = False,
-        collate_mbatches=_default_collate_mbatches_fn,
-        **kwargs
-    ):
-        """Task-balanced data loader for Avalanche's datasets.
+    def __init__(self, data: AvalancheDataset,
+                 oversample_small_tasks: bool = False,
+                 collate_mbatches=_default_collate_mbatches_fn,
+                 **kwargs):
+        """ Task-balanced data loader for Avalanche's datasets.
 
         The iterator returns a mini-batch balanced across each task, which
         makes it useful when training in multi-task scenarios whenever data is
@@ -84,11 +81,11 @@ class TaskBalancedDataLoader:
         # the iteration logic is implemented by GroupBalancedDataLoader.
         # we use kwargs to pass the arguments to avoid passing the same
         # arguments multiple times.
-        if "data" in kwargs:
-            del kwargs["data"]
+        if 'data' in kwargs:
+            del kwargs['data']
         # needed if they are passed as positional arguments
-        kwargs["oversample_small_groups"] = oversample_small_tasks
-        kwargs["collate_mbatches"] = collate_mbatches
+        kwargs['oversample_small_groups'] = oversample_small_tasks
+        kwargs['collate_mbatches'] = collate_mbatches
         self._dl = GroupBalancedDataLoader(datasets=task_datasets, **kwargs)
 
     def __iter__(self):
@@ -100,17 +97,14 @@ class TaskBalancedDataLoader:
 
 
 class GroupBalancedDataLoader:
-    """Data loader that balances data from multiple datasets."""
+    """ Data loader that balances data from multiple datasets."""
 
-    def __init__(
-        self,
-        datasets: Sequence[AvalancheDataset],
-        oversample_small_groups: bool = False,
-        collate_mbatches=_default_collate_mbatches_fn,
-        batch_size: int = 32,
-        **kwargs
-    ):
-        """Data loader that balances data from multiple datasets.
+    def __init__(self, datasets: Sequence[AvalancheDataset],
+                 oversample_small_groups: bool = False,
+                 collate_mbatches=_default_collate_mbatches_fn,
+                 batch_size: int = 32,
+                 **kwargs):
+        """ Data loader that balances data from multiple datasets.
 
         Mini-batches emitted by this dataloader are created by collating
         together mini-batches from each group. It may be used to balance data
@@ -190,16 +184,13 @@ class GroupBalancedDataLoader:
 
 
 class GroupBalancedInfiniteDataLoader:
-    """Data loader that balances data from multiple datasets emitting an
-    infinite stream."""
+    """ Data loader that balances data from multiple datasets emitting an
+        infinite stream."""
 
-    def __init__(
-        self,
-        datasets: Sequence[AvalancheDataset],
-        collate_mbatches=_default_collate_mbatches_fn,
-        **kwargs
-    ):
-        """Data loader that balances data from multiple datasets emitting an
+    def __init__(self, datasets: Sequence[AvalancheDataset],
+                 collate_mbatches=_default_collate_mbatches_fn,
+                 **kwargs):
+        """ Data loader that balances data from multiple datasets emitting an
         infinite stream.
 
         Mini-batches emitted by this dataloader are created by collating
@@ -218,10 +209,12 @@ class GroupBalancedInfiniteDataLoader:
         self.collate_mbatches = collate_mbatches
 
         for data in self.datasets:
-            infinite_sampler = RandomSampler(
-                data, replacement=True, num_samples=10 ** 10
-            )
-            dl = DataLoader(data, sampler=infinite_sampler, **kwargs)
+            infinite_sampler = RandomSampler(data, replacement=True,
+                                             num_samples=10 ** 10)
+            dl = DataLoader(
+                data,
+                sampler=infinite_sampler,
+                **kwargs)
             self.dataloaders.append(dl)
         self.max_len = 10 ** 10
 
@@ -242,19 +235,16 @@ class GroupBalancedInfiniteDataLoader:
 
 
 class ReplayDataLoader:
-    """Custom data loader for rehearsal/replay strategies."""
+    """ Custom data loader for rehearsal/replay strategies."""
 
-    def __init__(
-        self,
-        data: AvalancheDataset,
-        memory: AvalancheDataset = None,
-        oversample_small_tasks: bool = False,
-        collate_mbatches=_default_collate_mbatches_fn,
-        batch_size: int = 32,
-        force_data_batch_size: int = None,
-        **kwargs
-    ):
-        """Custom data loader for rehearsal strategies.
+    def __init__(self, data: AvalancheDataset, memory: AvalancheDataset = None,
+                 oversample_small_tasks: bool = False,
+                 collate_mbatches=_default_collate_mbatches_fn,
+                 batch_size_data: int = 32,
+                 batch_size_mem: int = 32,
+                 task_balanced_dataloader: bool = False,
+                 **kwargs):
+        """ Custom data loader for rehearsal strategies.
 
         The iterates in parallel two datasets, the current `data` and the
         rehearsal `memory`, which are used to create mini-batches by
@@ -272,11 +262,14 @@ class ReplayDataLoader:
         :param collate_mbatches: function that given a sequence of mini-batches
             (one for each task) combines them into a single mini-batch. Used to
             combine the mini-batches obtained separately from each task.
-        :param batch_size: the size of the batch. It must be greater than or
-            equal to the number of tasks.
-        :param force_data_batch_size: How many of the samples should be from the
-            current `data`. If None, it will equally divide each batch between
-            samples from all seen tasks in the current `data` and `memory`.
+        :param batch_size_data: the size of the data batch. It must be greater
+            than or equal to the number of tasks.
+        :param batch_size_mem: the size of the memory batch. If
+            `task_balanced_dataloader` is set to True, it must be greater than
+            or equal to the number of tasks.
+        :param task_balanced_dataloader: if true, buffer data loaders will be
+            task-balanced, otherwise it creates a single data loader for the
+            buffer samples.
         :param kwargs: data loader arguments used to instantiate the loader for
             each task separately. See pytorch :class:`DataLoader`.
         """
@@ -288,55 +281,32 @@ class ReplayDataLoader:
         self.oversample_small_tasks = oversample_small_tasks
         self.collate_mbatches = collate_mbatches
 
-        if force_data_batch_size is not None:
-            assert (
-                force_data_batch_size <= batch_size
-            ), "Forced batch size of data must be <= entire batch size"
-
-            remaining_example_data = 0
-
-            mem_keys = len(self.memory.task_set)
-            mem_batch_size = batch_size - force_data_batch_size
-            mem_batch_size_k = mem_batch_size // mem_keys
-            remaining_example_mem = mem_batch_size % mem_keys
-
-            assert mem_batch_size >= mem_keys, (
-                "Batch size must be greator or equal "
-                "to the number of tasks in the memory."
-            )
-
-            self.loader_data, _ = self._create_dataloaders(
-                data, force_data_batch_size, remaining_example_data, **kwargs
-            )
-            self.loader_memory, _ = self._create_dataloaders(
-                memory, mem_batch_size_k, remaining_example_mem, **kwargs
-            )
-        else:
-            num_keys = len(self.data.task_set) + len(self.memory.task_set)
-            assert batch_size >= num_keys, (
-                "Batch size must be greator or equal "
-                "to the number of tasks in the memory "
+        num_keys = len(self.memory.task_set)
+        if task_balanced_dataloader:
+            assert batch_size_mem >= num_keys, \
+                "Batch size must be greator or equal " \
+                "to the number of tasks in the memory " \
                 "and current data."
-            )
 
-            single_group_batch_size = batch_size // num_keys
-            remaining_example = batch_size % num_keys
+        # Create dataloader for data items
+        self.loader_data, _ = self._create_dataloaders(
+            data, batch_size_data, 0, False, **kwargs)
 
-            self.loader_data, remaining_example = self._create_dataloaders(
-                data, single_group_batch_size, remaining_example, **kwargs
-            )
-            self.loader_memory, remaining_example = self._create_dataloaders(
-                memory, single_group_batch_size, remaining_example, **kwargs
-            )
+        # Create dataloader for memory items
+        if task_balanced_dataloader:
+            single_group_batch_size = batch_size_mem // num_keys
+            remaining_example = batch_size_mem % num_keys
+        else:
+            single_group_batch_size = batch_size_mem
+            remaining_example = 0
 
-        self.max_len = max(
-            [
-                len(d)
-                for d in chain(
-                    self.loader_data.values(), self.loader_memory.values()
-                )
-            ]
-        )
+        self.loader_memory, remaining_example = self._create_dataloaders(
+            memory, single_group_batch_size, remaining_example,
+            task_balanced_dataloader, **kwargs)
+
+        self.max_len = max([len(d) for d in chain(
+            self.loader_data.values(), self.loader_memory.values())]
+                           )
 
     def __iter__(self):
         iter_data_dataloaders = {}
@@ -347,33 +317,20 @@ class ReplayDataLoader:
         for t in self.loader_memory.keys():
             iter_buffer_dataloaders[t] = iter(self.loader_memory[t])
 
-        max_len = max(
-            [
-                len(d)
-                for d in chain(
-                    iter_data_dataloaders.values(),
-                    iter_buffer_dataloaders.values(),
-                )
-            ]
-        )
+        max_len = max([len(d) for d in iter_data_dataloaders.values()])
+
         try:
             for it in range(max_len):
                 mb_curr = []
                 self._get_mini_batch_from_data_dict(
-                    self.data,
-                    iter_data_dataloaders,
-                    self.loader_data,
-                    self.oversample_small_tasks,
-                    mb_curr,
-                )
+                    self.data, iter_data_dataloaders,
+                    self.loader_data, False,
+                    mb_curr)
 
                 self._get_mini_batch_from_data_dict(
-                    self.memory,
-                    iter_buffer_dataloaders,
-                    self.loader_memory,
-                    self.oversample_small_tasks,
-                    mb_curr,
-                )
+                    self.memory, iter_buffer_dataloaders,
+                    self.loader_memory, self.oversample_small_tasks,
+                    mb_curr)
 
                 yield self.collate_mbatches(mb_curr)
         except StopIteration:
@@ -382,14 +339,9 @@ class ReplayDataLoader:
     def __len__(self):
         return self.max_len
 
-    def _get_mini_batch_from_data_dict(
-        self,
-        data,
-        iter_dataloaders,
-        loaders_dict,
-        oversample_small_tasks,
-        mb_curr,
-    ):
+    def _get_mini_batch_from_data_dict(self, data, iter_dataloaders,
+                                       loaders_dict, oversample_small_tasks,
+                                       mb_curr):
         # list() is necessary because we may remove keys from the
         # dictionary. This would break the generator.
         for t in list(iter_dataloaders.keys()):
@@ -408,25 +360,29 @@ class ReplayDataLoader:
                     continue
             mb_curr.append(tbatch)
 
-    def _create_dataloaders(
-        self, data_dict, single_exp_batch_size, remaining_example, **kwargs
-    ):
+    def _create_dataloaders(self, data_dict, single_exp_batch_size,
+                            remaining_example, task_balanced_dataloader,
+                            **kwargs):
         loaders_dict: Dict[int, DataLoader] = {}
-        for task_id in data_dict.task_set:
-            data = data_dict.task_set[task_id]
-            current_batch_size = single_exp_batch_size
-            if remaining_example > 0:
-                current_batch_size += 1
-                remaining_example -= 1
-            loaders_dict[task_id] = DataLoader(
-                data, batch_size=current_batch_size, **kwargs
-            )
+        if task_balanced_dataloader:
+            for task_id in data_dict.task_set:
+                data = data_dict.task_set[task_id]
+                current_batch_size = single_exp_batch_size
+                if remaining_example > 0:
+                    current_batch_size += 1
+                    remaining_example -= 1
+                loaders_dict[task_id] = DataLoader(
+                    data, batch_size=current_batch_size, **kwargs)
+        else:
+            loaders_dict[0] = DataLoader(
+                data_dict, batch_size=single_exp_batch_size, **kwargs)
+
         return loaders_dict, remaining_example
 
 
 __all__ = [
-    "TaskBalancedDataLoader",
-    "GroupBalancedDataLoader",
-    "ReplayDataLoader",
-    "GroupBalancedInfiniteDataLoader",
+    'TaskBalancedDataLoader',
+    'GroupBalancedDataLoader',
+    'ReplayDataLoader',
+    'GroupBalancedInfiniteDataLoader'
 ]

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -240,7 +240,7 @@ class ReplayDataLoader:
     def __init__(self, data: AvalancheDataset, memory: AvalancheDataset = None,
                  oversample_small_tasks: bool = False,
                  collate_mbatches=_default_collate_mbatches_fn,
-                 batch_size: int = 32,
+                 batch_size_data: int = 32,
                  batch_size_mem: int = 32,
                  task_balanced_dataloader: bool = False,
                  **kwargs):
@@ -262,7 +262,7 @@ class ReplayDataLoader:
         :param collate_mbatches: function that given a sequence of mini-batches
             (one for each task) combines them into a single mini-batch. Used to
             combine the mini-batches obtained separately from each task.
-        :param batch_size: the size of the data batch. It must be greater
+        :param batch_size_data: the size of the data batch. It must be greater
             than or equal to the number of tasks.
         :param batch_size_mem: the size of the memory batch. If
             `task_balanced_dataloader` is set to True, it must be greater than
@@ -290,7 +290,7 @@ class ReplayDataLoader:
 
         # Create dataloader for data items
         self.loader_data, _ = self._create_dataloaders(
-            data, batch_size, 0, False, **kwargs)
+            data, batch_size_data, 0, False, **kwargs)
 
         # Create dataloader for memory items
         if task_balanced_dataloader:

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -240,7 +240,7 @@ class ReplayDataLoader:
     def __init__(self, data: AvalancheDataset, memory: AvalancheDataset = None,
                  oversample_small_tasks: bool = False,
                  collate_mbatches=_default_collate_mbatches_fn,
-                 batch_size_data: int = 32,
+                 batch_size: int = 32,
                  batch_size_mem: int = 32,
                  task_balanced_dataloader: bool = False,
                  **kwargs):
@@ -262,7 +262,7 @@ class ReplayDataLoader:
         :param collate_mbatches: function that given a sequence of mini-batches
             (one for each task) combines them into a single mini-batch. Used to
             combine the mini-batches obtained separately from each task.
-        :param batch_size_data: the size of the data batch. It must be greater
+        :param batch_size: the size of the data batch. It must be greater
             than or equal to the number of tasks.
         :param batch_size_mem: the size of the memory batch. If
             `task_balanced_dataloader` is set to True, it must be greater than
@@ -290,7 +290,7 @@ class ReplayDataLoader:
 
         # Create dataloader for data items
         self.loader_data, _ = self._create_dataloaders(
-            data, batch_size_data, 0, False, **kwargs)
+            data, batch_size, 0, False, **kwargs)
 
         # Create dataloader for memory items
         if task_balanced_dataloader:

--- a/avalanche/training/plugins/replay.py
+++ b/avalanche/training/plugins/replay.py
@@ -1,12 +1,11 @@
 from typing import Optional, TYPE_CHECKING
 
 from avalanche.benchmarks.utils import AvalancheConcatDataset
-from avalanche.benchmarks.utils.data_loader import ReplayDataLoader
+from avalanche.benchmarks.utils.data_loader import \
+    ReplayDataLoader
 from avalanche.training.plugins.strategy_plugin import StrategyPlugin
-from avalanche.training.storage_policy import (
-    ExemplarsBuffer,
-    ExperienceBalancedBuffer,
-)
+from avalanche.training.storage_policy import ExemplarsBuffer, \
+    ExperienceBalancedBuffer
 
 if TYPE_CHECKING:
     from avalanche.training.strategies import BaseStrategy
@@ -18,53 +17,53 @@ class ReplayPlugin(StrategyPlugin):
 
     Handles an external memory filled with randomly selected
     patterns and implementing `before_training_exp` and `after_training_exp`
-    callbacks.
+    callbacks. 
     The `before_training_exp` callback is implemented in order to use the
     dataloader that creates mini-batches with examples from both training
-    data and external memory. The examples in the mini-batch is balanced
-    such that there are the same number of examples for each experience.
-
-    The `after_training_exp` callback is implemented in order to add new
+    data and external memory. The examples in the mini-batch is balanced 
+    such that there are the same number of examples for each experience.    
+    
+    The `after_training_exp` callback is implemented in order to add new 
     patterns to the external memory.
 
-    The :mem_size: attribute controls the total number of patterns to be stored
+    The :mem_size: attribute controls the total number of patterns to be stored 
     in the external memory.
+
+    :param batch_size_mem: the size of the memory batch. If
+        `task_balanced_dataloader` is set to True, it must be greater than or
+        equal to the number of tasks. If its value is set to `None`
+        (the default value), it will be automatically set equal to the
+        data batch size.
+    :param task_balanced_dataloader: if True, buffer data loaders will be
+            task-balanced, otherwise it will create a single dataloader for the
+            buffer samples.
     :param storage_policy: The policy that controls how to add new exemplars
                            in memory
-    :param force_data_batch_size: How many of the samples should be from the
-            current `data`. If None, it will equally divide each batch between
-            samples from all seen tasks in the current `data` and `memory`.
     """
 
-    def __init__(
-        self,
-        mem_size: int = 200,
-        storage_policy: Optional["ExemplarsBuffer"] = None,
-        force_data_batch_size: int = None,
-    ):
+    def __init__(self, mem_size: int = 200, batch_size_mem: int = None,
+                 task_balanced_dataloader: bool = False,
+                 storage_policy: Optional["ExemplarsBuffer"] = None):
         super().__init__()
         self.mem_size = mem_size
-        self.force_data_batch_size = force_data_batch_size
+        self.batch_size_mem = batch_size_mem
+        self.task_balanced_dataloader = task_balanced_dataloader
 
         if storage_policy is not None:  # Use other storage policy
             self.storage_policy = storage_policy
             assert storage_policy.max_size == self.mem_size
         else:  # Default
             self.storage_policy = ExperienceBalancedBuffer(
-                max_size=self.mem_size, adaptive_size=True
-            )
+                max_size=self.mem_size,
+                adaptive_size=True)
 
     @property
     def ext_mem(self):
         return self.storage_policy.buffer_groups  # a Dict<task_id, Dataset>
 
-    def before_training_exp(
-        self,
-        strategy: "BaseStrategy",
-        num_workers: int = 0,
-        shuffle: bool = True,
-        **kwargs
-    ):
+    def before_training_exp(self, strategy: "BaseStrategy",
+                            num_workers: int = 0, shuffle: bool = True,
+                            **kwargs):
         """
         Dataloader to build batches containing examples from both memories and
         the training dataset
@@ -73,15 +72,20 @@ class ReplayPlugin(StrategyPlugin):
             # first experience. We don't use the buffer, no need to change
             # the dataloader.
             return
+
+        batch_size_mem = self.batch_size_mem
+        if batch_size_mem is None:
+            batch_size_mem = strategy.train_mb_size
+
         strategy.dataloader = ReplayDataLoader(
             strategy.adapted_dataset,
             self.storage_policy.buffer,
             oversample_small_tasks=True,
+            batch_size_data=strategy.train_mb_size,
+            batch_size_mem=batch_size_mem,
+            task_balanced_dataloader=self.task_balanced_dataloader,
             num_workers=num_workers,
-            batch_size=strategy.train_mb_size,
-            force_data_batch_size=self.force_data_batch_size,
-            shuffle=shuffle,
-        )
+            shuffle=shuffle)
 
     def after_training_exp(self, strategy: "BaseStrategy", **kwargs):
         self.storage_policy.update(strategy, **kwargs)

--- a/avalanche/training/plugins/replay.py
+++ b/avalanche/training/plugins/replay.py
@@ -29,8 +29,6 @@ class ReplayPlugin(StrategyPlugin):
     The :mem_size: attribute controls the total number of patterns to be stored 
     in the external memory.
 
-    :param batch_size: the size of the data batch. If set to `None`, it
-        will be set equal to the strategy's batch size.
     :param batch_size_mem: the size of the memory batch. If
         `task_balanced_dataloader` is set to True, it must be greater than or
         equal to the number of tasks. If its value is set to `None`
@@ -43,13 +41,11 @@ class ReplayPlugin(StrategyPlugin):
                            in memory
     """
 
-    def __init__(self, mem_size: int = 200, batch_size: int = None,
-                 batch_size_mem: int = None,
+    def __init__(self, mem_size: int = 200, batch_size_mem: int = None,
                  task_balanced_dataloader: bool = False,
                  storage_policy: Optional["ExemplarsBuffer"] = None):
         super().__init__()
         self.mem_size = mem_size
-        self.batch_size = batch_size
         self.batch_size_mem = batch_size_mem
         self.task_balanced_dataloader = task_balanced_dataloader
 
@@ -77,10 +73,6 @@ class ReplayPlugin(StrategyPlugin):
             # the dataloader.
             return
 
-        batch_size = self.batch_size
-        if batch_size is None:
-            batch_size = strategy.train_mb_size
-
         batch_size_mem = self.batch_size_mem
         if batch_size_mem is None:
             batch_size_mem = strategy.train_mb_size
@@ -89,7 +81,7 @@ class ReplayPlugin(StrategyPlugin):
             strategy.adapted_dataset,
             self.storage_policy.buffer,
             oversample_small_tasks=True,
-            batch_size=batch_size,
+            batch_size_data=strategy.train_mb_size,
             batch_size_mem=batch_size_mem,
             task_balanced_dataloader=self.task_balanced_dataloader,
             num_workers=num_workers,

--- a/avalanche/training/plugins/replay.py
+++ b/avalanche/training/plugins/replay.py
@@ -29,7 +29,7 @@ class ReplayPlugin(StrategyPlugin):
     The :mem_size: attribute controls the total number of patterns to be stored 
     in the external memory.
 
-    :param batch_size_data: the size of the data batch. If set to `None`, it
+    :param batch_size: the size of the data batch. If set to `None`, it
         will be set equal to the strategy's batch size.
     :param batch_size_mem: the size of the memory batch. If
         `task_balanced_dataloader` is set to True, it must be greater than or
@@ -43,13 +43,13 @@ class ReplayPlugin(StrategyPlugin):
                            in memory
     """
 
-    def __init__(self, mem_size: int = 200, batch_size_data: int = None,
+    def __init__(self, mem_size: int = 200, batch_size: int = None,
                  batch_size_mem: int = None,
                  task_balanced_dataloader: bool = False,
                  storage_policy: Optional["ExemplarsBuffer"] = None):
         super().__init__()
         self.mem_size = mem_size
-        self.batch_size_data = batch_size_data
+        self.batch_size = batch_size
         self.batch_size_mem = batch_size_mem
         self.task_balanced_dataloader = task_balanced_dataloader
 
@@ -77,9 +77,9 @@ class ReplayPlugin(StrategyPlugin):
             # the dataloader.
             return
 
-        batch_size_data = self.batch_size_data
-        if batch_size_data is None:
-            batch_size_data = strategy.train_mb_size
+        batch_size = self.batch_size
+        if batch_size is None:
+            batch_size = strategy.train_mb_size
 
         batch_size_mem = self.batch_size_mem
         if batch_size_mem is None:
@@ -89,7 +89,7 @@ class ReplayPlugin(StrategyPlugin):
             strategy.adapted_dataset,
             self.storage_policy.buffer,
             oversample_small_tasks=True,
-            batch_size_data=batch_size_data,
+            batch_size=batch_size,
             batch_size_mem=batch_size_mem,
             task_balanced_dataloader=self.task_balanced_dataloader,
             num_workers=num_workers,

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,7 +4,7 @@ description: Powered by ContinualAI
 
 # Avalanche: an End-to-End Library for Continual Learning
 
-![](../../.gitbook/assets/avalanche_logo_with_clai.png)
+![](../../.gitbook/assets/avalanche\_logo\_with\_clai.png)
 
 **Avalanche** is an _End-to-End Continual Learning Library_ based on [**PyTorch**](https://pytorch.org), born within [**ContinualAI**](https://www.continualai.org) with the unique goal of providing a **shared** and **collaborative** open-source (MIT licensed) **codebase** for _fast prototyping_, _training_ and [_reproducible_ _evaluation_](https://github.com/ContinualAI/reproducible-continual-learning) of continual learning algorithms.
 
@@ -24,7 +24,7 @@ The library is organized in five main modules:
 * **`Models`**: In this module you'll be able to find several model architectures and pre-trained models that can be used for your continual learning experiment (similar to what has been done in [torchvision.models](https://pytorch.org/docs/stable/torchvision/index.html)).
 * **`Logging`**: It includes advanced logging and plotting features, including native _stdout_, _file_ and [TensorBoard](https://www.tensorflow.org/tensorboard) support (How cool it is to have a complete, interactive dashboard, tracking your experiment metrics in real-time with a single line of code?)
 
-_Avalanche_ the first experiment of a **End-to-end Library** for [reproducible continual learning](https://github.com/ContinualAI/reproducible-continual-learning) research & development where you can find _benchmarks_, _algorithms,_ _evaluation metrics_ and much more_,_ **in the same place**.
+_Avalanche_ the first experiment of a **End-to-end Library** for [reproducible continual learning](https://github.com/ContinualAI/reproducible-continual-learning) research & development where you can find _benchmarks_, _algorithms,_ _evaluation metrics_ and much more, **in the same place**.
 
 Let's make it together 👫 a wonderful ride! 🎈
 
@@ -238,13 +238,13 @@ If you used _Avalanche_ in your research project, please remember to cite our re
 
 ## 🗂️ Maintained by ContinualAI Lab
 
-![](<../../.gitbook/assets/continualai_lab_logo (1).png>)
+![](<../../.gitbook/assets/continualai\_lab\_logo (1).png>)
 
 _Avalanche_ is the flagship open-source collaborative project of [**ContinualAI**](https://www.continualai.org/#home): _a non profit research organization and the largest open community on Continual Learning for AI._
 
 Do you have a question, do you want to report an issue or simply ask for a new feature? Check out the [Questions & Issues](questions-and-issues/ask-your-question.md) center. Do you want to improve _Avalanche_ yourself? Follow these simple rules on [How to Contribute](https://app.gitbook.com/@continualai/s/avalanche/\~/drafts/-MMtZhFEUwjWE4nnEpIX/from-zero-to-hero-tutorial/6.-contribute-to-avalanche).
 
-The _Avalanche_ project is maintained by the collaborative research team [_**ContinualAI Lab**_](https://www.continualai.org/lab/) _and used extensively by the Units_ of the [_**ContinualAI Research (CLAIR)**_](https://www.continualai.org/research/) consortium, a research network of the major continual learning stakeholders around the world_._
+The _Avalanche_ project is maintained by the collaborative research team [_**ContinualAI Lab**_](https://www.continualai.org/lab/) _and used extensively by the Units_ of the [_**ContinualAI Research (CLAIR)**_](https://www.continualai.org/research/) consortium, a research network of the major continual learning stakeholders around the world.
 
 We are always looking for new _awesome members_ willing to join the _ContinualAI Lab_, so check out our [official website](https://www.continualai.org/lab/) if you want to learn more about us and our activities, or [contact us](contacts-and-links/the-team.md#contacts).
 

--- a/docs/gitbook/contacts-and-links/the-team.md
+++ b/docs/gitbook/contacts-and-links/the-team.md
@@ -12,8 +12,9 @@ The Project is maintained mostly by [ContinualAI Lab](https://www.continualai.or
 
 * [**Antonio Carta**](http://pages.di.unipi.it/carta/) (Lead Mantainer)
 * [**Lorenzo Pellegrini** ](https://www.unibo.it/sitoweb/l.pellegrini)(Mantainer)
-* [**Andrea Cossu**](https://andreacossu.github.io) **(**Mantainer)
+* [**Andrea Cossu**](https://andreacossu.github.io) (Mantainer)
 * [**Gabriele Graffieti**](https://www.unibo.it/sitoweb/gabriele.graffieti/en) (Mantainer)
+* [**Hamed Hemati**](https://www.unisg.ch/personenverzeichnis/80af945c-59bf-452e-b2de-369bd134e6af) **** (Mantainer)
 * [**Vincenzo Lomonaco**](https://www.vincenzolomonaco.com) (Project Manager)
 
 ## 🔨 Contributors
@@ -30,7 +31,7 @@ _Avalanche_ is a great tool also thanks to its many users. Here we list some res
 * [**Pervasive AI Lab**](http://pai.di.unipi.it) (PI: Davide Bacciu)
 * [**BioLab** ](http://biolab.csr.unibo.it/home.asp)(PI: Davide Maltoni, University of Bologna)
 * [**Computational Intelligence & Machine Learning Group**](http://ciml.di.unipi.it/index.html) (PI: Alessio Micheli, University of Pisa)
-* [**Italian Association for Machine Learning**](https://iaml.it) (President: Simone Scardapane,  Sapienza University)
+* [**Italian Association for Machine Learning**](https://iaml.it) (President: Simone Scardapane, Sapienza University)
 * [**AIforPeople**](https://www.aiforpeople.org) (President: Marta Ziosi, University of Oxford)
 * [**Learning and Machine Perception Team**](http://www.cvc.uab.es/lamp/) (PI: Joost van de Weijer)
 * [**Tinne Tuytelaars’ group**](https://homes.esat.kuleuven.be/\~tuytelaa/) (PI: Tinne Tuytelaars)
@@ -38,7 +39,7 @@ _Avalanche_ is a great tool also thanks to its many users. Here we list some res
 * [**LASTI Lab**](https://kalisteo.cea.fr/index.php/textual-and-visual-semantic/) (PI: Adrian Popescu)
 * [**Visual Artificial Intelligence Laboratory**](https://cms.brookes.ac.uk/staff/FabioCuzzolin) (PI: Fabio Cuzzolin)
 * [**Eugenio Culurciello’s group**](https://scholar.google.com/citations?user=SeGmqkIAAAAJ\&hl=en) (PI: Eugenio Culurciello)
-* _..._[_and many more!_ ](https://www.continualai.org/research)
+* _..._[_and many more!_](https://www.continualai.org/research)
 
 ## 📫 Contacts
 

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -27,28 +27,16 @@ from avalanche.benchmarks.utils import AvalancheConcatDataset
 from avalanche.logging import TextLogger
 from avalanche.models import SimpleMLP
 from avalanche.training.plugins import EvaluationPlugin, ReplayPlugin
-from avalanche.training.strategies import (
-    Naive,
-    Replay,
-    CWRStar,
-    GDumb,
-    LwF,
-    AGEM,
-    GEM,
-    EWC,
-    SynapticIntelligence,
-    JointTraining,
-)
+from avalanche.training.strategies import Naive, Replay, CWRStar, \
+    GDumb, LwF, AGEM, GEM, EWC, \
+    SynapticIntelligence, JointTraining
 from avalanche.training.strategies.ar1 import AR1
 from avalanche.training.strategies.cumulative import Cumulative
 from avalanche.benchmarks import nc_benchmark, SplitCIFAR10
 from avalanche.training.utils import get_last_fc_layer
 from avalanche.evaluation.metrics import StreamAccuracy
-from avalanche.benchmarks.utils.data_loader import (
-    ReplayDataLoader,
-    TaskBalancedDataLoader,
-    GroupBalancedDataLoader,
-)
+from avalanche.benchmarks.utils.data_loader import \
+    ReplayDataLoader, TaskBalancedDataLoader, GroupBalancedDataLoader
 
 
 def get_fast_benchmark():
@@ -56,23 +44,18 @@ def get_fast_benchmark():
     dataset = make_classification(
         n_samples=10 * n_samples_per_class,
         n_classes=10,
-        n_features=6,
-        n_informative=6,
-        n_redundant=0,
-    )
+        n_features=6, n_informative=6, n_redundant=0)
 
     X = torch.from_numpy(dataset[0]).float()
     y = torch.from_numpy(dataset[1]).long()
 
     train_X, test_X, train_y, test_y = train_test_split(
-        X, y, train_size=0.6, shuffle=True, stratify=y
-    )
+        X, y, train_size=0.6, shuffle=True, stratify=y)
 
     train_dataset = TensorDataset(train_X, train_y)
     test_dataset = TensorDataset(test_X, test_y)
-    my_nc_benchmark = nc_benchmark(
-        train_dataset, test_dataset, 5, task_labels=True
-    )
+    my_nc_benchmark = nc_benchmark(train_dataset, test_dataset, 5,
+                                   task_labels=True)
     return my_nc_benchmark
 
 
@@ -101,11 +84,9 @@ class DataLoaderTests(unittest.TestCase):
         cl_strategy = Naive(
             model,
             SGD(model.parameters(), lr=0.001, momentum=0.9, weight_decay=0.001),
-            CrossEntropyLoss(),
-            train_mb_size=16,
-            train_epochs=1,
+            CrossEntropyLoss(), train_mb_size=16, train_epochs=1,
             eval_mb_size=16,
-            plugins=[replayPlugin],
+            plugins=[replayPlugin]
         )
         for step in benchmark.train_stream[:2]:
             cl_strategy.train(step)
@@ -119,22 +100,21 @@ class DataLoaderTests(unittest.TestCase):
         cl_strategy = Naive(
             model,
             SGD(model.parameters(), lr=0.001, momentum=0.9, weight_decay=0.001),
-            CrossEntropyLoss(),
-            train_mb_size=batch_size,
-            train_epochs=1,
-            eval_mb_size=100,
-            plugins=[replayPlugin],
+            CrossEntropyLoss(), train_mb_size=batch_size, train_epochs=1,
+            eval_mb_size=100, plugins=[replayPlugin]
         )
         for step in benchmark.train_stream:
             adapted_dataset = step.dataset
-            dataloader = ReplayDataLoader(
-                adapted_dataset,
-                replayPlugin.storage_policy.buffer,
-                oversample_small_tasks=True,
-                num_workers=0,
-                batch_size=batch_size,
-                shuffle=True,
-            )
+            if len(replayPlugin.storage_policy.buffer) > 0:
+                dataloader = ReplayDataLoader(
+                        adapted_dataset,
+                        replayPlugin.storage_policy.buffer,
+                        oversample_small_tasks=True,
+                        num_workers=0,
+                        batch_size=batch_size,
+                        shuffle=True)
+            else:
+                dataloader = TaskBalancedDataLoader(adapted_dataset)
 
             for mini_batch in dataloader:
                 mb_task_labels = mini_batch[-1]
@@ -149,5 +129,5 @@ class DataLoaderTests(unittest.TestCase):
             cl_strategy.train(step)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -27,16 +27,28 @@ from avalanche.benchmarks.utils import AvalancheConcatDataset
 from avalanche.logging import TextLogger
 from avalanche.models import SimpleMLP
 from avalanche.training.plugins import EvaluationPlugin, ReplayPlugin
-from avalanche.training.strategies import Naive, Replay, CWRStar, \
-    GDumb, LwF, AGEM, GEM, EWC, \
-    SynapticIntelligence, JointTraining
+from avalanche.training.strategies import (
+    Naive,
+    Replay,
+    CWRStar,
+    GDumb,
+    LwF,
+    AGEM,
+    GEM,
+    EWC,
+    SynapticIntelligence,
+    JointTraining,
+)
 from avalanche.training.strategies.ar1 import AR1
 from avalanche.training.strategies.cumulative import Cumulative
 from avalanche.benchmarks import nc_benchmark, SplitCIFAR10
 from avalanche.training.utils import get_last_fc_layer
 from avalanche.evaluation.metrics import StreamAccuracy
-from avalanche.benchmarks.utils.data_loader import \
-    ReplayDataLoader, TaskBalancedDataLoader, GroupBalancedDataLoader
+from avalanche.benchmarks.utils.data_loader import (
+    ReplayDataLoader,
+    TaskBalancedDataLoader,
+    GroupBalancedDataLoader,
+)
 
 
 def get_fast_benchmark():
@@ -44,18 +56,23 @@ def get_fast_benchmark():
     dataset = make_classification(
         n_samples=10 * n_samples_per_class,
         n_classes=10,
-        n_features=6, n_informative=6, n_redundant=0)
+        n_features=6,
+        n_informative=6,
+        n_redundant=0,
+    )
 
     X = torch.from_numpy(dataset[0]).float()
     y = torch.from_numpy(dataset[1]).long()
 
     train_X, test_X, train_y, test_y = train_test_split(
-        X, y, train_size=0.6, shuffle=True, stratify=y)
+        X, y, train_size=0.6, shuffle=True, stratify=y
+    )
 
     train_dataset = TensorDataset(train_X, train_y)
     test_dataset = TensorDataset(test_X, test_y)
-    my_nc_benchmark = nc_benchmark(train_dataset, test_dataset, 5,
-                                   task_labels=True)
+    my_nc_benchmark = nc_benchmark(
+        train_dataset, test_dataset, 5, task_labels=True
+    )
     return my_nc_benchmark
 
 
@@ -84,9 +101,11 @@ class DataLoaderTests(unittest.TestCase):
         cl_strategy = Naive(
             model,
             SGD(model.parameters(), lr=0.001, momentum=0.9, weight_decay=0.001),
-            CrossEntropyLoss(), train_mb_size=16, train_epochs=1,
+            CrossEntropyLoss(),
+            train_mb_size=16,
+            train_epochs=1,
             eval_mb_size=16,
-            plugins=[replayPlugin]
+            plugins=[replayPlugin],
         )
         for step in benchmark.train_stream[:2]:
             cl_strategy.train(step)
@@ -100,21 +119,22 @@ class DataLoaderTests(unittest.TestCase):
         cl_strategy = Naive(
             model,
             SGD(model.parameters(), lr=0.001, momentum=0.9, weight_decay=0.001),
-            CrossEntropyLoss(), train_mb_size=batch_size, train_epochs=1,
-            eval_mb_size=100, plugins=[replayPlugin]
+            CrossEntropyLoss(),
+            train_mb_size=batch_size,
+            train_epochs=1,
+            eval_mb_size=100,
+            plugins=[replayPlugin],
         )
         for step in benchmark.train_stream:
             adapted_dataset = step.dataset
-            if len(replayPlugin.storage_policy.buffer) > 0:
-                dataloader = ReplayDataLoader(
-                        adapted_dataset,
-                        replayPlugin.storage_policy.buffer,
-                        oversample_small_tasks=True,
-                        num_workers=0,
-                        batch_size=batch_size,
-                        shuffle=True)
-            else:
-                dataloader = TaskBalancedDataLoader(adapted_dataset)
+            dataloader = ReplayDataLoader(
+                adapted_dataset,
+                replayPlugin.storage_policy.buffer,
+                oversample_small_tasks=True,
+                num_workers=0,
+                batch_size=batch_size,
+                shuffle=True,
+            )
 
             for mini_batch in dataloader:
                 mb_task_labels = mini_batch[-1]
@@ -129,5 +149,5 @@ class DataLoaderTests(unittest.TestCase):
             cl_strategy.train(step)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds major changes to `ReplayPlugin` and `ReplayDataLoader`. Below I've briefly the changes that I've made:

`ReplayPlugin` has now the options `batch_size_data`, `batch_size_mem` and `task_balanced_dataloader` which allow the user to manually set the ratio of data in ReplayPlugin. The reason that I've added the `task_balanced_dataloader` is that in some cases you want the data replay samples to be completely random regardless of their task ID (which can be done by`task_balanced_dataloader=False`).

`ReplayDataloader` has now three new options `batch_size_data`, `batch_size_mem` and `task_balanced_dataloader`. `batch_size_data` is set to the strategy's `mb_size` when initialized in the `ReplayPlugin`. When creating dataloaders, it now checks whether the dataloader should be task-balanced or not. Another change that I thought would be meaningful to be added was setting :
```python 
max_len = max([len(d) for d in iter_data_dataloaders.values()])
```
inside `__iter__`, since the main data stream should be the training data and not the buffer data (at least that's been the case in all implementations that I've seen so far). So if by chance the number of buffer batches in a task is higher than the number of training data batches, it doesn't make sense to train after the main data batches end (either by repeating samples or just iterating through buffer samples).
