### PR TITLE
Support for transformations with N parameters.

### DIFF
--- a/avalanche/benchmarks/datasets/lvis/lvis_data.py
+++ b/avalanche/benchmarks/datasets/lvis/lvis_data.py
@@ -28,8 +28,7 @@ lvis_archives = [
     (
         "train2017.zip",  # Training set annotations
         "http://images.cocodataset.org/zips/train2017.zip",
-        "cced6f7f71b7629ddf16f17bbcfab6b2"),
-
+        "cced6f7f71b7629ddf16f17bbcfab6b2")
 ]
 
 

--- a/avalanche/benchmarks/utils/__init__.py
+++ b/avalanche/benchmarks/utils/__init__.py
@@ -1,3 +1,4 @@
+from .adaptive_transform import *
 from .utils import *
 from .avalanche_dataset import *
 from .datasets_from_filelists import *

--- a/avalanche/benchmarks/utils/adaptive_transform.py
+++ b/avalanche/benchmarks/utils/adaptive_transform.py
@@ -1,0 +1,159 @@
+import warnings
+from typing import Callable, Sequence
+from inspect import signature, Parameter
+
+
+class Compose:
+    """
+    A replacement for torchvision's Compose transformation.
+
+    Differently from the original Compose, this transformation can handle both
+    single-element and multi-elements transformations.
+
+    For instance, single-element transformations are commonly used in
+    classification tasks where there is no need to transform the class label.
+    Multi-element transformations are used to transform the image and
+    bounding box annotations at the same timein object detection tasks. This
+    is needed as applying augmentations (such as flipping) may change the
+    position of objects in the image.
+
+    This class automatically detects the type of augmentation by inspecting
+    its signature. Keyword-only arguments are never filled.
+    """
+
+    def __init__(self, transforms: Sequence[Callable]):
+        self.transforms = transforms
+        self.param_def = []
+
+        self.max_params = -1
+        self.min_params = -1
+
+        if len(transforms) > 0:
+            for tr in transforms:
+                self.param_def.append(
+                    MultiParamTransform._detect_parameters(tr))
+            all_maxes = set([max_p for _, max_p in self.param_def])
+            if len(all_maxes) > 1:
+                warnings.warn(
+                    'Transformations define a different amount of parameters. '
+                    'This may lead to errors. This warning will only appear'
+                    'once.', ComposeMaxParamsWarning)
+
+            if -1 in all_maxes:
+                self.max_param = -1  # At least one transform has an *args param
+            else:
+                self.max_params = max(all_maxes)
+            self.min_params = min([min_p for min_p, _ in self.param_def])
+
+    def __call__(self, *args, force_tuple_output=False):
+        if len(self.transforms) > 0:
+            for transform, (min_par, max_par) in zip(self.transforms,
+                                                     self.param_def):
+                args = MultiParamTransform._call_transform(
+                    transform, min_par, max_par, *args)
+
+        if len(args) == 1 and not force_tuple_output:
+            return args[0]  # Single return value (as an unwrapped value)
+        return args  # Multiple return values (as a tuple)
+
+    def __repr__(self):
+        format_string = self.__class__.__name__ + '('
+        for t in self.transforms:
+            format_string += '\n'
+            format_string += '    {0}'.format(t)
+        format_string += '\n)'
+        return format_string
+
+
+class MultiParamTransform:
+    def __init__(self, transform: Callable):
+        self.transform = transform
+
+        self.min_params, self.max_params = \
+            MultiParamTransform._detect_parameters(transform)
+
+    def __call__(self, *args, force_tuple_output=False):
+        args = MultiParamTransform._call_transform(
+            self.transform, self.min_params, self.max_params, *args)
+
+        if len(args) == 1 and not force_tuple_output:
+            return args[0]  # Single return value (as an unwrapped value)
+        return args  # Multiple return values (as a tuple)
+
+    def __repr__(self):
+        format_string = self.__class__.__name__ + '('
+        format_string += '\n'
+        format_string += '    {0}'.format(self.transform)
+        format_string += '\n)'
+        return format_string
+
+    @staticmethod
+    def _call_transform(transform_callable, _, max_par, *params):
+        # Here we ignore the min_param
+        if max_par == -1:  # The transform accepts *args
+            n_params = len(params)
+        else:
+            n_params = min(max_par, len(params))
+        params = list(params)
+
+        transform_result = transform_callable(*params[:n_params])
+        if not isinstance(transform_result, tuple):
+            transform_result = (transform_result,)
+
+        # In this way the transform is free to return more or less elements
+        # than the amount of input parameters. May be useful in the future.
+        params[:n_params] = transform_result
+
+        return params
+
+    @staticmethod
+    def _detect_parameters(transform_callable):
+        min_params = 0
+        max_params = 0
+
+        if hasattr(transform_callable, 'min_params') and \
+                hasattr(transform_callable, 'max_params'):
+            min_params = transform_callable.min_params
+            max_params = transform_callable.max_params
+        else:
+            t_sig = signature(transform_callable)
+            for param_name in t_sig.parameters:
+                param = t_sig.parameters[param_name]
+                if param.kind == Parameter.KEYWORD_ONLY:
+                    raise ValueError(
+                        f'Invalid transformation {transform_callable}: '
+                        f'keyword-only parameters (such as {param_name}) are '
+                        'not supported.')
+                elif param.kind == Parameter.POSITIONAL_ONLY:
+                    # Positional-only (not much used)
+                    min_params += 1
+                    max_params += 1
+                elif param.kind == Parameter.POSITIONAL_OR_KEYWORD:
+                    # Standard function parameter
+                    if param.default == Parameter.empty:
+                        # Not optional
+                        min_params += 1
+                        max_params += 1
+                    else:
+                        # Has a default value -> optional
+                        max_params += 1
+                elif param.kind == Parameter.VAR_POSITIONAL:  # *args
+                    max_params = -1  # As for "infinite"
+                # elif param.kind == Parameter.VAR_KEYWORD  # **kwargs
+                # **kwargs can be safely ignored (they will be empty)
+        return min_params, max_params
+
+
+class ComposeMaxParamsWarning(Warning):
+    def __init__(self, message):
+        self.message = message
+
+
+warnings.simplefilter("once", ComposeMaxParamsWarning)
+
+
+__all__ = [
+    'Compose',
+    'MultiParamTransform',
+    'ComposeMaxParamsWarning'
+]

