### PR TITLE
Set num workers to 0 in AGEM buffer dataloader

### DIFF
--- a/avalanche/training/plugins/agem.py
+++ b/avalanche/training/plugins/agem.py
@@ -1,3 +1,5 @@
+import warnings
+
 import torch
 from torch.utils.data import random_split
 
@@ -110,10 +112,13 @@ class AGEMPlugin(SupervisedPlugin):
         return next(self.buffer_dliter)
 
     @torch.no_grad()
-    def update_memory(self, dataset, num_workers=4, **kwargs):
+    def update_memory(self, dataset, num_workers=0, **kwargs):
         """
         Update replay memory with patterns from current experience.
         """
+        if num_workers > 0:
+            warnings.warn("Num workers > 0 is known to cause heavy"
+                          "slowdowns in AGEM.")
         removed_els = len(dataset) - self.patterns_per_experience
         if removed_els > 0:
             dataset, _ = random_split(


### PR DESCRIPTION
This closes #950 by setting to zero the num_workers in the replay buffer of AGEM.
If a larger number is used, the plugin will raise a warning to let you know you could incur in slowdown.