### PR TITLE
Add Generics for new benchmark components

### DIFF
--- a/avalanche/benchmarks/scenarios/generic_scenario.py
+++ b/avalanche/benchmarks/scenarios/generic_scenario.py
@@ -151,6 +151,7 @@ class CLExperience(object):
         exp._exp_mode = ExperienceMode.LOGGING
         return exp
 
+
 class CLStream(Generic[E]):
     """A CL stream is a named iterator of experiences.
 
@@ -176,7 +177,7 @@ class CLStream(Generic[E]):
 
         self._iter = None
 
-    def __iter__(self)->Generator[E, None, None]:
+    def __iter__(self) -> Generator[E, None, None]:
         def foo(self):
             for i, exp in enumerate(self.exps_iter):
                 if self.set_stream_info:
@@ -223,7 +224,7 @@ class EagerCLStream(CLStream[E]):
                 e.origin_stream = self
                 e.current_experience = i
 
-    def __getitem__(self, item)->Union['EagerCLStream[E]',E]:
+    def __getitem__(self, item) -> Union['EagerCLStream[E]', E]:
         # This check allows CL streams slicing
         if isinstance(item, slice):
             return EagerCLStream(

--- a/avalanche/benchmarks/scenarios/generic_scenario.py
+++ b/avalanche/benchmarks/scenarios/generic_scenario.py
@@ -10,9 +10,10 @@
 ################################################################################
 from copy import copy
 from enum import Enum
-from typing import List, Iterable, TypeVar, Union, Generic
+from typing import Generator, List, Iterable, TypeVar, Union, Generic
 
 T = TypeVar("T")
+E = TypeVar("E")
 
 
 class MaskedAttributeError(ValueError):
@@ -150,8 +151,7 @@ class CLExperience(object):
         exp._exp_mode = ExperienceMode.LOGGING
         return exp
 
-
-class CLStream:
+class CLStream(Generic[E]):
     """A CL stream is a named iterator of experiences.
 
     In general, many streams may be generator and not explicit lists to avoid
@@ -176,7 +176,7 @@ class CLStream:
 
         self._iter = None
 
-    def __iter__(self):
+    def __iter__(self)->Generator[E, None, None]:
         def foo(self):
             for i, exp in enumerate(self.exps_iter):
                 if self.set_stream_info:
@@ -187,7 +187,7 @@ class CLStream:
         return foo(self)
 
 
-class EagerCLStream(CLStream):
+class EagerCLStream(CLStream[E]):
     """A CL stream which is a named list of experiences.
 
     Eager streams are indexable and sliceable, like python lists.
@@ -223,7 +223,7 @@ class EagerCLStream(CLStream):
                 e.origin_stream = self
                 e.current_experience = i
 
-    def __getitem__(self, item):
+    def __getitem__(self, item)->Union['EagerCLStream[E]',E]:
         # This check allows CL streams slicing
         if isinstance(item, slice):
             return EagerCLStream(

--- a/avalanche/benchmarks/scenarios/rl_scenario.py
+++ b/avalanche/benchmarks/scenarios/rl_scenario.py
@@ -142,21 +142,21 @@ class RLScenario(CLScenario):
 
         tr_exps = [RLExperience(tr_envs[i], n_parallel_envs[i], 
                                 tr_task_labels[i]) for i in range(len(tr_envs))]
-        tstream = EagerCLStream("train", tr_exps)
+        tstream = EagerCLStream[RLExperience]("train", tr_exps)
         # we're only supporting single process envs in evaluation atm
         print("EVAL ", eval_task_labels)
         eval_exps = [RLExperience(e, 1, l)
                      for e, l in zip(eval_envs, eval_task_labels)]
-        estream = EagerCLStream("eval", eval_exps)
+        estream = EagerCLStream[RLExperience]("eval", eval_exps)
 
         super().__init__([tstream, estream])
 
     @property
-    def train_stream(self):
+    def train_stream(self)->EagerCLStream[RLExperience]:
         return self.streams["train_stream"]
 
     @property
-    def eval_stream(self):
+    def eval_stream(self)->EagerCLStream[RLExperience]:
         return self.streams["eval_stream"]
 
 

--- a/avalanche/benchmarks/scenarios/rl_scenario.py
+++ b/avalanche/benchmarks/scenarios/rl_scenario.py
@@ -69,7 +69,7 @@ class RLScenario(CLScenario):
 
     def __init__(self, envs: List[Env],
                  n_parallel_envs: Union[int, List[int]],
-                 eval_envs: Union[List[Env], List[Callable[[], Env]]]=None,
+                 eval_envs: Union[List[Env], List[Callable[[], Env]]] = None,
                  wrappers_generators: Dict[str, List[Wrapper]] = None,
                  task_labels: bool = True,
                  shuffle: bool = False):
@@ -96,7 +96,7 @@ class RLScenario(CLScenario):
         """
 
         n_experiences = len(envs)
