### PR TITLE
Examples in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ logs/
 *.pyc
 doc_html/*
 .coverage
+tb_data/
+docs/generated/

--- a/avalanche/models/simple_cnn.py
+++ b/avalanche/models/simple_cnn.py
@@ -20,6 +20,13 @@ from avalanche.models.dynamic_modules import (
 class SimpleCNN(nn.Module):
     """
     Convolutional Neural Network
+    
+    **Example**::
+
+        >>> from avalanche.models import SimpleCNN
+        >>> n_classes = 10 # e.g. MNIST
+        >>> model = SimpleCNN(num_classes=n_classes)
+        >>> print(model) # View model details
     """
 
     def __init__(self, num_classes=10):
@@ -50,7 +57,6 @@ class SimpleCNN(nn.Module):
         x = x.view(x.size(0), -1)
         x = self.classifier(x)
         return x
-
 
 class MTSimpleCNN(SimpleCNN, MultiTaskModule):
     """Convolutional Neural Network

--- a/avalanche/models/simple_cnn.py
+++ b/avalanche/models/simple_cnn.py
@@ -20,7 +20,7 @@ from avalanche.models.dynamic_modules import (
 class SimpleCNN(nn.Module):
     """
     Convolutional Neural Network
-    
+
     **Example**::
 
         >>> from avalanche.models import SimpleCNN
@@ -58,9 +58,12 @@ class SimpleCNN(nn.Module):
         x = self.classifier(x)
         return x
 
+
 class MTSimpleCNN(SimpleCNN, MultiTaskModule):
-    """Convolutional Neural Network
-    with multi-head classifier"""
+    """
+    Convolutional Neural Network
+    with multi-head classifier
+    """
 
     def __init__(self):
         super().__init__()

--- a/avalanche/models/simple_mlp.py
+++ b/avalanche/models/simple_mlp.py
@@ -22,6 +22,13 @@ class SimpleMLP(nn.Module, BaseModel):
     """
     Multi-Layer Perceptron with custom parameters.
     It can be configured to have multiple layers and dropout.
+
+    **Example**::
+
+        >>> from avalanche.models import SimpleMLP
+        >>> n_classes = 10 # e.g. MNIST
+        >>> model = SimpleMLP(num_classes=n_classes)
+        >>> print(model) # View model details
     """
 
     def __init__(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.githubpages',
     'sphinx_rtd_theme',
+    'sphinx_copybutton'
 ]
 
 autosummary_generate = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = u'Avalanche'
-copyright = u'2021, ContinualAI'
+copyright = u'2022, ContinualAI'
 author = u'ContinualAI'
 
 # The short X.Y version

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,3 +19,4 @@ lvis
 higher
 lvis
 ctrl-benchmark
+sphinx_copybutton

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -29,6 +29,7 @@ dependencies:
 - sphinx_rtd_theme
 - conda-forge::astroid=2.4.2
 - conda-forge::sphinx-autoapi
+- conda-forge::sphinx-copybutton
 - pip:
     - pytorchcv
     - gdown


### PR DESCRIPTION
### Adding code blocks as examples in the API Documentation

This PR is a result from discussion in Issue #886 and is inspired by PyTorch documentation ([here's an example](https://pytorch.org/docs/stable/generated/torch.nn.Conv1d.html#:~:text=%3E%3E%3E%20m%20%3D%20nn.conv1d(16%2C%2033%2C%203%2C%20stride%3D2)))

#### Changes: 
- Update API docs footer to be 2022 (previously was 2021)
- Add examples to Simple CNN and SimpleMLP classes. It defaults to python syntax highlighting.
- Use the `sphinx_copybutton` extension to allow for users to quickly copy code blocks.

#### Notes:
- The `sphinx_copybutton` extension can be installed in the conda environment with [these instructions](https://pypi.org/project/sphinx-copybutton/)

**Before**:
 
![avalanche-old](https://user-images.githubusercontent.com/41016622/167914481-04e6a086-26b6-4c5e-bded-9a003b907d4a.png)

**After**:

![avalanche-new](https://user-images.githubusercontent.com/41016622/167914539-275bc8ee-7c20-473d-b822-0ac10e8948cd.png)


