### PR TITLE
Output mask for IncrementalClassifier and MultiHeadClassifier

### DIFF
--- a/avalanche/benchmarks/scenarios/generic_scenario.py
+++ b/avalanche/benchmarks/scenarios/generic_scenario.py
@@ -131,7 +131,7 @@ class CLExperience(object):
         exp._exp_mode = ExperienceMode.TRAIN
         return exp
 
-    def inference(self):
+    def eval(self):
         """Return inference experience.
 
         This is a copy of the experience itself where the inference data (e.g.

--- a/avalanche/models/dynamic_modules.py
+++ b/avalanche/models/dynamic_modules.py
@@ -15,6 +15,7 @@
 """
 import torch
 from torch.nn import Module
+import numpy as np
 
 from avalanche.benchmarks.utils.dataset_utils import ConstantSequence
 from avalanche.benchmarks.scenarios import CLExperience
@@ -110,7 +111,7 @@ class MultiTaskModule(DynamicModule):
             require the model's adaptation, such as the discovery of new
             classes or tasks.
 
-        :param dataset: data from the current experience.
+        :param experience: the current experience.
         :return:
         """
         dataset = experience.dataset
@@ -205,29 +206,47 @@ class IncrementalClassifier(DynamicModule):
     classes grows over time.
     """
 
-    def __init__(self, in_features, initial_out_features=2):
+    def __init__(self, in_features, initial_out_features=2,
+                 masking=True, mask_value=-1000):
         """
         :param in_features: number of input features.
         :param initial_out_features: initial number of classes (can be
             dynamically expanded).
+        :param masking: whether unused units should be masked (default=True).
+        :param mask_value: the value used for masked units (default=-1000).
         """
         super().__init__()
+        self.masking = masking
+        self.mask_value = mask_value
+
         self.classifier = torch.nn.Linear(in_features, initial_out_features)
+        au_init = torch.zeros(initial_out_features, dtype=torch.bool)
+        self.register_buffer('active_units', au_init)
 
     @torch.no_grad()
     def adaptation(self, experience: CLExperience):
         """If `dataset` contains unseen classes the classifier is expanded.
 
-        :param dataset: data from the current experience.
+        :param experience: data from the current experience.
         :return:
         """
-        dataset = experience.dataset
         in_features = self.classifier.in_features
         old_nclasses = self.classifier.out_features
+        curr_classes = experience.classes_in_this_experience
         new_nclasses = max(
-            self.classifier.out_features, max(dataset.targets) + 1
+            self.classifier.out_features, max(curr_classes) + 1
         )
 
+        # update active_units mask
+        if self.masking:
+            if old_nclasses != new_nclasses:  # expand active_units mask
+                old_act_units = self.active_units
+                self.active_units = torch.zeros(new_nclasses, dtype=torch.bool)
+                self.active_units[:old_act_units.shape[0]] = old_act_units
+            # update with new active classes
+            self.active_units[curr_classes] = 1
+
+        # update classifier weights
         if old_nclasses == new_nclasses:
             return
         old_w, old_b = self.classifier.weight, self.classifier.bias
@@ -242,7 +261,10 @@ class IncrementalClassifier(DynamicModule):
         :param x:
         :return:
         """
-        return self.classifier(x)
+        out = self.classifier(x)
+        if self.masking:
+            out[..., torch.logical_not(self.active_units)] = self.mask_value
+        return out
 
 
 class MultiHeadClassifier(MultiTaskModule):
@@ -268,46 +290,89 @@ class MultiHeadClassifier(MultiTaskModule):
             large enough `initial_out_features`.
     """
 
-    def __init__(self, in_features, initial_out_features=2):
+    def __init__(self, in_features, initial_out_features=2,
+                 masking=True, mask_value=-1000):
         """
         :param in_features: number of input features.
         :param initial_out_features: initial number of classes (can be
             dynamically expanded).
+        :param masking: whether unused units should be masked (default=True).
+        :param mask_value: the value used for masked units (default=-1000).
         """
         super().__init__()
