### PR TITLE
Draft for LVIS detection metrics

### DIFF
--- a/avalanche/evaluation/metric_results.py
+++ b/avalanche/evaluation/metric_results.py
@@ -29,7 +29,7 @@ class TensorImage:
         return self.image.numpy()
 
 
-MetricType = Union[float, int, Tensor, Image, TensorImage, Figure]
+MetricType = Union[float, int, str, Tensor, Image, TensorImage, Figure]
 
 
 class AlternativeValues:

--- a/avalanche/evaluation/metrics/__init__.py
+++ b/avalanche/evaluation/metrics/__init__.py
@@ -14,3 +14,4 @@ from .timing import *
 from .mean_scores import *
 from .labels_repartition import *
 from .images_samples import *
+from .detection import *

--- a/avalanche/evaluation/metrics/detection.py
+++ b/avalanche/evaluation/metrics/detection.py
@@ -1,0 +1,153 @@
+import os
+import torch
+import json
+from typing import Any
+from torch import Tensor
+from json import JSONEncoder
+from avalanche.evaluation import PluginMetric
+from avalanche.evaluation.metric_results import MetricValue
+from avalanche.evaluation.metric_utils import get_metric_name
+from avalanche.training.templates import SupervisedTemplate
+from examples.tvdetection.lvis_eval import LvisEvaluator
+from examples.tvdetection.engine import get_detection_api_from_dataset
+
+
+class TensorEncoder(JSONEncoder):
+    def __init__(self, **kwargs):
+        super(TensorEncoder, self).__init__(**kwargs)
+
+    def default(self, o: Any) -> Any:
+        if isinstance(o, Tensor):
+            o = o.detach().cpu().tolist()
+
+        return o
+
+
+def tensor_decoder(dct):
+    for t_name in ['boxes', 'mask', 'scores', 'keypoints', 'labels']:
+        if t_name in dct:
+            if t_name == 'labels':
+                dct[t_name] = torch.as_tensor(dct[t_name], dtype=torch.int64)
+            else:
+                dct[t_name] = torch.as_tensor(dct[t_name])
+
+            if t_name == 'boxes':
+                dct[t_name] = torch.reshape(dct[t_name], shape=(-1, 4))
+            # TODO: implement mask shape
+
+    return dct
+
+
+class LvisMetrics(PluginMetric[str]):
+    """This metric serializes model outputs to JSON files.
+    The metric produces one file for each evaluation experience.
+    It also returns the metrics computed by LVIS benchmark based
+    on model output. Metrics are returned after each
+    evaluation experience."""
+
+    def __init__(self, save_folder=None, filename_prefix='model_output',
+                 iou_types=['bbox']):
+        """
+        :param save_folder: path to the folder where to write model output
+            files. None to disable writing to file.
+        :param filename_prefix: prefix common to all model outputs files
+        :param iou_types: list of iou types
+        """
+        super().__init__()
+
+        if save_folder is not None:
+            os.makedirs(save_folder, exist_ok=True)
+
+        self.save_folder = save_folder
+        self.filename_prefix = filename_prefix
+        self.iou_types = iou_types
+        self.lvis_evaluator = None
+
+        """Main LVIS evaluator object to compute metrics"""
+        self.current_filename = None
+        """File containing current model dump"""
+
+        self.current_outputs = []
+        """List of dictionaries containing the current model outputs"""
+
+        self.no_save = save_folder is None
+        """If True, no JSON file will be written"""
+
+    def reset(self) -> None:
+        self.current_outputs = []
+        self.current_filename = None
+
+    def update(self, res):
+        if not self.no_save:
+            self.current_outputs.append(res)
+
+        # Ensure int keys
+        r = {int(k): v for k, v in res.items()}
+        self.lvis_evaluator.update(r)
+
+    def result(self):
+        if not self.no_save:
+            with open(self.current_filename, 'w') as f:
+                json.dump(self.current_outputs, f, cls=TensorEncoder)
+
+        self.lvis_evaluator.evaluate()
+        self.lvis_evaluator.summarize()
+        # Encode metrics in CodaLab output format
+        bbox_eval = self.lvis_eval.lvis_eval_per_iou['bbox']
+        score_str = ''
+        ordered_keys = sorted(bbox_eval.results.keys())
+        for key in ordered_keys:
+            value = bbox_eval.results[key]
+            score_str += '{}: {:.5f}\n'.format(key, value)
+        score_str = score_str[:-1]  # Remove final \n
+        return score_str
+
+    def before_eval_exp(self, strategy: "SupervisedTemplate") -> None:
+        super().before_eval_exp(strategy)
+
+        self.reset()
+        if self.lvis_evaluator is None:  # only for the first experience
+            lvis_api = get_detection_api_from_dataset(
+                strategy.experience.dataset)
+            self.lvis_evaluator = LvisEvaluator(lvis_api, self.iou_types)
+        self.current_filename = self._get_filename(strategy)
+
+    def after_eval_iteration(self, strategy: "SupervisedTemplate") -> None:
+        super().after_eval_iteration(strategy)
+        outputs = [{k: v.detach().cpu() for k, v in t.items()}
+                   for t in strategy.mb_output]
+        res = {target["image_id"].item(): output
+               for target, output in zip(strategy.mb_y, outputs)}
+        self.update(res)
+
+    def after_eval_exp(self, strategy: "SupervisedTemplate"):
+        super().after_eval_exp(strategy)
+        return self._package_result(strategy)
+
+    def _package_result(self, strategy: "SupervisedTemplate"):
+        metric_name = get_metric_name(self, strategy, add_experience=True,
+                                      add_task=False)
+        plot_x_position = strategy.clock.train_iterations
+        filename = self.result()
+        metric_values = [
+            MetricValue(self, metric_name, filename, plot_x_position)
+        ]
+        return metric_values
+
+    def _get_filename(self, strategy):
+        """e.g. prefix_eval_exp0.json"""
+        middle = '_eval_exp'
+        if self.filename_prefix == '':
+            middle = middle[1:]
+        return os.path.join(
+            self.save_folder,
+            f"{self.filename_prefix}{middle}"
+            f"{strategy.experience.current_experience}.json")
+
+    def __str__(self):
+        return "LvisMetrics"
+
+
+__all__ = [
+    "LvisMetrics"
+]