-        if type(n_parallel_envs) is int:
+        if isinstance(n_parallel_envs, int):
             n_parallel_envs = [n_parallel_envs] * n_experiences
         assert len(n_parallel_envs) == len(envs)
         # this is so that we can infer the task labels
@@ -152,11 +152,11 @@ class RLScenario(CLScenario):
         super().__init__([tstream, estream])
 
     @property
-    def train_stream(self)->EagerCLStream[RLExperience]:
+    def train_stream(self) -> EagerCLStream[RLExperience]:
         return self.streams["train_stream"]
 
     @property
-    def eval_stream(self)->EagerCLStream[RLExperience]:
+    def eval_stream(self) -> EagerCLStream[RLExperience]:
         return self.streams["eval_stream"]
 
 

--- a/tests/benchmarks/scenarios/test_rl_scenario.py
+++ b/tests/benchmarks/scenarios/test_rl_scenario.py
@@ -33,17 +33,29 @@ def test_multiple_envs():
     envs = [gym.make('CartPole-v0'), gym.make('CartPole-v1'),
             gym.make('Acrobot-v1')]
     rl_scenario = RLScenario(envs, n_parallel_envs=1,
-                             task_labels=True, eval_envs=[])        
+                             task_labels=True, eval_envs=envs[:2])        
     tr_stream = rl_scenario.train_stream
     assert len(tr_stream) == 3
 
     for i, exp in enumerate(tr_stream):
         assert exp.current_experience == i == exp.task_label
 
+    assert len(rl_scenario.eval_stream) == 2
+    for i, exp in enumerate(rl_scenario.eval_stream):
+        assert exp.task_label == i
+        assert exp.environment.spec.id == envs[i].spec.id
+
     # deep copies of the same env are considered as different tasks
     envs = [gym.make('CartPole-v1') for _ in range(3)]
+    eval_envs = [gym.make('CartPole-v1')] * 2
     rl_scenario = RLScenario(envs, n_parallel_envs=1,
-                             task_labels=True, eval_envs=[]) 
+                             task_labels=True, eval_envs=eval_envs) 
     for i, exp in enumerate(rl_scenario.train_stream):
         assert exp.task_label == i 
+    # while shallow copies in eval behave like the ones in train
+    assert len(rl_scenario.eval_stream) == 2
+    for i, exp in enumerate(rl_scenario.eval_stream):
+        assert exp.task_label == 0
+        assert exp.environment.spec.id == envs[0].spec.id   
+    
     


### PR DESCRIPTION
Proposal/first draft addressing the type hint issue which we currently have with CLStream and custom CLExperience (language server can't see their properties and methods).
An example of this is the [RLScenario](https://github.com/ContinualAI/avalanche/compare/master...NickLucche:refactoring-avalanche-rl#diff-2d765ee33fe8c41d986c0e95bb3cbbb972ad57c894905087fade0bf899636344R45) which now properly displays the return type of its train/eval streams (RLExperience).

I've also added task labels for eval experiences when creating an RLScenario. 