+        self.masking = masking
+        self.mask_value = mask_value
         self.in_features = in_features
         self.starting_out_features = initial_out_features
         self.classifiers = torch.nn.ModuleDict()
 
         # needs to create the first head because pytorch optimizers
         # fail when model.parameters() is empty.
+        # masking in IncrementalClassifier is unaware of task labels
+        # so we do masking here instead.
         first_head = IncrementalClassifier(
-            self.in_features, self.starting_out_features
+            self.in_features, self.starting_out_features, masking=False
         )
         self.classifiers["0"] = first_head
         self.max_class_label = max(self.max_class_label, initial_out_features)
 
+        au_init = torch.zeros(initial_out_features, dtype=torch.bool)
+        self.register_buffer('active_units_T0', au_init)
+
     def adaptation(self, experience: CLExperience):
         """If `dataset` contains new tasks, a new head is initialized.
 
-        :param dataset: data from the current experience.
+        :param experience: data from the current experience.
         :return:
         """
         super().adaptation(experience)
-        dataset = experience.dataset
-        task_labels = dataset.targets_task_labels
+        curr_classes = experience.classes_in_this_experience
+        task_labels = experience.task_labels
         if isinstance(task_labels, ConstantSequence):
             # task label is unique. Don't check duplicates.
             task_labels = [task_labels[0]]
 
         for tid in set(task_labels):
+            # head adaptation
             tid = str(tid)  # need str keys
-            if tid not in self.classifiers:
+            if tid not in self.classifiers:  # create new head
                 new_head = IncrementalClassifier(
                     self.in_features, self.starting_out_features
                 )
-                new_head.adaptation(experience)
                 self.classifiers[tid] = new_head
+
+                au_init = torch.zeros(self.starting_out_features,
+                                      dtype=torch.bool)
+                self.register_buffer(f'active_units_T{tid}', au_init)
+
+            self.classifiers[tid].adaptation(experience)
+
+            # update active_units mask for the current task
+            if self.masking:
+                # TODO: code below assumes a single task for each experience
+                # it should be easy to generalize but it may be slower.
+                if len(task_labels) > 1:
+                    raise NotImplementedError(
+                        "Multi-Head unit masking is not supported when "
+                        "experiences have multiple task labels. Set "
+                        "masking=False in your "
+                        "MultiHeadClassifier to disable masking.")
+
+                au_name = f'active_units_T{tid}'
+                curr_head = self.classifiers[str(tid)]
+                old_nunits = self._buffers[au_name].shape[0]
+
+                new_nclasses = max(
+                    curr_head.classifier.out_features, max(curr_classes) + 1
+                )
+                if old_nunits != new_nclasses:  # expand active_units mask
+                    old_act_units = self._buffers[au_name]
+                    self._buffers[au_name] = torch.zeros(new_nclasses,
+                                                         dtype=torch.bool)
+                    self._buffers[au_name][:old_act_units.shape[0]] = \
+                        old_act_units
+                # update with new active classes
+                self._buffers[au_name][curr_classes] = 1
 
     def forward_single_task(self, x, task_label):
         """compute the output given the input `x`. This module uses the task
@@ -317,7 +382,11 @@ class MultiHeadClassifier(MultiTaskModule):
         :param task_label:
         :return:
         """
-        return self.classifiers[str(task_label)](x)
+        out = self.classifiers[str(task_label)](x)
+        if self.masking:
+            curr_au = self._buffers[f'active_units_T{task_label}']
+            out[..., torch.logical_not(curr_au)] = self.mask_value
+        return out
 
 
 class TrainEvalModel(DynamicModule):

--- a/avalanche/models/pnn.py
+++ b/avalanche/models/pnn.py
@@ -2,10 +2,10 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from avalanche.benchmarks.utils import AvalancheDataset
 from avalanche.benchmarks.utils.dataset_utils import ConstantSequence
-from avalanche.models import MultiTaskModule, DynamicModule
+from avalanche.models import MultiTaskModule
 from avalanche.models import MultiHeadClassifier
+from avalanche.benchmarks.scenarios import CLExperience
 
 
 class LinearAdapter(nn.Module):
