### PR TITLE
Added model output export to JSON in example

### DIFF
--- a/examples/tvdetection/engine.py
+++ b/examples/tvdetection/engine.py
@@ -195,7 +195,9 @@ def evaluate(model, data_loader, device, export_predictions=False):
 def get_detection_api_from_dataset(dataset):
     # Lorenzo: adapted to support LVIS and AvalancheDataset
     for _ in range(10):
-        if isinstance(dataset, CocoDetection):
+        if isinstance(dataset, (LVIS, COCO)):
+            return dataset
+        elif isinstance(dataset, CocoDetection):
             break
         elif hasattr(dataset, 'lvis_api'):
             break

--- a/examples/tvdetection/lvis_eval.py
+++ b/examples/tvdetection/lvis_eval.py
@@ -1,6 +1,6 @@
 import copy
 import itertools
-from typing import List
+from typing import List, Optional, Dict
 
 import numpy as np
 import pycocotools.mask as mask_util
@@ -20,7 +20,7 @@ class LvisEvaluator:
         self.iou_types = iou_types
         self.img_ids = []
         self.predictions = []
-        self.lvis_eval_per_iou = dict()
+        self.lvis_eval_per_iou: Optional[Dict[str, LVISEval]] = dict()
 
     def update(self, predictions):
         img_ids = list(np.unique(list(predictions.keys())))
@@ -49,7 +49,8 @@ class LvisEvaluator:
         else:
             return self.predictions, True
 
-    def evaluate(self, max_dets_per_image=None):
+    def evaluate(self, max_dets_per_image=None) -> \
+            Optional[Dict[str, LVISEval]]:
         all_preds, main_process = self.synchronize_between_processes()
         if main_process:
             if max_dets_per_image is None:


### PR DESCRIPTION
Added, in `examples/detection.py`, a simple mechanism to import/export model outputs from/to a JSON file. Added a CLI option to just compute metrics starting from model outputs loaded from such JSON files.

@AndreaCossu, it's quite simple, but it does the job.