--- a/avalanche/training/losses.py
+++ b/avalanche/training/losses.py
@@ -1,7 +1,7 @@
 import copy
 
 import torch
-from avalanche.training.plugins import SupervisedPlugin
+from avalanche.core import SupervisedPlugin
 from torch.nn import BCELoss
 import numpy as np
 

--- a/avalanche/training/plugins/clock.py
+++ b/avalanche/training/plugins/clock.py
@@ -8,7 +8,7 @@
 # E-mail: contact@continualai.org                                              #
 # Website: avalanche.continualai.org                                           #
 ################################################################################
-from avalanche.training.plugins import SupervisedPlugin
+from avalanche.core import SupervisedPlugin
 
 
 class Clock(SupervisedPlugin):

--- a/avalanche/training/plugins/early_stopping.py
+++ b/avalanche/training/plugins/early_stopping.py
@@ -2,7 +2,7 @@ import operator
 import warnings
 from copy import deepcopy
 
-from avalanche.training.plugins import SupervisedPlugin
+from avalanche.core import SupervisedPlugin
 
 
 class EarlyStoppingPlugin(SupervisedPlugin):

--- a/avalanche/training/plugins/lr_scheduling.py
+++ b/avalanche/training/plugins/lr_scheduling.py
@@ -2,7 +2,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 from avalanche.evaluation.metrics import Mean
-from avalanche.training.plugins import SupervisedPlugin
+from avalanche.core import SupervisedPlugin
 import inspect
 
 if TYPE_CHECKING:

--- a/avalanche/training/supervised/cumulative.py
+++ b/avalanche/training/supervised/cumulative.py
@@ -6,7 +6,8 @@ from torch.utils.data import ConcatDataset
 
 from avalanche.benchmarks.utils import AvalancheConcatDataset
 from avalanche.training.plugins.evaluation import default_evaluator
-from avalanche.training.plugins import SupervisedPlugin, EvaluationPlugin
+from avalanche.training.plugins import EvaluationPlugin
+from avalanche.core import SupervisedPlugin
 from avalanche.training.templates.supervised import SupervisedTemplate
 
 

--- a/avalanche/training/supervised/deep_slda.py
+++ b/avalanche/training/supervised/deep_slda.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence
 import os
 import torch
 
-from avalanche.training.plugins import SupervisedPlugin
+from avalanche.core import SupervisedPlugin
 from avalanche.training.templates.supervised import SupervisedTemplate
 from avalanche.training.plugins.evaluation import default_evaluator
 from avalanche.models.dynamic_modules import MultiTaskModule

--- a/avalanche/training/supervised/joint_training.py
+++ b/avalanche/training/supervised/joint_training.py
@@ -21,7 +21,7 @@ from avalanche.training.templates.supervised import SupervisedTemplate
 from avalanche.models import DynamicModule
 
 if TYPE_CHECKING:
-    from avalanche.training.plugins import SupervisedPlugin
+    from avalanche.core import SupervisedPlugin
 
 
 class AlreadyTrainedError(Exception):

--- a/avalanche/training/supervised/strategy_wrappers_online.py
+++ b/avalanche/training/supervised/strategy_wrappers_online.py
@@ -14,7 +14,8 @@ from torch.nn import Module, CrossEntropyLoss
 from torch.optim import Optimizer
 
 from avalanche.training.plugins.evaluation import default_evaluator
