### PR TITLE
Deterministic test accuracy

### DIFF
--- a/tests/training/test_strategies_accuracy.py
+++ b/tests/training/test_strategies_accuracy.py
@@ -26,7 +26,8 @@ from avalanche.training.supervised.cumulative import Cumulative
 from avalanche.evaluation.metrics import StreamAccuracy, ExperienceAccuracy
 from avalanche.training.supervised.strategy_wrappers import PNNStrategy
 
-from tests.unit_tests_utils import get_fast_benchmark, get_device
+from tests.unit_tests_utils import get_fast_benchmark, get_device, \
+    set_deterministic_run
 
 
 class TestMLP(nn.Module):
@@ -68,16 +69,7 @@ class StrategyTest(unittest.TestCase):
         # check that multi-head reaches high enough accuracy.
         # Ensure nothing weird is happening with the multiple heads.
 
-        # seeds (for reproducibility and determinism)
-        seed = 0
-        random.seed(seed)
-        np.random.seed(seed)
-        torch.manual_seed(seed)
-        if torch.cuda.is_available():
-            torch.cuda.manual_seed(seed)
-            torch.backends.cudnn.enabled = True
-            torch.backends.cudnn.benchmark = False
-            torch.backends.cudnn.deterministic = True
+        set_deterministic_run(seed=0)
 
         model = MHTestMLP(input_size=6, hidden_size=100)
         criterion = CrossEntropyLoss()
@@ -112,16 +104,7 @@ class StrategyTest(unittest.TestCase):
         # check that pnn reaches high enough accuracy.
         # Ensure nothing weird is happening with the multiple heads.
 
-        # seeds (for reproducibility and determinism)
-        seed = 0
-        random.seed(seed)
-        np.random.seed(seed)
-        torch.manual_seed(seed)
-        if torch.cuda.is_available():
-            torch.cuda.manual_seed(seed)
-            torch.backends.cudnn.enabled = True
-            torch.backends.cudnn.benchmark = False
-            torch.backends.cudnn.deterministic = True
+        set_deterministic_run(seed=0)
 
         main_metric = StreamAccuracy()
         exp_acc = ExperienceAccuracy()

--- a/tests/training/test_strategies_accuracy.py
+++ b/tests/training/test_strategies_accuracy.py
@@ -10,6 +10,10 @@
 ################################################################################
 import unittest
 
+import random
+import torch
+import numpy as np
+
 from torch import nn
 
 from torch.optim import SGD
@@ -63,6 +67,18 @@ class StrategyTest(unittest.TestCase):
     def test_multihead_cumulative(self):
         # check that multi-head reaches high enough accuracy.
         # Ensure nothing weird is happening with the multiple heads.
+
+        # seeds (for reproducibility and determinism)
+        seed = 0
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed(seed)
+            torch.backends.cudnn.enabled = True
+            torch.backends.cudnn.benchmark = False
+            torch.backends.cudnn.deterministic = True
+
         model = MHTestMLP(input_size=6, hidden_size=100)
         criterion = CrossEntropyLoss()
         optimizer = SGD(model.parameters(), lr=1)
@@ -95,6 +111,18 @@ class StrategyTest(unittest.TestCase):
     def test_pnn(self):
         # check that pnn reaches high enough accuracy.
         # Ensure nothing weird is happening with the multiple heads.
+
+        # seeds (for reproducibility and determinism)
+        seed = 0
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed(seed)
+            torch.backends.cudnn.enabled = True
+            torch.backends.cudnn.benchmark = False
+            torch.backends.cudnn.deterministic = True
+
         main_metric = StreamAccuracy()
         exp_acc = ExperienceAccuracy()
         evalp = EvaluationPlugin(main_metric, exp_acc, loggers=None)

--- a/tests/unit_tests_utils.py
+++ b/tests/unit_tests_utils.py
@@ -1,9 +1,11 @@
 from os.path import expanduser
 
 import os
+import random
 import torch
 from sklearn.datasets import make_classification
 from sklearn.model_selection import train_test_split
+import numpy as np
 from torch.utils.data import TensorDataset
 from torch.utils.data.dataloader import DataLoader
 
@@ -130,10 +132,22 @@ def get_device():
     return device
 
 
+def set_deterministic_run(seed=0):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.backends.cudnn.enabled = True
+        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.deterministic = True
+
+
 __all__ = [
     "common_setups",
     "load_benchmark",
     "get_fast_benchmark",
     "load_experience_train_eval",
     "get_device",
+    "set_deterministic_run",
 ]


### PR DESCRIPTION
Now the accuracy tests inside `tests/training/test_strategies_accuracy.py` are deterministic and should not give any problem when run in the unit testing action. 
This is only a quick fix for the test inside the file reported, a comprehensive revision of all the test is needed, especially is accuracy or the results of experiments are taken into account, in order to make all the test deterministic. 
This PR closes #974 