--- a/avalanche/benchmarks/utils/avalanche_dataset.py
+++ b/avalanche/benchmarks/utils/avalanche_dataset.py
@@ -24,8 +24,8 @@ from enum import Enum, auto
 import torch
 from torch.utils.data.dataloader import default_collate
 from torch.utils.data.dataset import Dataset, Subset, ConcatDataset
-from torchvision.transforms import Compose
 
+from .adaptive_transform import Compose, MultiParamTransform
 from .dataset_utils import (
     manage_advanced_indexing,
     SequenceDataset,
@@ -57,15 +57,41 @@ from typing import (
     Callable,
     Dict,
     Tuple,
-    Collection,
+    Collection
 )
+
+from typing_extensions import Protocol
 
 T_co = TypeVar("T_co", covariant=True)
 TTargetType = TypeVar("TTargetType")
 
 TAvalancheDataset = TypeVar("TAvalancheDataset", bound="AvalancheDataset")
-XTransform = Optional[Callable[[Any], Any]]
-YTransform = Optional[Callable[[Any], TTargetType]]
+
+
+# Info: https://mypy.readthedocs.io/en/stable/protocols.html#callback-protocols
+class XComposedTransformDef(Protocol):
+    def __call__(self, *input_values: Any) -> Any:
+        pass
+
+
+class XTransformDef(Protocol):
+    def __call__(self, input_value: Any) -> Any:
+        pass
+
+
+class YTransformDef(Protocol):
+    def __call__(self, input_value: Any) -> Any:
+        pass
+
+
+XTransform = Optional[Union[XTransformDef, XComposedTransformDef]]
+YTransform = Optional[YTransformDef]
+TransformGroupDef = Union[
+    None,
+    XTransform,
+    Tuple[XTransform, YTransform]
+]
+
 
 SupportedDataset = Union[
     IDatasetWithTargets, ITensorDataset, Subset, ConcatDataset
@@ -122,7 +148,7 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
         *,
         transform: XTransform = None,
         target_transform: YTransform = None,
-        transform_groups: Dict[str, Tuple[XTransform, YTransform]] = None,
+        transform_groups: Dict[str, TransformGroupDef] = None,
         initial_transform_group: str = None,
         task_labels: Union[int, Sequence[int]] = None,
         targets: Sequence[TTargetType] = None,
@@ -763,30 +789,30 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
         if has_task_label:
             element = element[:-1]
 
-        pattern = element[0]
-        label = element[1]
-
-        pattern, label = self._apply_transforms(pattern, label)
+        element = self._apply_transforms(element)
 
         return TupleTLabel(
-            (pattern, label, *element[2:], self.targets_task_labels[idx])
+            (*element, self.targets_task_labels[idx])
         )
 
-    def _apply_transforms(self, pattern: Any, label: int):
+    def _apply_transforms(self, element: Sequence[Any]):
+        element = list(element)
         frozen_group = self._frozen_transforms[self.current_transform_group]
-        if frozen_group[0] is not None:
-            pattern = frozen_group[0](pattern)
 
-        if self.transform is not None:
-            pattern = self.transform(pattern)
-
+        # Target transform
         if frozen_group[1] is not None:
-            label = frozen_group[1](label)
+            element[1] = frozen_group[1](element[1])
 
         if self.target_transform is not None:
-            label = self.target_transform(label)
+            element[1] = self.target_transform(element[1])
 
-        return pattern, label
+        if frozen_group[0] is not None:
+            element = MultiParamTransform(frozen_group[0])(*element)
+
+        if self.transform is not None:
+            element = MultiParamTransform(self.transform)(*element)
+
+        return element
 
     @staticmethod
     def _check_groups_dict_format(groups_dict):
@@ -825,7 +851,7 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
 
     def _initialize_groups_dict(
         self,
-        transform_groups: Optional[Dict[str, Tuple[XTransform, YTransform]]],
+        transform_groups: Optional[Dict[str, TransformGroupDef]],
         dataset: Any,
         transform: XTransform,
         target_transform: YTransform,
@@ -854,6 +880,24 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
             }
         else:
             transform_groups = dict(transform_groups)
+
+        for group_name, group_transforms in dict(transform_groups).items():
+            if group_transforms is None:
+                transform_groups[group_name] = (None, None)
+            elif isinstance(group_transforms, Callable):
+                # Single transformation: (safely) assume it is the X transform
+                transform_groups[group_name] = (group_transforms, None)
+            elif isinstance(group_transforms, Sequence) and \
+                    len(group_transforms) == 2:
+                # X and Y transforms
+                transform_groups[group_name] = (group_transforms[0],
+                                                group_transforms[1])
+            else:
+                raise ValueError(
+                    f'Unsupported transformations for group {group_name}. '
+                    f'The transformation group may be None, a single Callable, '
+                    f'or a tuple of 2 elements containing the X and Y '
+                    f'transforms')
 
         if "train" in transform_groups:
             if "eval" not in transform_groups:


### PR DESCRIPTION
This PR introduces the support for transformations that accept more than 1 parameter.

This is part of the effort for bringing a more solid object detection and segmentation support into Avalanche.

Multi-param transformations can be set as the `transform` parameter in `AvalancheDataset`. Transformations accept a variable amount of parameters (not limited to 2) so that this mechanism can be applied to datasets that return `x, y, z, j, k, ...` values, too. Task labels are never passed to transformations.