-from avalanche.training.plugins import SupervisedPlugin, EvaluationPlugin
+from avalanche.training.plugins import EvaluationPlugin
+from avalanche.core import SupervisedPlugin
 from avalanche.training.templates.online_supervised import (
     SupervisedOnlineTemplate,
 )

--- a/avalanche/training/templates/base_sgd.py
+++ b/avalanche/training/templates/base_sgd.py
@@ -5,7 +5,8 @@ from torch.nn import Module
 from torch.optim import Optimizer
 
 from avalanche.benchmarks import Experience
-from avalanche.training.plugins import SupervisedPlugin, EvaluationPlugin
+from avalanche.training.plugins import EvaluationPlugin
+from avalanche.core import SupervisedPlugin
 from avalanche.training.plugins.clock import Clock
 from avalanche.training.plugins.evaluation import default_evaluator
 from avalanche.training.templates.base import BaseTemplate

--- a/avalanche/training/templates/online_supervised.py
+++ b/avalanche/training/templates/online_supervised.py
@@ -9,7 +9,8 @@ from torch.optim import Optimizer
 from avalanche.benchmarks import Experience
 from avalanche.benchmarks.utils import AvalancheSubset
 from avalanche.models import DynamicModule
-from avalanche.training.plugins import SupervisedPlugin, EvaluationPlugin
+from avalanche.training.plugins import EvaluationPlugin
+from avalanche.core import SupervisedPlugin
 from avalanche.training.plugins.evaluation import default_evaluator
 from avalanche.training.templates.supervised import SupervisedTemplate
 

--- a/avalanche/training/templates/supervised.py
+++ b/avalanche/training/templates/supervised.py
@@ -8,7 +8,7 @@ from avalanche.benchmarks.utils.data_loader import TaskBalancedDataLoader
 from avalanche.models import avalanche_forward
 from avalanche.models.dynamic_optimizers import reset_optimizer
 from avalanche.models.utils import avalanche_model_adaptation
-from avalanche.training.plugins import SupervisedPlugin
+from avalanche.core import SupervisedPlugin
 from avalanche.training.plugins.evaluation import default_evaluator
 from avalanche.training.templates.base_sgd import BaseSGDTemplate
 from avalanche.training.utils import trigger_plugins

--- a/examples/detection_challenge.py
+++ b/examples/detection_challenge.py
@@ -21,7 +21,7 @@ from examples.detection import split_lvis
 
 sys.path.append('.')
 
-from avalanche.evaluation.metrics import ElapsedTime
+from avalanche.evaluation.metrics import ElapsedTime, LvisMetrics
 from avalanche.logging import BaseLogger, InteractiveLogger
 from avalanche.training.plugins import LRSchedulerPlugin, EvaluationPlugin
 from avalanche.training.templates import BaseSGDTemplate
@@ -253,6 +253,7 @@ def main(args):
         ],
         evaluator=EvaluationPlugin(
             ElapsedTime(),
+            LvisMetrics(save_folder='/home/acossu/lvis_test'),
             loggers=[lvis_logger, InteractiveLogger()])
     )
 
@@ -267,7 +268,7 @@ def main(args):
         print("Start of experience: ", experience.current_experience)
         print('Dataset contains', len(experience.dataset), 'instances')
 
-        cl_strategy.train(experience)
+        # cl_strategy.train(experience)
         print("Training completed")
 
         # TODO: Just run the eval on a small set (otherwise it takes ages to

--- a/examples/tvdetection/lvis_eval.py
+++ b/examples/tvdetection/lvis_eval.py
@@ -15,8 +15,8 @@ class LvisEvaluator:
     def __init__(self, lvis_gt: LVIS, iou_types: List[str]):
         assert isinstance(iou_types, (list, tuple))
         self.lvis_gt = lvis_gt
-        if not isinstance(lvis_gt, LVIS):
-            raise TypeError('Unsupported LVIS object', lvis_gt)
+        #if not isinstance(lvis_gt, LVIS):
+        #    raise TypeError('Unsupported LVIS object', lvis_gt)
 
         self.iou_types = iou_types
         self.img_ids = []


### PR DESCRIPTION
The metric implements two functionalities:

1. (optional) Saving model outputs to JSON file. The metric produces one file for each eval experience, where each file stores a list of dictionaries. Each dictionary is a model output.
2. Computation of metrics through LVISEvaluator object starting from model outputs. The metric returns a string. This point does not need 1. to work.

The code contains portions of code from #921 , adapted to fit the metric interface.

I am assuming to be able to access model outputs and targets through the usual `strategy.mb_output` and `strategy.mb_y` fields.

I just implemented the metric but I have not tested it in any ways.
