### PR TITLE
Add RLScenario for Avalanche RL

### DIFF
--- a/avalanche/benchmarks/scenarios/rl_scenario.py
+++ b/avalanche/benchmarks/scenarios/rl_scenario.py
@@ -9,14 +9,108 @@
 # Website: avalanche.continualai.org                                           #
 ################################################################################
 """Reinforcement Learning scenario definitions."""
-from typing import Union, Sequence
+from avalanche.benchmarks.scenarios import CLExperience, ExperienceAttribute, CLScenario, EagerCLStream
+from typing import Callable, List, Union, Dict
+import numpy as np
+import torch
+import random
 
 try:
-    from gym import Env
+    from gym import Env, Wrapper
 except ImportError:
-    # empty class to make sure everything below works without changes
+    # empty classes to make sure everything below works without changes
     class Env:
+        pass
+    class Wrapper:
         pass
 
 
-RLStreamDataOrigin = Union[Env, Sequence[Env]]
+class RLExperience(CLExperience):
+
+    def __init__(self, env: Union[Env, Callable[[], Env]], n_envs: int = 1, task_label: int = None, current_experience: int = None, origin_stream=None):
+        # current experience and origin stream are set when iterating a CLStream by default
+        super().__init__(current_experience, origin_stream)
+        self.env = env
+        self.n_envs = n_envs
+        # task label to be (optionally) used for training purposes
+        self.task_label = ExperienceAttribute(task_label, use_in_train=True)
+
+    @property
+    def environment(self) -> Env:
+        # supports dynamic creation of environment, useful to instantiate envs for evaluation
+        if not isinstance(self.env, Env):
+            return self.env()
+        return self.env
+
+
+class RLScenario(CLScenario):
+
+    def __init__(self, envs: List[Env],
+                 n_experiences: int,
+                 n_parallel_envs: Union[int, List[int]],
+                 eval_envs: Union[List[Env], List[Callable[[], Env]]],
+                 wrappers_generators: Dict[str, List[Wrapper]] = None,
+                 task_labels: bool = True,
+                 shuffle: bool = False, 
+                 seed: int = None):
+
+        assert n_experiences > 0, "Number of experiences must be a positive integer"
+        if type(n_parallel_envs) is int:
+            n_parallel_envs = [n_parallel_envs] * n_experiences
+        assert len(n_parallel_envs) == len(envs)
+        assert all([n > 0 for n in n_parallel_envs]
+                   ), "Number of parallel environments must be a positive integer"
+        tr_envs = envs
+        eval_envs = eval_envs or []
+        self._num_original_envs = len(tr_envs)
+        self.n_envs = n_parallel_envs
+        # this shouldn't contain duplicate envs, but it's difficult to ensure if scenario isn't created through a benchmark generator
+        tr_task_labels = list(range(len(envs)))
+
+        # eval_task_labels = list(range(len(eval_envs)))
+        self._wrappers_generators = wrappers_generators
+
+        if n_experiences < len(tr_envs):
+            tr_envs = tr_envs[:n_experiences]
+            tr_task_labels = tr_task_labels[:n_experiences]
+        elif n_experiences > len(tr_envs):
+            # cycle through envs sequentially, referencing same object to create a longer stream
+            for i in range(n_experiences - len(tr_envs)):
+                tr_envs.append(tr_envs[i % len(tr_envs)])
+                tr_task_labels.append(
+                    tr_task_labels[i % len(tr_task_labels)])
+
+        # move to template/strategy?
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+
+        if shuffle:
+            perm = np.random.permutation(tr_envs)
+            tr_envs = [tr_envs[i] for i in perm]
+            tr_task_labels = [tr_task_labels[i] for i in perm]
+
+        # decide whether to provide task labels to experiences
+        tr_task_labels = tr_task_labels if task_labels else [
+            None] * len(tr_envs)
+
+        tr_exps = [RLExperience(
+            tr_envs[i], n_parallel_envs[i], tr_task_labels[i]) for i in range(len(tr_envs))]
+        tstream = EagerCLStream("train", tr_exps)
+        # we're only supporting single process envs in evaluation atm
+        eval_exps = [RLExperience(e, 1) for e in eval_envs]
+        estream = EagerCLStream("eval", eval_exps)
+
+        super().__init__([tstream, estream])
+
+    @property
+    def train_stream(self):
+        return self.streams["train_stream"]
+
+    @property
+    def eval_stream(self):
+        return self.streams["eval_stream"]
+
+
+__all__ = ["RLExperience", "RLScenario"]

--- a/tests/benchmarks/scenarios/test_rl_scenario.py
+++ b/tests/benchmarks/scenarios/test_rl_scenario.py
@@ -1,0 +1,26 @@
+from avalanche.benchmarks.scenarios.rl_scenario import RLScenario, RLExperience
+import pytest
+import numpy as np
+try:
+    import gym
+    skip = False
+except ImportError:
+    skip = True
+
+
+@pytest.mark.skipif(skip, reason="Need gym to run these tests")
+def test_simple_scenario():
+    n_envs = 3
+    envs = [gym.make('CartPole-v1') for _ in range(n_envs)]
+    rl_scenario = RLScenario(envs, n_experiences=n_envs,
+                             n_parallel_envs=1, task_labels=True, eval_envs=[])        
+    tr_stream = rl_scenario.train_stream
+    assert len(tr_stream) == n_envs
+    assert not len(rl_scenario.eval_stream) 
+    
+    for i, exp in enumerate(tr_stream):
+        assert exp.current_experience == i
+        env = exp.environment     
+        assert isinstance(env, gym.Env)   
+        obs = env.reset()
+        assert isinstance(obs, np.ndarray)


### PR DESCRIPTION
This PR adds a first implementation of the RLScenario we use in [Avalanche RL](https://github.com/ContinualAI/avalanche-rl). Essentially it adds support for a scenario wrapping streams of `gym.Env` environments.

Due to changes to the old "Strategy" model, I still haven't managed to test this PR within avalanche-rl, as the integration would require a few changes in order to match the new Templates-based structure.
Nonetheless, I would appreciate any feedback on this first implementation and whether it adheres to the new benchmark guidelines.

Also, I would like to raise a few issues regarding typing, as with the current implementation we're not able to implicitly infer the type of the experience (e.g. RLExperience) which is returned when iterating a stream (e.g. https://github.com/NickLucche/avalanche/blob/refactoring-avalanche-rl/tests/benchmarks/scenarios/test_rl_scenario.py#L21).
Perhaps we could borrow some of the Generics definitions from the old implementation of scenarios, or define a few subclasses just for better type hinting in `rl_scenario.py`.