### PR TITLE
Set `num_workers=0` in all tests

### DIFF
--- a/tests/training/test_plugins.py
+++ b/tests/training/test_plugins.py
@@ -127,8 +127,8 @@ class PluginTests(unittest.TestCase):
             plugins=[plug],
         )
         strategy.evaluator.loggers = [TextLogger(sys.stdout)]
-        strategy.train(benchmark.train_stream[0], num_workers=4)
-        strategy.eval([benchmark.test_stream[0]], num_workers=4)
+        strategy.train(benchmark.train_stream[0], num_workers=0)
+        strategy.eval([benchmark.test_stream[0]], num_workers=0)
         assert all(plug.activated)
 
     @staticmethod

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -735,7 +735,7 @@ class StrategyTest(unittest.TestCase):
         for train_batch_info in benchmark.train_stream:
             print("Start of experience ", train_batch_info.current_experience)
 
-            cl_strategy.train(train_batch_info)
+            cl_strategy.train(train_batch_info, num_workers=0)
             print("Training completed")
 
             print("Computing accuracy on the current test set")


### PR DESCRIPTION
This PR sets `num_workers=0` in `test_stratgies.py` and `test_plugins.py` to avoid data loading issues when running tests locally.
It also adds `num_workers` param to `AGEMPlugin`.