### PR TITLE
Add torchmetrics dependency. Align lines in environment(-dev).yml

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,6 +12,7 @@
 channels:
 - conda-forge
 dependencies:
+- pip
 - psutil
 - conda-forge::gputil
 - wandb
@@ -21,13 +22,13 @@ dependencies:
 - numpy
 - conda-forge::quadprog
 - tqdm
-- pip
+- conda-forge::pycocotools
+- conda-forge::torchmetrics
 - conda-forge::pycodestyle
 - sphinx
 - sphinx_rtd_theme
 - conda-forge::astroid=2.4.2
 - conda-forge::sphinx-autoapi
-- conda-forge::pycocotools
 - pip:
     - pytorchcv
     - gdown

--- a/environment.yml
+++ b/environment.yml
@@ -12,17 +12,18 @@
 channels:
 - conda-forge
 dependencies:
+- pip
 - psutil
 - conda-forge::gputil
+- wandb
+- tensorboard
 - scikit-learn
 - matplotlib
 - numpy
 - conda-forge::quadprog
 - tqdm
-- wandb
-- tensorboard
 - conda-forge::pycocotools
-- pip
+- conda-forge::torchmetrics
 - pip:
     - pytorchcv
     - gdown


### PR DESCRIPTION
This PR adds the `torchmetrics` dependency in the conda environment definition files (.yml).

Lines in environment.yml and environment-dev.yml are now aligned, with dev additional packages being listed as the last ones before the pip dependencies.