### PR TITLE
apidoc improvements

### DIFF
--- a/avalanche/benchmarks/classic/cinaturalist.py
+++ b/avalanche/benchmarks/classic/cinaturalist.py
@@ -55,8 +55,8 @@ def SplitInaturalist(
     eval_transform: Optional[Any] = _default_eval_transform,
     dataset_root: Union[str, Path] = None
 ):
-    """
-    Creates a CL benchmark using the iNaturalist2018 dataset.
+    """Creates a CL benchmark using the iNaturalist2018 dataset.
+
     A selection of supercategories (by default 10) define the experiences.
     Note that the supercategories are highly imbalanced in the number of classes
     and the amount of data available.
@@ -66,9 +66,8 @@ def SplitInaturalist(
     (120Gtrain/val).
 
     To parse the dataset jsons you need to install an additional dependency:
-    "pycocotools". You can install it like this:
-
-        "conda install -c conda-forge pycocotools"
+    "pycocotools". You can install it with the command
+    ``conda install -c conda-forge pycocotools``
 
     Implementation is based on the CL survey
     (https://ieeexplore.ieee.org/document/9349197) but differs slightly.
@@ -98,10 +97,10 @@ def SplitInaturalist(
     which contains usage examples ranging from "basic" to "advanced".
 
     :param super_categories: The list of supercategories which define the
-    tasks, i.e. each task consists of all classes in a super-category.
+        tasks, i.e. each task consists of all classes in a super-category.
     :param download: If true and the dataset is not present in the computer,
-    this method will automatically download and store it. This will take 120G
-    for the train/val set.
+        this method will automatically download and store it. This will take
+        120G for the train/val set.
     :param return_task_id: if True, a progressive task id is returned for every
         experience. If False, all experiences will have a task ID of 0.
     :param seed: A valid int used to initialize the random number generator.

--- a/avalanche/benchmarks/classic/clear.py
+++ b/avalanche/benchmarks/classic/clear.py
@@ -27,12 +27,9 @@ from pathlib import Path
 from typing import Union, Any, Optional
 from typing_extensions import Literal
 
-from avalanche.benchmarks.classic.classic_benchmarks_utils import (
-    check_vision_benchmark,
-)
 from avalanche.benchmarks.datasets.clear import (
-    CLEARImage,
-    CLEARFeature,
+    _CLEARImage,
+    _CLEARFeature,
     SEED_LIST,
     CLEAR_FEATURE_TYPES,
 )
@@ -135,7 +132,7 @@ def CLEAR(
         raise NotImplementedError()
 
     if feature_type is None:
-        clear_dataset_train = CLEARImage(
+        clear_dataset_train = _CLEARImage(
             root=dataset_root,
             data_name=data_name,
             download=True,
@@ -143,7 +140,7 @@ def CLEAR(
             seed=seed,
             transform=train_transform,
         )
-        clear_dataset_test = CLEARImage(
+        clear_dataset_test = _CLEARImage(
             root=dataset_root,
             data_name=data_name,
             download=True,
@@ -159,7 +156,7 @@ def CLEAR(
         )
         benchmark_generator = create_generic_benchmark_from_paths
     else:
-        clear_dataset_train = CLEARFeature(
+        clear_dataset_train = _CLEARFeature(
             root=dataset_root,
             data_name=data_name,
             download=True,
@@ -167,7 +164,7 @@ def CLEAR(
             split=train_split,
             seed=seed,
         )
-        clear_dataset_test = CLEARFeature(
+        clear_dataset_test = _CLEARFeature(
             root=dataset_root,
             data_name=data_name,
             download=True,

--- a/avalanche/benchmarks/classic/endless_cl_sim.py
+++ b/avalanche/benchmarks/classic/endless_cl_sim.py
@@ -48,15 +48,14 @@ def EndlessCLSim(
     dataset_root: Union[str, Path] = None,
     semseg=False
 ):
-    """
-    Creates a CL scenario for the Endless-Continual-Learning Simulator's
-    derived datasets, which are available at:
-    https://zenodo.org/record/4899267, or custom datasets created from
-    the Endless-Continual-Learning-Simulator's standalone application,
-    available at: https://zenodo.org/record/4899294.
+    """Creates a CL scenario for the Endless-Continual-Learning Simulator's
+    derived `datasets <https://zenodo.org/record/4899267>`__, or custom
+    datasets created from
+    the Endless-Continual-Learning-Simulator's `standalone application <
+    https://zenodo.org/record/4899294>`__.
     Both are part of the publication of `A Procedural World Generation
     Framework for Systematic Evaluation of Continual Learning
-    (https://arxiv.org/abs/2106.02585).
+    <https://arxiv.org/abs/2106.02585>`__.
 
     If the dataset is not present in the computer, this method will
     automatically download and store it.

--- a/avalanche/benchmarks/datasets/__init__.py
+++ b/avalanche/benchmarks/datasets/__init__.py
@@ -12,3 +12,4 @@ from .torchvision_wrapper import *
 from .inaturalist import *
 from .lvis_dataset import *
 from .penn_fudan import *
+from .clear import *

--- a/avalanche/benchmarks/datasets/clear/clear.py
+++ b/avalanche/benchmarks/datasets/clear/clear.py
@@ -163,7 +163,7 @@ class CLEARDataset(DownloadableDataset):
         return len(self.samples)
 
 
-class CLEARImage(CLEARDataset):
+class _CLEARImage(CLEARDataset):
     """CLEAR Image Dataset (base class for CLEAR10Image)"""
 
     def __init__(
@@ -222,12 +222,12 @@ class CLEARImage(CLEARDataset):
         aligned with target index.
         """
 
-        super(CLEARImage, self).__init__(
+        super(_CLEARImage, self).__init__(
             root, data_name=data_name, download=download, verbose=True
         )
 
     def _load_metadata(self) -> bool:
-        if not super(CLEARImage, self)._load_metadata():
+        if not super(_CLEARImage, self)._load_metadata():
             print("CLEAR has not yet been downloaded")
             return False
 
@@ -290,7 +290,7 @@ class CLEARImage(CLEARDataset):
         return len(self.targets)
 
 
-class CLEARFeature(CLEARDataset):
+class _CLEARFeature(CLEARDataset):
     """CLEAR Feature Dataset (base class for CLEAR10Feature)"""
 
     def __init__(
@@ -347,12 +347,12 @@ class CLEARFeature(CLEARDataset):
         assert feature_type in CLEAR_FEATURE_TYPES[data_name]
         self.target_transform = target_transform
 
-        super(CLEARFeature, self).__init__(
+        super(_CLEARFeature, self).__init__(
             root, data_name=data_name, download=download, verbose=True
         )
 
     def _load_metadata(self) -> bool:
-        if not super(CLEARFeature, self)._load_metadata():
+        if not super(_CLEARFeature, self)._load_metadata():
             print("CLEAR has not yet been downloaded")
             return False
 
@@ -433,7 +433,7 @@ if __name__ == "__main__":
     root = f"../avalanche_datasets/{data_name}"
     if not os.path.exists(root):
         Path(root).mkdir(parents=True)
-    clear_dataset_all = CLEARImage(
+    clear_dataset_all = _CLEARImage(
         root=root,
         data_name=data_name,
         download=True,
@@ -441,7 +441,7 @@ if __name__ == "__main__":
         seed=None,
         transform=transform,
     )
-    clear_dataset_train = CLEARImage(
+    clear_dataset_train = _CLEARImage(
         root=root,
         data_name=data_name,
         download=True,
@@ -449,7 +449,7 @@ if __name__ == "__main__":
         seed=0,
         transform=transform,
     )
-    clear_dataset_test = CLEARImage(
+    clear_dataset_test = _CLEARImage(
         root=root,
         data_name=data_name,
         download=True,
@@ -461,7 +461,7 @@ if __name__ == "__main__":
     print("clear10 size (train): ", len(clear_dataset_train))
     print("clear10 size (test): ", len(clear_dataset_test))
 
-    clear_dataset_all_feature = CLEARFeature(
+    clear_dataset_all_feature = _CLEARFeature(
         root=root,
         data_name=data_name,
         download=True,
@@ -469,7 +469,7 @@ if __name__ == "__main__":
         split="all",
         seed=None,
     )
-    clear_dataset_train_feature = CLEARFeature(
+    clear_dataset_train_feature = _CLEARFeature(
         root=root,
         data_name=data_name,
         download=True,
@@ -477,7 +477,7 @@ if __name__ == "__main__":
         split="train",
         seed=0,
     )
-    clear_dataset_test_feature = CLEARFeature(
+    clear_dataset_test_feature = _CLEARFeature(
         root=root,
         data_name=data_name,
         download=True,
@@ -499,4 +499,5 @@ if __name__ == "__main__":
         print(len(y))
         break
 
-__all__ = ["CLEARFeature", "CLEARImage", "SEED_LIST", "CLEAR_FEATURE_TYPES"]
+__all__ = ["CLEARDataset", "_CLEARFeature", "_CLEARImage", "SEED_LIST",
+           "CLEAR_FEATURE_TYPES"]

--- a/avalanche/benchmarks/datasets/core50/core50.py
+++ b/avalanche/benchmarks/datasets/core50/core50.py
@@ -45,11 +45,10 @@ class CORe50Dataset(DownloadableDataset):
         object_level=True,
     ):
 
-        """
-        Creates an instance of the CORe50 dataset.
+        """Creates an instance of the CORe50 dataset.
 
-        :param root: root for the datasets data. Defaults to None, which means
-        that the default location for 'core50' will be used.
+        :param root: root for the datasets data. Defaults to None, which 
+            means that the default location for 'core50' will be used.
         :param train: train or test split.
         :param transform: eventual transformations to be applied.
         :param target_transform: eventual transformation to be applied to the

--- a/avalanche/benchmarks/datasets/downloadable_dataset.py
+++ b/avalanche/benchmarks/datasets/downloadable_dataset.py
@@ -28,8 +28,7 @@ from avalanche.benchmarks.datasets.dataset_utils import default_dataset_location
 
 
 class DownloadableDataset(Dataset[T_co], ABC):
-    """
-    Base class for a downloadable dataset.
+    """Base class for a downloadable dataset.
 
     It is recommended to extend this class if a dataset can be downloaded from
     the internet. This implementation codes the recommended behaviour for
@@ -71,8 +70,7 @@ class DownloadableDataset(Dataset[T_co], ABC):
         download: bool = True,
         verbose: bool = False,
     ):
-        """
-        Creates an instance of a downloadable dataset.
+        """Creates an instance of a downloadable dataset.
 
         Consider looking at the class documentation for the precise details on
         how to extend this class.

--- a/avalanche/benchmarks/datasets/endless_cl_sim/endless_cl_sim.py
+++ b/avalanche/benchmarks/datasets/endless_cl_sim/endless_cl_sim.py
@@ -271,10 +271,12 @@ class EndlessCLSimDataset(DownloadableDataset):
         Endless-Continual-Learning Simulator, including settings of incremental
         classes, decrasing illumination, and shifting weather conditions, as
         described in the paper `A Procedural World Generation Framework for
-        Systematic Evaluation of Continual Learning <https://arxiv.org/abs/2106.02585>`__.
+        Systematic Evaluation of Continual Learning 
+        <https://arxiv.org/abs/2106.02585>`__.
         Also custom datasets are supported
         when following the same structure. Such can be obtained from the
-        `Endless-CL-Simulator standalone application <https://zenodo.org/record/4899294>`__.
+        `Endless-CL-Simulator standalone application
+        <https://zenodo.org/record/4899294>`__.
 
         Please note:
         1) The EndlessCLSimDataset does not provide examples directly, but

--- a/avalanche/benchmarks/datasets/endless_cl_sim/endless_cl_sim.py
+++ b/avalanche/benchmarks/datasets/endless_cl_sim/endless_cl_sim.py
@@ -9,7 +9,7 @@
 # Website: continualai.org                                                     #
 ################################################################################
 
-""" Endless-CL-Sim Dataset """
+"""Endless-CL-Sim Dataset."""
 
 from pathlib import Path
 import glob
@@ -43,8 +43,7 @@ class ClassificationSubSequence(Dataset):
         transform=None,
         target_transform=None,
     ):
-        """
-        Dataset containing image-patches and targets for one subsequence of
+        """Dataset containing image-patches and targets for one subsequence of
         an endless continual learning simulator's sequence, that has been
         converted for image-patch classification.
 
@@ -127,9 +126,8 @@ class VideoSubSequence(Dataset):
         transform=None,
         target_transform=None,
     ):
-        """
-        Dataset that contains the (image) data and semantic segmentation targets
-        for one subsequence of a video sequence.
+        """Dataset that contains the (image) data and semantic segmentation
+        targets for one subsequence of a video sequence.
 
         :param file_paths: List containing the paths to all images files that
             are part of this subsequence.
@@ -218,8 +216,8 @@ class VideoSubSequence(Dataset):
         raise ValueError(f"label: {label} could not be converted!")
 
     def _convert_target(self, target):
-        """
-        Converts segmentation target (instance-segmented) according to classmap
+        """Converts segmentation target (instance-segmented) according to
+        classmap.
         """
         # Get all unique labels in target
         target = target.copy()
@@ -266,17 +264,17 @@ class EndlessCLSimDataset(DownloadableDataset):
         semseg=False,
         labelmap_path=None,
     ):
-        """
-        Creates an instance of the Endless-Continual-Leanring-Simulator Dataset.
+        """Creates an instance of the Endless-Continual-Leanring-Simulator
+        Dataset.
+
         This dataset is able to download and prepare datasets derived from the
         Endless-Continual-Learning Simulator, including settings of incremental
         classes, decrasing illumination, and shifting weather conditions, as
         described in the paper `A Procedural World Generation Framework for
-        Systematic Evaluation of Continual Learning'
-        (https://arxiv.org/abs/2106.02585). Also custom datasets are supported
+        Systematic Evaluation of Continual Learning <https://arxiv.org/abs/2106.02585>`__.
+        Also custom datasets are supported
         when following the same structure. Such can be obtained from the
-        Endless-CL-Simulator standalone application
-        (https://zenodo.org/record/4899294).
+        `Endless-CL-Simulator standalone application <https://zenodo.org/record/4899294>`__.
 
         Please note:
         1) The EndlessCLSimDataset does not provide examples directly, but
@@ -288,9 +286,9 @@ class EndlessCLSimDataset(DownloadableDataset):
         supported!
 
         :param root: root for the datasets data. Defaults to None, which means
-        that the default location for 'endless-cl-sim' will be used.
+            that the default location for 'endless-cl-sim' will be used.
         :param scenario: identifier for the dataset to be used.
-        Predefined options are 'Classes', for incremental classes scenario,
+            Predefined options are 'Classes', for incremental classes scenario,
             'Illumination', for the decreasing lighting scenario,
             and 'Weather', for the scenario of shifting weather conditions.
             To load a custom (non-predefined/downloadable) dataset, the
@@ -350,9 +348,10 @@ class EndlessCLSimDataset(DownloadableDataset):
         return
 
     def _get_scenario_data(self):
-        """
-        Returns:
-            tuple: ("DataName.zip", "download-url", "MD5-checksum") of a
+        """Get data about the scenario.
+
+        :return:
+            tuple ("DataName.zip", "download-url", "MD5-checksum") of a
             derived data to be used, as defined in endless_cl_sim_data.py
         """
         data = endless_cl_sim_data.data
@@ -375,12 +374,10 @@ class EndlessCLSimDataset(DownloadableDataset):
         raise ValueError("Provided 'scenario' parameter is not valid!")
 
     def _prepare_classification_subsequence_datasets(self, path) -> bool:
-        """
-        Args:
-            path (str): Path to the root of the data to be loaded.
+        """Prepare subsequences.
 
-        Returns:
-            success (bool): Boolean wether the preparation was successfull.
+        :param path: (str) Path to the root of the data to be loaded.
+        :return: success (bool): Boolean wether the preparation was successfull.
         """
         # Get sequence dirs
         sequence_paths = glob.glob(path + os.path.sep + "*" + os.path.sep)
@@ -455,12 +452,10 @@ class EndlessCLSimDataset(DownloadableDataset):
         return sequence_indices
 
     def _prepare_video_subsequence_datasets(self, path) -> bool:
-        """
-        Args:
-            path (str): Path to the root of the data to be loaded.
+        """Prepare video subsequence datasets.
 
-        Returns:
-            success (bool): Boolean wether the preparation was successfull.
+        :param path: (str) Path to the root of the data to be loaded.
+        :return: success (bool) Boolean wether the preparation was successfull.
         """
         # Get sequence dirs
         sequence_paths = glob.glob(path + os.path.sep + "*" + os.path.sep)
@@ -560,12 +555,10 @@ class EndlessCLSimDataset(DownloadableDataset):
         return True
 
     def __getitem__(self, index):
-        """
-        Args:
-            index (int): Index
+        """Index dataset.
 
-        Returns:
-            tuple: (TrainSubSeqquenceDataset, TestSubSequenceDataset),
+        :param index: Index
+        :return: tuple (TrainSubSeqquenceDataset, TestSubSequenceDataset),
             the i-th subsequence data, as requested by the provided index.
         """
         return (

--- a/avalanche/benchmarks/datasets/inaturalist/inaturalist.py
+++ b/avalanche/benchmarks/datasets/inaturalist/inaturalist.py
@@ -9,7 +9,8 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-""" INATURALIST2018 Pytorch Dataset
+"""INATURALIST2018 Pytorch Dataset
+
 Info: https://www.kaggle.com/c/inaturalist-2018/data
 Download: https://github.com/visipedia/inat_comp/tree/master/2018
 Based on survey in CL: https://ieeexplore.ieee.org/document/9349197
@@ -20,8 +21,8 @@ selected from the 14 available, based on at least having 100 categories (leaving
 out Chromista, Protozoa, Bacteria), and omitting a random super category from
 the remainder (Actinopterygii).
 
-Example filename from the JSON:
- "file_name": "train_val2018/Insecta/1455/994fa5...f1e360d34aae943.jpg"
+Example filename from the JSON: "file_name":
+"train_val2018/Insecta/1455/994fa5...f1e360d34aae943.jpg"
 """
 
 from typing import Any, List
@@ -54,20 +55,22 @@ class INATURALIST2018(Dataset):
     """INATURALIST Pytorch Dataset
 
     For default selection of 10 supercategories:
+
     - Training Images in total: 428,830
     - Validation Images in total:  23,229
     - Shape of images: torch.Size([1, 3, 600, 800])
     - Class counts per supercategory (both train/val):
-     { 'Amphibia': 144,
-      'Animalia': 178,
-      'Arachnida': 114,
-      'Aves': 1258,
-      'Fungi': 321,
-      'Insecta': 2031,
-      'Mammalia': 234,
-      'Mollusca': 262,
-      'Plantae': 2917,
-      'Reptilia': 284}
+
+        - 'Amphibia': 144,
+        - 'Animalia': 178,
+        - 'Arachnida': 114,
+        - 'Aves': 1258,
+        - 'Fungi': 321,
+        - 'Insecta': 2031,
+        - 'Mammalia': 234,
+        - 'Mollusca': 262,
+        - 'Plantae': 2917,
+        - 'Reptilia': 284}
     """
 
     splits = ["train", "val", "test"]
@@ -159,15 +162,6 @@ class INATURALIST2018(Dataset):
         return self.ds.loadAnns(self.ds.getAnnIds(img_id))
 
     def __getitem__(self, index):
-        """
-        Args:
-            index (int): Index
-
-        Returns:
-            tuple: (sample, target) where target is class_index of the target
-                class.
-        """
-
         id = self.img_ids[index]
         img = self._load_image(id)
         # target = self._load_target(id)

--- a/avalanche/benchmarks/scenarios/exmodel_scenario.py
+++ b/avalanche/benchmarks/scenarios/exmodel_scenario.py
@@ -23,12 +23,17 @@ class ExModelExperience(CLExperience):
     """
 
     def __init__(
-        self, expert_model, current_experience: int = None, origin_stream=None
+        self,
+        expert_model,
+        current_experience: int = None,
+        origin_stream=None,
+        classes_in_this_experience=None
     ):
         super().__init__(
             current_experience=current_experience, origin_stream=origin_stream
         )
         self.expert_model = expert_model
+        self.classes_in_this_experience = classes_in_this_experience
 
 
 class ExModelCLScenario(CLScenario):
@@ -56,8 +61,14 @@ class ExModelCLScenario(CLScenario):
             trained on the i-th experience of the train stream of
             `original_benchmark`.
         """
-        expert_models_l = [ExModelExperience(m) for m in expert_models]
-        expert_stream = CLStream("expert_models", expert_models_l)
+        expert_models_l = []
+        for m, e in zip(expert_models, original_benchmark.train_stream):
+            cine = e.classes_in_this_experience
+            expert_models_l.append(ExModelExperience(
+                m, classes_in_this_experience=cine))
+
+        expert_stream = CLStream("expert_models", expert_models_l,
+                                 benchmark=self)
         streams = [expert_stream]
 
         self.original_benchmark = original_benchmark

--- a/avalanche/evaluation/metrics/checkpoint.py
+++ b/avalanche/evaluation/metrics/checkpoint.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 class WeightCheckpoint(PluginMetric[Tensor]):
     """
-    The WeightCheckpoint Metric. This is a standalone metric.
+    The WeightCheckpoint Metric.
 
     Instances of this metric keeps the weight checkpoint tensor of the
     model at each experience.
@@ -84,7 +84,8 @@ class WeightCheckpoint(PluginMetric[Tensor]):
             )
         ]
 
-    def after_eval_exp(self, strategy: "SupervisedTemplate") -> "MetricResult":
+    def after_training_exp(self, strategy: "SupervisedTemplate") -> \
+            "MetricResult":
         model_params = copy.deepcopy(strategy.model.parameters())
         self.update(model_params)
 

--- a/avalanche/evaluation/metrics/confusion_matrix.py
+++ b/avalanche/evaluation/metrics/confusion_matrix.py
@@ -45,8 +45,7 @@ if TYPE_CHECKING:
 
 
 class ConfusionMatrix(Metric[Tensor]):
-    """
-    The standalone confusion matrix metric.
+    """The standalone confusion matrix metric.
 
     Instances of this metric keep track of the confusion matrix by receiving a
     pair of "ground truth" and "prediction" Tensors describing the labels of a
@@ -77,8 +76,7 @@ class ConfusionMatrix(Metric[Tensor]):
         num_classes: int = None,
         normalize: Literal["true", "pred", "all"] = None,
     ):
-        """
-        Creates an instance of the standalone confusion matrix metric.
+        """Creates an instance of the standalone confusion matrix metric.
 
         By default this metric in its initial state will return an empty Tensor.
         The metric can be updated by using the `update` method while the running
@@ -468,8 +466,7 @@ def confusion_matrix_metrics(
     wandb=False,
     absolute_class_order: bool = False,
 ) -> List[PluginMetric]:
-    """
-    Helper method that can be used to obtain the desired set of
+    """Helper method that can be used to obtain the desired set of
     plugin metrics.
 
     :param num_classes: The number of classes. Defaults to None,
@@ -501,7 +498,7 @@ def confusion_matrix_metrics(
     :param absolute_class_order: Not W&B. If true, the labels in the created
         image will be sorted by id, otherwise they will be sorted by order of
         encounter at training time. This parameter is ignored if `save_image` is
-         False, or the scenario is not a NCScenario.
+        False, or the scenario is not a NCScenario.
 
     :return: A list of plugin metrics.
     """

--- a/avalanche/evaluation/metrics/images_samples.py
+++ b/avalanche/evaluation/metrics/images_samples.py
@@ -141,7 +141,7 @@ class ImagesSamplePlugin(PluginMetric):
     ) -> DataLoader:
         if self.disable_augmentations:
             data = data.replace_transforms(
-                transform=MaybeToTensor(),
+                transform=_MaybeToTensor(),
                 target_transform=None,
             )
         return DataLoader(
@@ -151,7 +151,7 @@ class ImagesSamplePlugin(PluginMetric):
         )
 
 
-class MaybeToTensor(ToTensor):
+class _MaybeToTensor(ToTensor):
     """Convert a ``PIL Image`` or ``numpy.ndarray`` to tensor. Pytorch tensors
     are left as is.
     """

--- a/avalanche/evaluation/metrics/ram_usage.py
+++ b/avalanche/evaluation/metrics/ram_usage.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
 
 
 class MaxRAM(Metric[float]):
-    """
-    The standalone RAM usage metric.
+    """The standalone RAM usage metric.
+
     Important: this metric approximates the real maximum RAM usage since
     it sample at discrete amount of time the RAM values.
 
@@ -39,23 +39,18 @@ class MaxRAM(Metric[float]):
     """
 
     def __init__(self, every=1):
-        """
-        Creates an instance of the RAM usage metric.
-        :param every: seconds after which update the maximum RAM
-            usage
+        """Creates an instance of the RAM usage metric.
+
+        :param every: seconds after which update the maximum RAM usage.
         """
 
         self._process_handle: Optional[Process] = Process(os.getpid())
-        """
-        The process handle, lazily initialized.
-        """
+        """The process handle, lazily initialized."""
 
         self.every = every
 
         self.stop_f = False
-        """
-        Flag to stop the thread
-        """
+        """Flag to stop the thread."""
 
         self.max_usage = 0
         """
@@ -132,14 +127,14 @@ class RAMPluginMetric(GenericPluginMetric[float]):
 
 
 class MinibatchMaxRAM(RAMPluginMetric):
-    """
-    The Minibatch Max RAM metric.
+    """The Minibatch Max RAM metric.
+
     This plugin metric only works at training time.
     """
 
     def __init__(self, every=1):
-        """
-        Creates an instance of the Minibatch Max RAM metric
+        """Creates an instance of the Minibatch Max RAM metric.
+
         :param every: seconds after which update the maximum RAM
             usage
         """
@@ -160,16 +155,15 @@ class MinibatchMaxRAM(RAMPluginMetric):
 
 
 class EpochMaxRAM(RAMPluginMetric):
-    """
-    The Epoch Max RAM metric.
+    """The Epoch Max RAM metric.
+
     This plugin metric only works at training time.
     """
 
     def __init__(self, every=1):
-        """
-        Creates an instance of the epoch Max RAM metric.
-        :param every: seconds after which update the maximum RAM
-            usage
+        """Creates an instance of the epoch Max RAM metric.
+        
+        :param every: seconds after which update the maximum RAM usage.
         """
         super(EpochMaxRAM, self).__init__(
             every, reset_at="epoch", emit_at="epoch", mode="train"
@@ -188,16 +182,15 @@ class EpochMaxRAM(RAMPluginMetric):
 
 
 class ExperienceMaxRAM(RAMPluginMetric):
-    """
-    The Experience Max RAM metric.
+    """The Experience Max RAM metric.
+
     This plugin metric only works at eval time.
     """
 
     def __init__(self, every=1):
-        """
-        Creates an instance of the Experience CPU usage metric.
-        :param every: seconds after which update the maximum RAM
-            usage
+        """Creates an instance of the Experience CPU usage metric.
+
+        :param every: seconds after which update the maximum RAM usage.
         """
         super(ExperienceMaxRAM, self).__init__(
             every, reset_at="experience", emit_at="experience", mode="eval"
@@ -216,16 +209,15 @@ class ExperienceMaxRAM(RAMPluginMetric):
 
 
 class StreamMaxRAM(RAMPluginMetric):
-    """
-    The Stream Max RAM metric.
+    """The Stream Max RAM metric.
+
     This plugin metric only works at eval time.
     """
 
     def __init__(self, every=1):
-        """
-        Creates an instance of the Experience CPU usage metric.
-        :param every: seconds after which update the maximum RAM
-            usage
+        """Creates an instance of the Experience CPU usage metric.
+
+        :param every: seconds after which update the maximum RAM usage.
         """
         super(StreamMaxRAM, self).__init__(
             every, reset_at="stream", emit_at="stream", mode="eval"
@@ -247,8 +239,7 @@ class StreamMaxRAM(RAMPluginMetric):
 def ram_usage_metrics(
     *, every=1, minibatch=False, epoch=False, experience=False, stream=False
 ) -> List[PluginMetric]:
-    """
-    Helper method that can be used to obtain the desired set of
+    """ Helper method that can be used to obtain the desired set of
     plugin metrics.
 
     :param every: seconds after which update the maximum RAM

--- a/avalanche/logging/csv_logger.py
+++ b/avalanche/logging/csv_logger.py
@@ -23,12 +23,14 @@ if TYPE_CHECKING:
 
 
 class CSVLogger(BaseLogger, SupervisedPlugin):
-    """
+    """CSV logger.
+
     The `CSVLogger` logs accuracy and loss metrics into a csv file.
     Metrics are logged separately for training and evaluation in files
     training_results.csv and eval_results.csv, respectively.
 
     .. note::
+
         This Logger assumes that the user is evaluating
         on only **one** experience
         during training (see below for an example of a `train` call).
@@ -39,9 +41,11 @@ class CSVLogger(BaseLogger, SupervisedPlugin):
     In order to monitor the performance on held-out experience
     associated to the current training experience, set
     `eval_every=1` (or larger value) in the strategy constructor
-    and pass the eval experience to the `train` method:
-    `for i, exp in enumerate(benchmark.train_stream):`
-        `strategy.train(exp, eval_streams=[benchmark.test_stream[i]])`
+    and pass the eval experience to the `train` method::
+
+        `for i, exp in enumerate(benchmark.train_stream):`
+            `strategy.train(exp, eval_streams=[benchmark.test_stream[i]])`
+
     The `strategy.eval` method should be called on the entire test stream for
     consistency, even if this is not strictly required.
 
@@ -57,8 +61,7 @@ class CSVLogger(BaseLogger, SupervisedPlugin):
     """
 
     def __init__(self, log_folder=None):
-        """
-        Creates an instance of `CSVLogger` class.
+        """Creates an instance of `CSVLogger` class.
 
         :param log_folder: folder in which to create log files.
             If None, `csvlogs` folder in the default current directory

--- a/avalanche/logging/tensorboard_logger.py
+++ b/avalanche/logging/tensorboard_logger.py
@@ -26,7 +26,8 @@ import weakref
 
 
 class TensorboardLogger(BaseLogger):
-    """
+    """Tensorboard logger.
+
     The `TensorboardLogger` provides an easy integration with
     Tensorboard logging. Each monitored metric is automatically
     logged to Tensorboard.
@@ -38,7 +39,9 @@ class TensorboardLogger(BaseLogger):
 
     If no parameters are provided, the default folder in which tensorboard
     log files are placed is "./runs/".
+
     .. note::
+
         We rely on PyTorch implementation of Tensorboard. If you
         don't have Tensorflow installed in your environment,
         tensorboard will tell you that it is running with reduced
@@ -50,8 +53,7 @@ class TensorboardLogger(BaseLogger):
         tb_log_dir: Union[str, Path] = "./tb_data",
         filename_suffix: str = "",
     ):
-        """
-        Creates an instance of the `TensorboardLogger`.
+        """Creates an instance of the `TensorboardLogger`.
 
         :param tb_log_dir: path to the directory where tensorboard log file
             will be stored. Default to "./tb_data".

--- a/avalanche/logging/wandb_logger.py
+++ b/avalanche/logging/wandb_logger.py
@@ -38,7 +38,8 @@ if TYPE_CHECKING:
 
 
 class WandBLogger(BaseLogger, SupervisedPlugin):
-    """
+    """Weights and Biases logger.
+
     The `WandBLogger` provides an easy integration with
     Weights & Biases logging. Each monitored metric is automatically
     logged to a dedicated Weights & Biases project dashboard.
@@ -49,6 +50,7 @@ class WandBLogger(BaseLogger, SupervisedPlugin):
     The wandb log files are placed by default in "./wandb/" unless specified.
 
     .. note::
+
         TensorBoard can be synced on to the W&B dedicated dashboard.
     """
 
@@ -65,8 +67,8 @@ class WandBLogger(BaseLogger, SupervisedPlugin):
         dir: Union[str, Path] = None,
         params: dict = None,
     ):
-        """
-        Creates an instance of the `WandBLogger`.
+        """Creates an instance of the `WandBLogger`.
+
         :param project_name: Name of the W&B project.
         :param run_name: Name of the W&B run.
         :param log_artifacts: Option to log model weights as W&B Artifacts.
@@ -76,9 +78,9 @@ class WandBLogger(BaseLogger, SupervisedPlugin):
         :param save_code: Saves the main training script to W&B.
         :param config: Syncs hyper-parameters and config values used to W&B.
         :param dir: Path to the local log directory for W&B logs to be saved at.
-        :param params: All arguments for wandb.init() function call.
-         Visit https://docs.wandb.ai/ref/python/init to learn about all
-         wand.init() parameters.
+        :param params: All arguments for wandb.init() function call. Visit
+            https://docs.wandb.ai/ref/python/init to learn about all
+            wand.init() parameters.
         """
         super().__init__()
         self.import_wandb()

--- a/avalanche/models/dynamic_modules.py
+++ b/avalanche/models/dynamic_modules.py
@@ -8,10 +8,9 @@
 # E-mail: contact@continualai.org                                              #
 # Website: avalanche.continualai.org                                           #
 ################################################################################
-"""
-    Dynamic Modules are Pytorch modules that can be incrementally expanded
-    to allow architectural modifications (multi-head classifiers, progressive
-    networks, ...).
+"""Dynamic Modules are Pytorch modules that can be incrementally expanded
+to allow architectural modifications (multi-head classifiers, progressive
+networks, ...).
 """
 import torch
 from torch.nn import Module
@@ -21,8 +20,7 @@ from avalanche.benchmarks.utils.dataset_utils import ConstantSequence
 
 
 class DynamicModule(Module):
-    """
-    Dynamic Modules are Avalanche modules that can be incrementally
+    """Dynamic Modules are Avalanche modules that can be incrementally
     expanded to allow architectural modifications (multi-head
     classifiers, progressive networks, ...).
 
@@ -78,17 +76,16 @@ class DynamicModule(Module):
 
 
 class MultiTaskModule(DynamicModule):
-    """
-    Multi-task modules are `torch.nn.Modules`s for multi-task
-    scenarios. The `forward` method accepts task labels, one for
+    """Base pytorch Module with support for task labels.
+
+    Multi-task modules are ``torch.nn.Module`` for multi-task
+    scenarios. The ``forward`` method accepts task labels, one for
     each sample in the mini-batch.
 
-    By default the `forward` method splits the mini-batch by task
-    and calls `forward_single_task`. Subclasses must implement
-    `forward_single_task` or override `forward.
-
-    if `task_labels == None`, the output is computed in parallel
-    for each task.
+    By default the ``forward`` method splits the mini-batch by task
+    and calls ``forward_single_task``. Subclasses must implement
+    ``forward_single_task`` or override `forward. If ``task_labels == None``,
+    the output is computed in parallel for each task.
     """
 
     def __init__(self):
@@ -259,6 +256,7 @@ class MultiHeadClassifier(MultiTaskModule):
         concatenate the samples together.
 
         These can be easily ensured in two possible ways:
+
         - each minibatch contains a single task, which is the case in most
             common benchmarks in Avalanche. Some exceptions to this setting
             are multi-task replay or cumulative strategies.
@@ -267,7 +265,8 @@ class MultiHeadClassifier(MultiTaskModule):
     """
 
     def __init__(self, in_features, initial_out_features=2):
-        """
+        """Init.
+
         :param in_features: number of input features.
         :param initial_out_features: initial number of classes (can be
             dynamically expanded).

--- a/avalanche/models/helper_method.py
+++ b/avalanche/models/helper_method.py
@@ -96,8 +96,7 @@ class MultiTaskDecorator(MultiTaskModule):
 
 
 def as_multitask(model: nn.Module, classifier_name: str) -> MultiTaskModule:
-    """
-    Wraps around a model to make it a multitask model
+    """Wraps around a model to make it a multitask model.
 
     :param model: model to be converted into MultiTaskModule
     :param classifier_name: the name of the attribute containing
@@ -105,8 +104,8 @@ def as_multitask(model: nn.Module, classifier_name: str) -> MultiTaskModule:
                             be an instance of nn.Sequential containing multiple
                             layers as long as the classification layer is the
                             last layer.
-    :return the decorated model, now subclassing MultiTaskModule, and
-    accepting task_labels as forward() method argument
+    :return: the decorated model, now subclassing MultiTaskModule, and
+        accepting task_labels as forward() method argument
     """
     return MultiTaskDecorator(model, classifier_name)
 

--- a/avalanche/models/slda_resnet.py
+++ b/avalanche/models/slda_resnet.py
@@ -18,12 +18,13 @@ class SLDAResNetModel(nn.Module):
         imagenet_pretrained=True,
         device="cpu",
     ):
-        """
-        :param arch: backbone architecture (default is resnet-18, but others
-        can be used by modifying layer for
-        feature extraction in `self.feature_extraction_wrapper'
+        """Init.
+
+        :param arch: backbone architecture. Default is resnet-18, but others
+            can be used by modifying layer for
+            feature extraction in ``self.feature_extraction_wrapper``.
         :param imagenet_pretrained: True if initializing backbone with imagenet
-        pre-trained weights else False
+            pre-trained weights else False
         :param output_layer_name: name of the layer from feature extractor
         :param device: cpu, gpu or other device
         """

--- a/avalanche/training/plugins/cope.py
+++ b/avalanche/training/plugins/cope.py
@@ -37,12 +37,12 @@ class CoPEPlugin(SupervisedPlugin):
         """
         :param mem_size: max number of input samples in the replay memory.
         :param n_classes: total number of classes that will be encountered. This
-        is used to output predictions for all classes, with zero probability
-        for unseen classes.
+            is used to output predictions for all classes, with zero probability
+            for unseen classes.
         :param p_size: The prototype size, which equals the feature size of the
-        last layer.
+            last layer.
         :param alpha: The momentum for the exponentially moving average of the
-        prototypes.
+            prototypes.
         :param T: The softmax temperature, used as a concentration parameter.
         :param max_it_cnt: How many processing iterations per batch (experience)
         """

--- a/avalanche/training/plugins/early_stopping.py
+++ b/avalanche/training/plugins/early_stopping.py
@@ -37,12 +37,12 @@ class EarlyStoppingPlugin(SupervisedPlugin):
 
         :param patience: Number of epochs to wait before stopping the training.
         :param val_stream_name: Name of the validation stream to search in the
-        metrics. The corresponding stream will be used to keep track of the
-        evolution of the performance of a model.
+            metrics. The corresponding stream will be used to keep track of the
+            evolution of the performance of a model.
         :param metric_name: The name of the metric to watch as it will be
-        reported in the evaluator.
+            reported in the evaluator.
         :param mode: Must be "max" or "min". max (resp. min) means that the
-        given metric should me maximized (resp. minimized).
+            given metric should me maximized (resp. minimized).
         :param peval_mode: one of {'epoch', 'iteration'}. Decides whether the
             early stopping should happen after `patience`
             epochs or iterations (Default='epoch').

--- a/avalanche/training/plugins/synaptic_intelligence.py
+++ b/avalanche/training/plugins/synaptic_intelligence.py
@@ -19,8 +19,7 @@ SynDataType = Dict[str, Dict[str, Tensor]]
 
 
 class SynapticIntelligencePlugin(SupervisedPlugin):
-    """
-    The Synaptic Intelligence plugin.
+    """Synaptic Intelligence plugin.
 
     This is the Synaptic Intelligence PyTorch implementation of the
     algorithm described in the paper
@@ -46,8 +45,7 @@ class SynapticIntelligencePlugin(SupervisedPlugin):
         excluded_parameters: Sequence["str"] = None,
         device: Any = "as_strategy",
     ):
-        """
-        Creates an instance of the Synaptic Intelligence plugin.
+        """Creates an instance of the Synaptic Intelligence plugin.
 
         :param si_lambda: Synaptic Intelligence lambda term.
             If list, one lambda for each experience. If the list has less

--- a/avalanche/training/storage_policy.py
+++ b/avalanche/training/storage_policy.py
@@ -238,8 +238,7 @@ class ExperienceBalancedBuffer(BalancedExemplarsBuffer):
 class ClassBalancedBuffer(BalancedExemplarsBuffer):
     """Stores samples for replay, equally divided over classes.
 
-    There is a separate buffer updated by reservoir sampling for each
-        class.
+    There is a separate buffer updated by reservoir sampling for each class.
     It should be called in the 'after_training_exp' phase (see
     ExperienceBalancedStoragePolicy).
     The number of classes can be fixed up front or adaptive, based on
@@ -253,7 +252,8 @@ class ClassBalancedBuffer(BalancedExemplarsBuffer):
         adaptive_size: bool = True,
         total_num_classes: int = None,
     ):
-        """
+        """Init.
+
         :param max_size: The max capacity of the replay memory.
         :param adaptive_size: True if mem_size is divided equally over all
                             observed experiences (keys in replay_mem).
@@ -323,12 +323,13 @@ class ParametricBuffer(BalancedExemplarsBuffer):
         groupby=None,
         selection_strategy: Optional["ExemplarsSelectionStrategy"] = None,
     ):
-        """
+        """Init.
+
         :param max_size: The max capacity of the replay memory.
         :param groupby: Grouping mechanism. One of {None, 'class', 'task',
-        'experience'}.
+            'experience'}.
         :param selection_strategy: The strategy used to select exemplars to
-                                   keep in memory when cutting it off.
+            keep in memory when cutting it off.
         """
         super().__init__(max_size)
         assert groupby in {None, "task", "class", "experience"}, (

--- a/avalanche/training/supervised/ar1.py
+++ b/avalanche/training/supervised/ar1.py
@@ -96,12 +96,10 @@ class AR1(SupervisedTemplate):
         :param evaluator: (optional) instance of EvaluationPlugin for logging
             and metric computations.
         :param eval_every: the frequency of the calls to `eval` inside the
-            training loop.
-                if -1: no evaluation during training.
-                if  0: calls `eval` after the final epoch of each training
-                    experience.
-                if >0: calls `eval` every `eval_every` epochs and at the end
-                    of all the epochs for a single experience.
+            training loop. -1 disables the evaluation. 0 means `eval` is called
+            only at the end of the learning experience. Values >0 mean that
+            `eval` is called every `eval_every` epochs and at the end of the
+            learning experience.
         """
 
         warnings.warn(

--- a/avalanche/training/supervised/deep_slda.py
+++ b/avalanche/training/supervised/deep_slda.py
@@ -16,8 +16,7 @@ class StreamingLDA(SupervisedTemplate):
 
     This strategy does not use backpropagation.
     Minibatches are first passed to the pretrained feature extractor.
-    The result is processed one element at a time to fit the
-    LDA.
+    The result is processed one element at a time to fit the LDA.
     Original paper:
     "Hayes et. al., Lifelong Machine Learning with Deep Streaming Linear
     Discriminant Analysis, CVPR Workshop, 2020"
@@ -57,7 +56,7 @@ class StreamingLDA(SupervisedTemplate):
         :param eval_mb_size: batch size for inference
         :param shrinkage_param: value of the shrinkage parameter
         :param streaming_update_sigma: True if sigma is plastic else False
-        feature extraction in `self.feature_extraction_wrapper'
+            feature extraction in `self.feature_extraction_wrapper`.
         :param plugins: list of StrategyPlugins
         :param evaluator: Evaluation Plugin instance
         :param eval_every: run eval every `eval_every` epochs.

--- a/avalanche/training/supervised/icarl.py
+++ b/avalanche/training/supervised/icarl.py
@@ -53,7 +53,7 @@ class ICaRL(SupervisedTemplate):
         :param memory_size: The nuber of patterns saved in the memory.
         :param buffer_transform: transform applied on buffer elements already
             modified by test_transform (if specified) before being used for
-             replay
+            replay
         :param fixed_memory: If True a memory of size memory_size is
             allocated and partitioned between samples from the observed
             experiences. If False every time a new class is observed

--- a/avalanche/training/supervised/strategy_wrappers.py
+++ b/avalanche/training/supervised/strategy_wrappers.py
@@ -83,7 +83,7 @@ class Naive(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
         super().__init__(
@@ -138,7 +138,7 @@ class PNNStrategy(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
         # Check that the model has the correct architecture.
@@ -176,7 +176,7 @@ class CWRStar(SupervisedTemplate):
         eval_every=-1,
         **base_kwargs
     ):
-        """
+        """Init.
 
         :param model: The model.
         :param optimizer: The optimizer to use.
@@ -195,7 +195,7 @@ class CWRStar(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param \*\*base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
         cwsp = CWRStarPlugin(model, cwr_layer_name, freeze_remaining_model=True)
@@ -258,7 +258,7 @@ class Replay(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param \*\*base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
 
@@ -339,7 +339,7 @@ class GenerativeReplay(SupervisedTemplate):
             learning experience.
         :param generator_strategy: A trainable strategy with a generative model,
             which employs GenerativeReplayPlugin. Defaults to None.
-        :param **base_kwargs: any additional
+        :param \*\*base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
 
@@ -456,7 +456,7 @@ class VAETraining(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param \*\*base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
 
@@ -523,7 +523,7 @@ class GSS_greedy(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param \*\*base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
         rp = GSS_greedyPlugin(
@@ -588,7 +588,7 @@ class GDumb(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
 
@@ -656,7 +656,7 @@ class LwF(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
 
@@ -724,7 +724,7 @@ class AGEM(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
 
@@ -792,7 +792,7 @@ class GEM(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
 
@@ -872,7 +872,7 @@ class EWC(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
         ewc = EWCPlugin(ewc_lambda, mode, decay_factor, keep_importance_data)
@@ -952,7 +952,7 @@ class SynapticIntelligence(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
         if plugins is None:
@@ -1008,15 +1008,15 @@ class CoPE(SupervisedTemplate):
         :param model: The model.
         :param optimizer: The optimizer to use.
         :param criterion: Loss criterion to use. Standard overwritten by
-        PPPloss (see CoPEPlugin).
+            PPPloss (see CoPEPlugin).
         :param mem_size: replay buffer size.
         :param n_classes: total number of classes that will be encountered. This
-        is used to output predictions for all classes, with zero probability
-        for unseen classes.
+            is used to output predictions for all classes, with zero probability
+            for unseen classes.
         :param p_size: The prototype size, which equals the feature size of the
-        last layer.
+            last layer.
         :param alpha: The momentum for the exponentially moving average of the
-        prototypes.
+            prototypes.
         :param T: The softmax temperature, used as a concentration parameter.
         :param train_mb_size: The train minibatch size. Defaults to 1.
         :param train_epochs: The number of training epochs. Defaults to 1.
@@ -1030,7 +1030,7 @@ class CoPE(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
+        :param base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
         copep = CoPEPlugin(mem_size, n_classes, p_size, alpha, T)
@@ -1095,7 +1095,6 @@ class LFL(SupervisedTemplate):
             only at the end of the learning experience. Values >0 mean that
             `eval` is called every `eval_every` epochs and at the end of the
             learning experience.
-        :param **base_kwargs: any additional
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Documentation
+
+Documentation types:
+- gitbook: this corresponds to [avalanche.continualai.org/](avalanche.continualai.org/).
+- apidoc: [https://avalanche-api.continualai.org](https://avalanche-api.continualai.org)
+- notebooks: notebook folder. Also mirrored at [avalanche.continualai.org/](avalanche.continualai.org/).
+
+## API Doc
+Built with sphinx usig the ReST markup language, autosummary, and a bunch of other sphinx extensions.
+
+command to build the documentation (it must be executed in the `docs` folder):
+```
+sphinx-build . _build
+```
+
+### Doc coverage
+it is possible to check the class coverage, i.e. whether some missing classes and for syntax errors using the command:
+```
+sphinx-build -b coverage . _build
+```
+in `conf.py` you find a list `undocumented_classes_to_ignore`. This keeps track of the classes that we don't want to add to the apidoc. Add a class here if you believe it should not be documented in the apidoc. Ideally, this should be kept to a minimum.
+
+### Check for errors
+Due to a bug in sphinx, we have lots of warnings. You can silence them by changing the class template by renaming `_templates/autosummary/no-attributes-class.rst` into `_templates/autosummary/class.rst` to disable the documentation of attributes.

--- a/docs/_templates/autosummary/no-attributes-class.rst
+++ b/docs/_templates/autosummary/no-attributes-class.rst
@@ -1,0 +1,26 @@
+.. Custom class template without class attributes.
+   sphinx has a bug with inherited attributes (https://github.com/sphinx-doc/sphinx/issues/9884)
+   that results in a ton of warnings. You can use this template to remove those
+   warnings and check that the documentation does not have any other errors.
+   Just rename this file into `class.rst` and it will be used by default.
+
+{{ fullname | escape | underline}}
+
+This is my custom template.
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -6,7 +6,7 @@ Benchmarks module
 * Popular benchmarks (like SplitMNIST, PermutedMNIST, SplitCIFAR, ...) are contained in the ``classic`` sub-module.
 * Dataset implementations are available in the ``datasets`` sub-module.
 * One can create new benchmarks by using the utilities found in the ``generators`` sub-module.
-* Avalanche uses custom dataset and dataloader implementations contained in the ``utils`` sub-module. More info can be found in this couple of How-Tos `here <https://avalanche.continualai.org/how-tos/dataloading_buffers_replay>`_ and `here <https://avalanche.continualai.org/how-tos/avalanchedataset>`_.
+* Avalanche uses custom dataset and dataloader implementations contained in the ``utils`` sub-module. More info can be found in this couple of How-Tos `here <https://avalanche.continualai.org/how-tos/dataloading_buffers_replay>`__ and `here <https://avalanche.continualai.org/how-tos/avalanchedataset>`__.
 
 
 avalanche.benchmarks
@@ -16,6 +16,32 @@ avalanche.benchmarks
     :depth: 2
     :local:
     :backlinks: top
+
+.. currentmodule:: avalanche.benchmarks.scenarios
+
+Continual Learning Scenarios
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Generic definitions for scenarios, streams and experiences. All the continual learning benchmarks are specific instantiations of these concepts.
+
+.. autosummary::
+    :toctree: generated
+
+    GenericCLScenario
+    OnlineCLScenario
+    ExModelCLScenario
+    NCScenario
+    NIScenario
+
+    CLStream
+    EagerCLStream
+    ClassificationStream
+
+    GenericClassificationExperience
+    NCExperience
+    CLExperience
+    OnlineCLExperience
+    ExModelExperience
 
 .. currentmodule:: avalanche.benchmarks.classic
 
@@ -27,7 +53,7 @@ Classic Benchmarks
 
 CORe50-based benchmarks
 ............................
-Benchmarks based on the `CORe50 <https://vlomonaco.github.io/core50/>`_ dataset.
+Benchmarks based on the `CORe50 <https://vlomonaco.github.io/core50>`_ dataset.
 
 .. autosummary::
     :toctree: generated
@@ -58,7 +84,7 @@ Benchmarks based on the `Caltech-UCSD Birds 200 <http://www.vision.caltech.edu/v
 
 
 EndlessCLSim-based benchmarks
-............................
+.....................................
 Benchmarks based on the `EndlessCLSim <https://zenodo.org/record/4899267>`_ derived datasets.
 
 .. autosummary::
@@ -68,7 +94,7 @@ Benchmarks based on the `EndlessCLSim <https://zenodo.org/record/4899267>`_ deri
 
 
 FashionMNIST-based benchmarks
-............................
+.....................................
 Benchmarks based on the `Fashion MNIST <https://github.com/zalandoresearch/fashion-mnist>`_ dataset.
 
 .. autosummary::
@@ -79,7 +105,7 @@ Benchmarks based on the `Fashion MNIST <https://github.com/zalandoresearch/fashi
 
 ImageNet-based benchmarks
 ............................
-Benchmarks based on the `ImageNet ILSVRC-2012 <https://www.image-net.org/>`_ dataset.
+Benchmarks based on the `ImageNet ILSVRC-2012 <https://www.image-net.org>`_ dataset.
 
 .. autosummary::
     :toctree: generated
@@ -150,6 +176,18 @@ Benchmarks based on the `CLEAR <https://clear-benchmark.github.io>`_ dataset.
 
     CLEAR
 
+Ex-Model benchmarks
+...................
+
+Benchmarks for learning from pretrained models or multi-agent continual learning scenarios. Based on the `Ex-Model paper <https://arxiv.org/abs/2112.06511>`_. Pretrained models are downloaded automatically.
+
+.. autosummary::
+    :toctree: generated
+
+    ExMLMNIST
+    ExMLCoRE50
+    ExMLCIFAR10
+
 
 .. currentmodule:: avalanche.benchmarks.datasets
 
@@ -167,10 +205,10 @@ Datasets
     INATURALIST2018
     MiniImageNetDataset
     Omniglot
-    OpenLORIS
+    OpenLORISDataset
     Stream51
     TinyImagenet
-    CLEAR
+    CLEARDataset
 
 .. currentmodule:: avalanche.benchmarks.generators
 
@@ -181,7 +219,7 @@ Benchmark Generators
 
 
 Generators for Class/Task/Domain-incremental benchmarks
-............................
+........................................................
 
 .. autosummary::
     :toctree: generated
@@ -191,7 +229,7 @@ Generators for Class/Task/Domain-incremental benchmarks
 
 
 Starting from tensor lists, file lists, PyTorch datasets
-............................
+..........................................................
 
 .. autosummary::
     :toctree: generated
@@ -203,7 +241,7 @@ Starting from tensor lists, file lists, PyTorch datasets
 
 
 Misc (make data-incremental, add a validation stream, ...)
-............................
+..............................................................
 
 | Avalanche offers utilities to adapt a previously instantiated benchmark object.
 | More utilities to come!
@@ -217,7 +255,7 @@ Misc (make data-incremental, add a validation stream, ...)
 .. currentmodule:: avalanche.benchmarks.utils
 
 Utils (Data Loading and AvalancheDataset)
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 | The custom dataset and dataloader implementations contained in this sub-module are described in more detailed in the How-Tos `here <https://avalanche.continualai.org/how-tos/dataloading_buffers_replay>`_ and `here <https://avalanche.continualai.org/how-tos/avalanchedataset>`_.
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,9 @@
 #
 import os
 import sys
+
+import pkgutil
+
 sys.path.insert(0, os.path.abspath('..'))
 
 
@@ -55,13 +58,16 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.githubpages',
+    'sphinx.ext.coverage',
     'sphinx_rtd_theme',
 ]
 
 autosummary_generate = True
 
+coverage_show_missing_items = True
+
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['./_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -77,12 +83,12 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store', '_templates']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
@@ -224,3 +230,202 @@ epub_exclude_files = ['search.html']
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+
+# -- Doc Coverage -------------------------------------------------------------
+from sphinx.ext.coverage import CoverageBuilder
+import avalanche
+import inspect
+import pkgutil
+
+
+# These classes are currently not documented in the api-doc. Some of these may
+# be private, so it's ok not to add them. If you feel they should be documented
+# remove them from this list and add them in some .rst file.
+# You can check coverage with the command:
+#   sphinx-build -b coverage . _build
+undocumented_classes_to_ignore = [
+    # benchmarks
+    'ExperienceMode',
+    'IDataset',
+    'CLScenario',
+
+    # evaluation
+    'MACPluginMetric',
+    'CPUPluginMetric',
+    'TimePluginMetric',
+    'RAMPluginMetric',
+    'MetricValue',
+    'GenericStreamForgetting',
+
+    # Training
+    'SupervisedOnlineTemplate',
+    'AlreadyTrainedError',
+
+    # Utils
+    'LayerAndParameter',
+    'ComposeMaxParamsWarning',
+
+    # Other
+    'GenericStreamForwardTransfer',
+    'VAETraining',
+    'FeatureExtractorBackbone',
+    'IdentityShortcut',
+    'ClassificationDataset',
+    'MultiTaskDecorator',
+    'LazyClassMapping',
+    'Sum',
+    'AlternativeValues',
+    'BaseSGDTemplate',
+    'GenericExperienceForwardTransfer',
+    'TupleTLabel',
+    'YTransformDef',
+
+    'StreamDef',
+
+    'BWT',
+
+    'LoggingType',
+    'Flatten',
+    'XComposedTransformDef',
+    'SupervisedPlugin',
+    'Generator',
+    'SubSequence',
+    'GPUPluginMetric',
+    'MeanScoresPluginMetricABC',
+    'Clock',
+    'DiskPluginMetric',
+    'PNNLayer',
+    'GenericExperienceForgetting',
+    'RunningEpochTopkAccurac',
+    'TrainedExperienceTopkAccuracy',
+    'TopkAccuracyPluginMetric',
+    'SimpleDownloadableDataset',
+    'ResidualBlock',
+    'LabelsRepartition',
+    'LazyDatasetSequence',
+    'AbstractClassificationExperience',
+    'INATURALIST_DATA',
+    'ClassificationExperience',
+    'FilelistDataset',
+    'AvalancheDatasetType',
+    'ClassificationScenarioStream',
+    'DynamicModule',
+    'Forgetting',
+    'LazySubsequence',
+    'PeriodicEval',
+    'BatchRenorm2D',
+    'ExperienceAttribute',
+    'MultiParamTransform',
+    'SubsetWithTargets',
+    'L2Normalization',
+    'PixelsPermutation',
+    'LossPluginMetric',
+    'PNNColumn',
+    'IClassificationDataset',
+    'StreamUserDef',
+    'BasePlugin',
+    'MlpVAE',
+    'PPPloss',
+    'ClassificationSubSequence',
+    'ElapsedTime',
+    'ConstantSequence',
+    'Mean',
+    'BaseSGDPlugin',
+    'SequenceDataset',
+    'BaseTemplate',
+    'LinearAdapter',
+    'MaskedAttributeError',
+    'DownloadableDataset',
+    'LazyConcatIntTargets',
+    'NIExperience',
+    'ClassificationSubset',
+    'GenerativeReplayPlugin',
+    'PathsDataset',
+    'Compose',
+    'SupervisedTemplate',
+    'VideoSubSequence',
+    'LazyConcatTargets',
+    'PennFudanDataset',
+    'IDatasetWithTargets',
+    'LabelsRepartitionPlugin',
+    'AccuracyPluginMetric',
+    'ISupportedClassificationDataset',
+    'LazyStreamDefinition',
+    'ITensorDataset',
+    'XTransformDef',
+    'TensorImage',
+
+    'LazyClassesInExps',
+    'LazyStreamClassesInExps',
+    'VAEMLPEncoder',
+    'BaseModel',
+]
+undocumented_classes_to_ignore = set(undocumented_classes_to_ignore)
+
+
+def coverage_post_process(app, exception):
+    if exception is not None:
+        return
+
+    # Only run this test for the coverage build
+    if not isinstance(app.builder, CoverageBuilder):
+        return
+
+    # we collected what has been already documented by sphinx to compare it
+    # with the full list of classes of Avalanche.
+    doc_classes = app.env.domaindata['py']['objects']
+    doc_classes = set([s.split('.')[-1] for s in doc_classes])
+    # print(doc_classes)
+    # STRONG ASSUMPTION HERE: unique names for classes in different namespaces.
+    # Otherwise, we need to detect the case when mylib.Type is documented but
+    # mylib.a.Type (submodule) is not, and I don't want to do this. Also,
+    # uniqueness hold in Avalanche (for the moment).
+
+    def is_not_internal(name):
+        """Internal modules/classes start with underscores."""
+        split_name = name.split(".")
+        for name in split_name:
+            if name[0] == "_":
+                return False
+        return True
+
+    # print("Search classes:")
+    try:
+        lib_classes = set()
+        for _, modname, ispkg in pkgutil.walk_packages(
+                path=avalanche.__path__,
+                prefix=avalanche.__name__ + '.'):
+
+            # print("MODULE: " + modname)
+            try:
+                for name, obj in inspect.getmembers(sys.modules[modname]):
+                    # print(name)
+                    if inspect.isclass(obj) and obj.__module__.startswith('avalanche') and is_not_internal(obj.__module__ + '.' + name):
+                        # print("CLASS: " + obj.__module__ + '.' + obj.__name__)
+                        lib_classes.add(name)
+            except Exception as e:
+                # TODO: I got some errors on lvis.
+                # Also seems to crash on module attributes that are
+                # instance variables instead of classes/functions/modules.
+                # No idea why, but we can ignore them for the moment.
+                print(f"KeyError on module {modname}, class {name}, exception "
+                      f"type {type(e)}")
+
+    except Exception as e:
+        print("ERROR!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        print(f"on module {modname}, class {name}, exception type {type(e)}")
+        print("ERROR MESSAGE: ", e)
+
+    print(lib_classes)
+
+    missing_classes = lib_classes - doc_classes
+    missing_classes = missing_classes - undocumented_classes_to_ignore
+    print("MISSING CLASSES: ")
+    for el in missing_classes:
+        print(f"\t- {el}")
+
+
+# Called automatically by Sphinx, making this `conf.py` an "extension".
+def setup(app):
+    app.connect("build-finished", coverage_post_process)

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -35,7 +35,7 @@ Metrics helper functions
     ram_usage_metrics
     timing_metrics
     MAC_metrics
-    image_samples_metrics
+    images_samples_metrics
     labels_repartition_metrics
     mean_scores_metrics
 
@@ -46,7 +46,7 @@ Stream Metrics
 | Stream metrics work at eval time only. Stream metrics return the average of metric results over all the experiences present in the evaluation stream.
 | Slicing the evaluation stream during test (e.g., strategy.eval(benchmark.test_stream[0:2])) will not include sliced-out experiences in the average.
 
-.. autosummary:: Stream metrics
+.. autosummary::
    :toctree: generated
 
     StreamAccuracy
@@ -62,14 +62,15 @@ Stream Metrics
     StreamTime
     StreamMaxRAM
     StreamMaxGPU
+    StreamTopkAccuracy
     MeanScoresEvalPluginMetric
 
 Experience Metrics
 ^^^^^^^^^^^^^^^^^^^^
 
-| Experience metrics work at eval time only. Experience metrics return the average metric results over all the patterns in the experience.
+| Experience metrics compute values that are updated after each experience. Most of them are only updated at eval time and return the average metric results over all the patterns in the experience.
 
-.. autosummary:: Experience metrics
+.. autosummary::
    :toctree: generated
 
     ExperienceAccuracy
@@ -83,13 +84,16 @@ Experience Metrics
     ExperienceMAC
     ExperienceMaxRAM
     ExperienceMaxGPU
+    ExperienceTopkAccuracy
+    WeightCheckpoint
+    ImagesSamplePlugin
 
 Epoch Metrics
 ^^^^^^^^^^^^^^^^^^^^
 
 | Epoch metrics work at train time only. Epoch metrics return the average metric results over all the patterns in the training dataset.
 
-.. autosummary:: Epoch metrics
+.. autosummary::
    :toctree: generated
 
     EpochAccuracy
@@ -101,13 +105,14 @@ Epoch Metrics
     EpochMaxRAM
     EpochMaxGPU
     MeanScoresTrainPluginMetric
+    EpochTopkAccuracy
 
 RunningEpoch Metrics
 ^^^^^^^^^^^^^^^^^^^^^^
 
 | Running Epoch metrics work at train time only. RunningEpoch metrics return the average metric results over all the patterns encountered up to the current iteration in the training epoch.
 
-.. autosummary:: RunningEpoch metrics
+.. autosummary::
    :toctree: generated
 
     RunningEpochAccuracy
@@ -120,7 +125,7 @@ Minibatch Metrics
 
 | Minibatch metrics work at train time only. Minibatch metrics return the average metric results over all the patterns in the current minibatch.
 
-.. autosummary:: Minibatch metrics
+.. autosummary::
    :toctree: generated
 
     MinibatchAccuracy
@@ -131,6 +136,31 @@ Minibatch Metrics
     MinibatchMAC
     MinibatchMaxRAM
     MinibatchMaxGPU
+    MinibatchTopkAccuracy
+
+Other
+```
+
+Standalone Metrics
+^^^^^^^^^^^^^^^^^^
+
+| Standalone metrics define the metric computation itself. Unlike metric plugins, they cannot be used in Avalanche strategies directly. However, they can be easily used without Avalanche.
+
+.. autosummary::
+   :toctree: generated
+
+    MeanNewOldScores
+    MaxRAM
+    MAC
+    DiskUsage
+    CPUUsage
+    Loss
+    ConfusionMatrix
+    ForwardTransfer
+    MaxGPU
+    TopkAccuracy
+    Accuracy
+    MeanScores
 
 
 evaluation.metric_definitions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,6 @@ Welcome to Avalanche's API documentation!
 | This is the complete Avalanche's API documentation.  For examples and tutorials check out the main `avalanche website <https://avalanche.continualai.org>`_.
 | Go to API Reference for a complete overview of all the modules and packages, or go one of the main subpackage below for detailed information on the package content.
 
-
-
 ..  toctree::
    :maxdepth: 1
    :caption: Avalanche API
@@ -21,6 +19,3 @@ Welcome to Avalanche's API documentation!
    Logging module <logging>
    Models module <models>
    Training module <training>
-
-
-

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -26,11 +26,11 @@ Loggers
     TextLogger
     CSVLogger
 
-All the loggers inherit from the base class :py:class:`StrategyLogger`.
+All the loggers inherit from the base class :py:class:`BaseLogger`.
 
 .. autosummary::
     :toctree: generated
 
-    StrategyLogger
+    BaseLogger
 
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -31,12 +31,18 @@ networks, ...).
 Models
 ^^^^^^^^^^^^^^^^^^^^^^^
 
+| Neural network architectures that can be used as backbones for CL experiments.
+
 .. autosummary::
     :toctree: generated
 
     PNN
+    MLPAdapter
+    MLP
     make_icarl_net
+    IcarlNet
     SimpleMLP_TinyImageNet
+    VAEMLPDecoder
     SimpleCNN
     MTSimpleCNN
     SimpleMLP

--- a/docs/training.rst
+++ b/docs/training.rst
@@ -11,7 +11,6 @@ Ready-to-use continual learning strategies.
 .. autosummary::
     :toctree: generated
 
-    BaseStrategy
     Cumulative
     JointTraining
     Naive
@@ -30,7 +29,9 @@ Ready-to-use continual learning strategies.
     SynapticIntelligence
     CoPE
     LFL
-
+    GenerativeReplay
+    LaMAML
+    MAS
 
 Replay Buffers
 ----------------------------------------
@@ -82,7 +83,6 @@ Utilities
 .. autosummary::
     :toctree: generated
 
-    StrategyPlugin
     EarlyStoppingPlugin
     EvaluationPlugin
     LRSchedulerPlugin
@@ -107,3 +107,6 @@ Strategies
     LwFPlugin
     ReplayPlugin
     SynapticIntelligencePlugin
+    MASPlugin
+    TrainGeneratorAfterExpPlugin
+    RWalkPlugin

--- a/examples/clear.py
+++ b/examples/clear.py
@@ -34,8 +34,8 @@ import torch
 from avalanche.benchmarks.classic.clear import CLEAR
 from avalanche.benchmarks.datasets.clear import clear10_data
 from avalanche.benchmarks.datasets.clear import (
-    CLEARImage,
-    CLEARFeature,
+    _CLEARImage,
+    _CLEARFeature,
     SEED_LIST,
     CLEAR_FEATURE_TYPES,
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pycodestyle]
 count = False
-ignore = W293, W291, E226, E123, E126, W504, W503, E402, E203
+ignore = W293, W291, E226, E123, E126, W504, W503, E402, E203, W605
 max-line-length = 80
 statistics = True
 format = default


### PR DESCRIPTION
- Made some minor changes to docstrings to fix errors
- added a small function that checks for classes missing from the apidoc
- added a readme in `docs` for documentation for developers building the docs.

This was quite painful.

TODO: there are many classes that are not in the apidoc but should be. Let's try to add them before the next release.

@AndreaCossu can you do this check for the evaluation modules? also some of the descriptions may need to be updated.

@lrzpellegrini can you do it for the detection stuff?

read the doc for info on how to compile the doc without seeing tons of errors. Please try to not commit file with syntax errors.