@@ -161,7 +161,7 @@ class PNNLayer(MultiTaskModule):
     def num_columns(self):
         return len(self.columns)
 
-    def adaptation(self, dataset: AvalancheDataset):
+    def adaptation(self, experience: CLExperience):
         """Training adaptation for PNN layer.
 
         Adds an additional column to the layer.
@@ -169,7 +169,8 @@ class PNNLayer(MultiTaskModule):
         :param dataset:
         :return:
         """
-        super().train_adaptation(dataset)
+        dataset = experience.dataset
+        super().train_adaptation(experience)
         task_labels = dataset.targets_task_labels
         if isinstance(task_labels, ConstantSequence):
             # task label is unique. Don't check duplicates.

--- a/avalanche/models/utils.py
+++ b/avalanche/models/utils.py
@@ -3,6 +3,8 @@ from avalanche.models.dynamic_modules import MultiTaskModule, DynamicModule
 import torch.nn as nn
 from collections import OrderedDict
 
+from avalanche.benchmarks.scenarios import CLExperience
+
 
 def avalanche_forward(model, x, task_labels):
     if isinstance(model, MultiTaskModule):
@@ -11,10 +13,10 @@ def avalanche_forward(model, x, task_labels):
         return model(x)
 
 
-def avalanche_model_adaptation(model: nn.Module, dataset: AvalancheDataset):
+def avalanche_model_adaptation(model: nn.Module, experience: CLExperience):
     for module in model.modules():
         if isinstance(module, DynamicModule):
-            module.adaptation(dataset)
+            module.adaptation(experience)
 
 
 class FeatureExtractorBackbone(nn.Module):

--- a/avalanche/training/templates/online_supervised.py
+++ b/avalanche/training/templates/online_supervised.py
@@ -205,5 +205,5 @@ class SupervisedOnlineTemplate(SupervisedTemplate):
 
         for module in model.modules():
             if isinstance(module, DynamicModule):
-                module.adaptation(self.full_experience.dataset)
+                module.adaptation(self.full_experience)
         return model.to(self.device)

