### PR TITLE
Various fixes and enhancements for the data loading process

### DIFF
--- a/avalanche/benchmarks/utils/avalanche_dataset.py
+++ b/avalanche/benchmarks/utils/avalanche_dataset.py
@@ -275,7 +275,7 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
         self._optimize_task_labels()
         self._optimize_task_dict()
 
-        self.task_set = _TaskSubsetDict(self)
+        self.task_set = self._make_task_set_dict()
         """
         A dictionary that can be used to obtain the subset of patterns given
         a specific task label.
@@ -1082,31 +1082,23 @@ class AvalancheDataset(IDatasetWithTargets[T_co, TTargetType], Dataset[T_co]):
     def _flatten_dataset(self):
         pass
 
+    def _make_task_set_dict(self) -> Dict[int, "AvalancheDataset"]:
+        task_dict = _TaskSubsetDict()
+        for task_id in sorted(self.tasks_pattern_indices.keys()):
+            task_indices = self.tasks_pattern_indices[task_id]
+            task_dict[task_id] = (self, task_indices)
+
+        return task_dict
+
 
 class _TaskSubsetDict(OrderedDict):
-    def __init__(self, avalanche_dataset: AvalancheDataset):
-        self._full_dataset = avalanche_dataset
-        task_ids = self._full_dataset.tasks_pattern_indices.keys()
-        task_ids = sorted(list(task_ids))
-        base_dict = OrderedDict()
-        for x in task_ids:
-            base_dict[x] = x
-        super().__init__(base_dict)
+    def __getitem__(self, item):
+        avl_dataset, indices = super().__getitem__(item)
+        return _TaskSubsetDict._make_subset(avl_dataset, indices)
 
-    def __getitem__(self, task_id: int):
-        if task_id not in self._full_dataset.tasks_pattern_indices:
-            raise KeyError("No pattern with " + str(task_id) + " found")
-        pattern_indices = self._full_dataset.tasks_pattern_indices[task_id]
-        return self._make_subset(pattern_indices)
-
-    def or_empty(self, task_id: int):
-        try:
-            return self[task_id]
-        except KeyError:
-            return self._make_subset([])
-
-    def _make_subset(self, indices: Sequence[int]):
-        return AvalancheSubset(self._full_dataset, indices=indices)
+    @staticmethod
+    def _make_subset(avl_dataset, indices: Sequence[int]):
+        return AvalancheSubset(avl_dataset, indices=indices)
 
 
 class AvalancheSubset(AvalancheDataset[T_co, TTargetType]):

--- a/avalanche/training/templates/base_sgd.py
+++ b/avalanche/training/templates/base_sgd.py
@@ -141,7 +141,7 @@ class BaseSGDTemplate(BaseTemplate):
         :return: dictionary containing last recorded value for
             each metric name
         """
-        super().eval(exp_list)
+        super().eval(exp_list, **kwargs)
         return self.evaluator.get_last_metrics()
 
     def _before_training_exp(self, **kwargs):

--- a/avalanche/training/templates/supervised.py
+++ b/avalanche/training/templates/supervised.py
@@ -1,5 +1,7 @@
 from typing import Sequence, Optional
+from pkg_resources import parse_version
 
+import torch
 from torch.nn import Module, CrossEntropyLoss
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
@@ -186,7 +188,8 @@ class SupervisedTemplate(BaseSGDTemplate):
         super()._before_eval_exp(**kwargs)
 
     def make_train_dataloader(
-        self, num_workers=0, shuffle=True, pin_memory=True, **kwargs
+        self, num_workers=0, shuffle=True, pin_memory=True,
+        persistent_workers=False, **kwargs
     ):
         """Data loader initialization.
 
@@ -198,6 +201,12 @@ class SupervisedTemplate(BaseSGDTemplate):
         :param pin_memory: If True, the data loader will copy Tensors into CUDA
             pinned memory before returning them. Defaults to True.
         """
+
+        other_dataloader_args = {}
+
+        if parse_version(torch.__version__) >= parse_version('1.7.0'):
+            other_dataloader_args['persistent_workers'] = persistent_workers
+
         self.dataloader = TaskBalancedDataLoader(
             self.adapted_dataset,
             oversample_small_groups=True,
@@ -205,9 +214,12 @@ class SupervisedTemplate(BaseSGDTemplate):
             batch_size=self.train_mb_size,
             shuffle=shuffle,
             pin_memory=pin_memory,
+            **other_dataloader_args
         )
 
-    def make_eval_dataloader(self, num_workers=0, pin_memory=True, **kwargs):
+    def make_eval_dataloader(
+            self, num_workers=0, pin_memory=True, persistent_workers=False,
+            **kwargs):
         """
         Initializes the eval data loader.
         :param num_workers: How many subprocesses to use for data loading.
@@ -218,11 +230,17 @@ class SupervisedTemplate(BaseSGDTemplate):
         :param kwargs:
         :return:
         """
+        other_dataloader_args = {}
+
+        if parse_version(torch.__version__) >= parse_version('1.7.0'):
+            other_dataloader_args['persistent_workers'] = persistent_workers
+
         self.dataloader = DataLoader(
             self.adapted_dataset,
             num_workers=num_workers,
             batch_size=self.eval_mb_size,
             pin_memory=pin_memory,
+            **other_dataloader_args
         )
 
     def forward(self):


### PR DESCRIPTION
This PR brings the following fixes:

- Fixed an issue that prevented Windows users from using num_workers > 0
- `num_workers` was ignored in eval
- Added support for `persistent_workers` (since PyTorch 1.7.0)

Fixes #930