--- a/avalanche/training/templates/supervised.py
+++ b/avalanche/training/templates/supervised.py
@@ -260,7 +260,7 @@ class SupervisedTemplate(BaseSGDTemplate):
         """
         if model is None:
             model = self.model
-        avalanche_model_adaptation(model, self.experience.dataset)
+        avalanche_model_adaptation(model, self.experience)
         return model.to(self.device)
 
     def _unpack_minibatch(self):

--- a/profiling/replay_buffers.py
+++ b/profiling/replay_buffers.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock
+
+import time
+from os.path import expanduser
+
+from tqdm import tqdm
+
+from avalanche.benchmarks import fixed_size_experience_split, SplitMNIST
+from avalanche.training import ReservoirSamplingBuffer
+from avalanche.training import ParametricBuffer
+
+benchmark = SplitMNIST(
+    n_experiences=5,
+    dataset_root=expanduser("~") + "/.avalanche/data/mnist/",
+)
+
+experience = benchmark.train_stream[0]
+print("len experience: ", len(experience.dataset))
+
+# start = time.time()
+# buffer = ReservoirSamplingBuffer(100)
+# for exp in tqdm(fixed_size_experience_split(experience, 1)):
+#     buffer.update_from_dataset(exp.dataset)
+#
+# end = time.time()
+# duration = end - start
+# print("ReservoirSampling Duration: ", duration)
+
+
+start = time.time()
+buffer = ParametricBuffer(100)
+for exp in tqdm(fixed_size_experience_split(experience, 1)):
+    buffer.update(Mock(experience=exp, dataset=exp.dataset))
+
+end = time.time()
+duration = end - start
+print("ParametricBuffer (random sampling) Duration: ", duration)

--- a/tests/benchmarks/scenarios/test_generic_scenario.py
+++ b/tests/benchmarks/scenarios/test_generic_scenario.py
@@ -21,7 +21,7 @@ class ExperienceTests(unittest.TestCase):
 
         self.assertRaises(
             MaskedAttributeError,
-            lambda: CLExperience(5).inference().current_experience,
+            lambda: CLExperience(5).eval().current_experience,
         )
 
         print(

--- a/tests/benchmarks/scenarios/test_rl_scenario.py
+++ b/tests/benchmarks/scenarios/test_rl_scenario.py
@@ -57,5 +57,3 @@ def test_multiple_envs():
     for i, exp in enumerate(rl_scenario.eval_stream):
         assert exp.task_label == 0
         assert exp.environment.spec.id == envs[0].spec.id   
-    
-    

--- a/tests/test_helper_method.py
+++ b/tests/test_helper_method.py
@@ -78,6 +78,8 @@ class ConversionMethodTests(unittest.TestCase):
         module_singletask.eval()
         module_multitask.eval()
 
+        # disable masking to check output equivalence
+        module_multitask.classifier.masking = False
         out_single_task = module_singletask(test_input)
         out_multi_task = module_multitask(test_input, task_labels=0)
         self.assertTrue(torch.equal(out_single_task, out_multi_task))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -211,8 +211,10 @@ class DynamicModelsTests(unittest.TestCase):
         b_old = model.classifier.bias.clone()
 
         # adaptation. Increase number of classes
+        e = benchmark.train_stream[4]
         class Experience:
-            dataset = benchmark.train_stream[4].dataset
+            dataset = e.dataset
+            classes_in_this_experience = e.classes_in_this_experience
         experience = Experience()
 
         model.adaptation(experience)
@@ -317,6 +319,7 @@ class DynamicModelsTests(unittest.TestCase):
         model_t4 = model.classifiers["4"]
 
         # check head task0
+        model.masking = False  # disable masking to check output equality
         for x, y, t in DataLoader(benchmark.train_stream[0].dataset):
             y_mh = model(x, t)
             y_t = model_t0(x)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -212,6 +212,7 @@ class DynamicModelsTests(unittest.TestCase):
 
         # adaptation. Increase number of classes
         e = benchmark.train_stream[4]
+        
         class Experience:
             dataset = e.dataset
             classes_in_this_experience = e.classes_in_this_experience

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -330,6 +330,65 @@ class DynamicModelsTests(unittest.TestCase):
             assert ((y_mh - y_t) ** 2).sum() < 1.0e-7
             break
 
+    def test_incremental_classifier_masking(self):
+        benchmark = get_fast_benchmark(
+            use_task_labels=False, shuffle=True
+        )
+        model = IncrementalClassifier(in_features=6)
+        autot = []
+        for exp in benchmark.train_stream:
+            curr_au = exp.classes_in_this_experience
+            autot.extend(curr_au)
+
+            model.adaptation(exp)
+            assert torch.all(model.active_units[autot] == 1)
+
+            # print(model.active_units)
+            mb = exp.dataset[:7][0]
+            out = model(mb)
+            assert torch.all(out[:, autot] != model.mask_value)
+            out_masked = out[:, model.active_units == 0]
+            assert torch.all(out_masked == model.mask_value)
+
+    def test_multi_head_classifier_masking(self):
+        benchmark = get_fast_benchmark(
+            use_task_labels=True, shuffle=True
+        )
+
+        # print("task order: ", [e.task_label for e in benchmark.train_stream])
+        # print("class order: ", [e.classes_in_this_experience for e in
+        # benchmark.train_stream])
+
+        model = MultiHeadClassifier(in_features=6)
+        for tid, exp in enumerate(benchmark.train_stream):
+            # exclusive task label for each experience
+            curr_au = exp.classes_in_this_experience
+
+            model.adaptation(exp)
+            curr_mask = model._buffers[f'active_units_T{tid}']
+            nunits = curr_mask.shape[0]
+            assert torch.all(curr_mask[curr_au] == 1)
+
+            # print(model._buffers)
+            mb, tmb = exp.dataset[:7][0], exp.dataset[:7][2]
+            out = model(mb, tmb)
+            assert torch.all(out[:, curr_au] != model.mask_value)
+            assert torch.all(out[:, :nunits]
+                             [:, curr_mask == 0] == model.mask_value)
+        # check masking after adaptation on the entire stream
+        for tid, exp in enumerate(benchmark.train_stream):
+            curr_au = exp.classes_in_this_experience
+            curr_mask = model._buffers[f'active_units_T{tid}']
+            nunits = curr_mask.shape[0]
+            assert torch.all(curr_mask[curr_au] == 1)
+
+            # print(model._buffers)
+            mb, tmb = exp.dataset[:7][0], exp.dataset[:7][2]
+            out = model(mb, tmb)
+            assert torch.all(out[:, curr_au] != model.mask_value)
+            assert torch.all(out[:, :nunits]
+                             [:, curr_mask == 0] == model.mask_value)
+
 
 class TrainEvalModelTests(unittest.TestCase):
     def test_classifier_selection(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -211,8 +211,11 @@ class DynamicModelsTests(unittest.TestCase):
         b_old = model.classifier.bias.clone()
 
         # adaptation. Increase number of classes
-        dataset = benchmark.train_stream[4].dataset
-        model.adaptation(dataset)
+        class Experience:
+            dataset = benchmark.train_stream[4].dataset
+        experience = Experience()
+
+        model.adaptation(experience)
         w_new = model.classifier.weight.clone()
         b_new = model.classifier.bias.clone()
 
@@ -221,8 +224,8 @@ class DynamicModelsTests(unittest.TestCase):
         assert torch.equal(b_old, b_new[: w_old.shape[0]])
 
         # shape should be correct.
-        assert w_new.shape[0] == max(dataset.targets) + 1
-        assert b_new.shape[0] == max(dataset.targets) + 1
+        assert w_new.shape[0] == max(experience.dataset.targets) + 1
+        assert b_new.shape[0] == max(experience.dataset.targets) + 1
 
     def test_multihead_head_creation(self):
         # Check if the optimizer is updated correctly
@@ -391,7 +394,7 @@ class PNNTest(unittest.TestCase):
         d1 = benchmark.train_stream[1].dataset
         mb1 = iter(DataLoader(d1)).__next__()
 
-        avalanche_model_adaptation(model, d0)
-        avalanche_model_adaptation(model, d1)
+        avalanche_model_adaptation(model, benchmark.train_stream[0])
+        avalanche_model_adaptation(model, benchmark.train_stream[1])
         model(mb0[0], task_labels=mb0[-1])
         model(mb1[0], task_labels=mb1[-1])

--- a/tests/training/test_plugins.py
+++ b/tests/training/test_plugins.py
@@ -31,6 +31,7 @@ from avalanche.training.plugins import (
 from avalanche.training.plugins.clock import Clock
 from avalanche.training.plugins.lr_scheduling import LRSchedulerPlugin
 from avalanche.training.supervised import Naive
+from tests.unit_tests_utils import FAST_TEST
 
 
 class MockPlugin(SupervisedPlugin):
@@ -549,6 +550,10 @@ class PluginTests(unittest.TestCase):
         with self.assertRaises(Exception):
             LRSchedulerPlugin(scheduler, metric="cuteness")
 
+    @unittest.skipIf(
+        FAST_TEST,
+        "skip test because it is extremely slow "
+        "and should not be broken easily.")
     def test_scheduler_reduce_on_plateau_plugin_with_val_stream(self):
         # Regression test for issue #858 (part 2)
         n_epochs = 100

--- a/tests/training/test_supervised_regression.py
+++ b/tests/training/test_supervised_regression.py
@@ -374,7 +374,7 @@ class OldBaseStrategy:
 
         for module in model.modules():
             if isinstance(module, DynamicModule):
-                module.adaptation(self.experience.dataset)
+                module.adaptation(self.experience)
         return model.to(self.device)
 
     def forward(self):


### PR DESCRIPTION
I needed a couple of changes to the dynamic modules.

two changes:
- `DynamicModule`s `adaptation` now uses `experience` instead of `dataset`. This should make things faster and support other benchmarks (RL, ex-model, OCL) where we may not have a dataset.
- output masking: some units of incremental/multihead classifiers are unused (e.g. if an experience contains classes 2 and 7, 8 units are created, 6 of which end up unused but trained anyway). Masking avoids training those units. Enabled by default but can be disabled.