### PR TITLE
Minor Fix in Examples

### DIFF
--- a/examples/ewc_mnist.py
+++ b/examples/ewc_mnist.py
@@ -80,6 +80,8 @@ def main(args):
         loggers=[interactive_logger, tensorboard_logger],
     )
 
+    if args.ewc_mode == 'separate':
+        args.decay_factor = None
     # create strategy
     strategy = EWC(
         model,

--- a/examples/pytorchcv_models.py
+++ b/examples/pytorchcv_models.py
@@ -135,4 +135,3 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     main(args)
-    

--- a/examples/pytorchcv_models.py
+++ b/examples/pytorchcv_models.py
@@ -56,7 +56,7 @@ def main(args):
         else "cpu"
     )
 
-    device = "cpu"
+    # device = "cpu"
 
     # --- TRANSFORMATIONS
     transform = transforms.Compose(
@@ -135,3 +135,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     main(args)
+    

--- a/examples/simple_ctrl.py
+++ b/examples/simple_ctrl.py
@@ -119,8 +119,8 @@ def main(args):
         for train_task, val_task in zip(train_stream, val_stream):
             t_stream = train_task
             v_stream = val_task
-        #cl_strategy.train(train_stream[-1])
-        #res = cl_strategy.eval([test_stream[-1]])
+        # cl_strategy.train(train_stream[-1])
+        # res = cl_strategy.eval([test_stream[-1]])
         cl_strategy.train(t_stream)
         res = cl_strategy.eval([v_stream])
 
@@ -139,6 +139,7 @@ def main(args):
             f"independently: {acc_last_only}"
         )
         print(f"T({args.stream})={transfer_value}")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/examples/simple_ctrl.py
+++ b/examples/simple_ctrl.py
@@ -73,7 +73,7 @@ def main(args):
         model,
         optimizer,
         criterion,
-        train_mb_size=128, #32,
+        train_mb_size=32,
         device=device,
         train_epochs=args.max_epochs,
         eval_mb_size=128,
@@ -95,7 +95,7 @@ def main(args):
             ][1]
         )
 
-    if args.stream == "s_long" or args.stream == "s_minus":
+    if args.stream == "s_long":
         res = []
         for tid in range(len(train_stream)):
             res.append(logger.last_metric_results[
@@ -108,7 +108,7 @@ def main(args):
             model_init,
             optimizer,
             criterion,
-            train_mb_size=128, #32,
+            train_mb_size=32,
             device=device,
             train_epochs=args.max_epochs,
             eval_mb_size=128,

--- a/examples/simple_ctrl.py
+++ b/examples/simple_ctrl.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 
 import argparse
 from copy import deepcopy
+import numpy as np
 
 import torch
 from torch.nn import CrossEntropyLoss
@@ -72,7 +73,7 @@ def main(args):
         model,
         optimizer,
         criterion,
-        train_mb_size=32,
+        train_mb_size=128, #32,
         device=device,
         train_epochs=args.max_epochs,
         eval_mb_size=128,
@@ -94,31 +95,38 @@ def main(args):
             ][1]
         )
 
-    if args.stream == "s_long":
-        res = logger.last_metric_results[
-            "Top1_Acc_Stream/eval_phase/" "test_stream"
-        ]
-        print(f"Average accuracy on S_long : {res}")
+    if args.stream == "s_long" or args.stream == "s_minus":
+        res = []
+        for tid in range(len(train_stream)):
+            res.append(logger.last_metric_results[
+                "Top1_Acc_Stream/eval_phase/test_stream/" f"Task00{tid}"
+            ])
+        print(f"Average accuracy on S_long : {np.mean(res)}")
     else:
         optimizer = SGD(model_init.parameters(), lr=0.001, momentum=0.9)
         cl_strategy = Naive(
             model_init,
             optimizer,
             criterion,
-            train_mb_size=32,
+            train_mb_size=128, #32,
             device=device,
             train_epochs=args.max_epochs,
             eval_mb_size=128,
+            evaluator=logger,
             plugins=[EarlyStoppingPlugin(50, "val_stream")],
             eval_every=5,
         )
-
-        cl_strategy.train(train_stream[-1])
-        res = cl_strategy.eval([test_stream[-1]])
+        for train_task, val_task in zip(train_stream, val_stream):
+            t_stream = train_task
+            v_stream = val_task
+        #cl_strategy.train(train_stream[-1])
+        #res = cl_strategy.eval([test_stream[-1]])
+        cl_strategy.train(t_stream)
+        res = cl_strategy.eval([v_stream])
 
         acc_last_stream = transfer_mat[-1][-1]
         acc_last_only = res[
-            "Top1_Acc_Exp/eval_phase/test_stream/" "Task005/Exp-01"
+            "Top1_Acc_Exp/eval_phase/test_stream/" "Task005/Exp005"
         ]
         transfer_value = acc_last_stream - acc_last_only
 
@@ -131,7 +139,6 @@ def main(args):
             f"independently: {acc_last_only}"
         )
         print(f"T({args.stream})={transfer_value}")
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/examples/standalone_metric.py
+++ b/examples/standalone_metric.py
@@ -43,13 +43,13 @@ print("Initial Accuracy: ", acc_metric.result())  # output 0
 # result method returns the current average accuracy
 real_y = torch.tensor([1, 2]).long()
 predicted_y = torch.tensor([1, 0]).float()
-acc_metric.update(real_y, predicted_y)
+acc_metric.update(real_y, predicted_y, task_labels=0)
 acc = acc_metric.result()
 print("Average Accuracy: ", acc)  # output 0.5
 
 # you can continue to update the metric with new values
 predicted_y = torch.tensor([1, 2]).float()
-acc_metric.update(real_y, predicted_y)
+acc_metric.update(real_y, predicted_y, task_labels=0)
 acc = acc_metric.result()
 print("Average Accuracy: ", acc)  # output 0.75
 

--- a/examples/synaptic_intelligence.py
+++ b/examples/synaptic_intelligence.py
@@ -90,9 +90,9 @@ def main(args):
         Adam(model.parameters(), lr=0.001),
         CrossEntropyLoss(),
         si_lambda=0.0001,
-        train_mb_size=32,
-        train_epochs=2,
-        eval_mb_size=32,
+        train_mb_size=128,
+        train_epochs=4,
+        eval_mb_size=128,
         device=device,
         evaluator=evaluation_plugin,
     )

--- a/examples/synaptic_intelligence.py
+++ b/examples/synaptic_intelligence.py
@@ -69,7 +69,7 @@ def main(args):
     # DEFINE THE EVALUATION PLUGIN AND LOGGER
 
     my_logger = TensorboardLogger(
-        tb_log_dir="logs", tb_log_exp_name="logging_example"
+        tb_log_dir="logs_example_SynapticIntelligence"
     )
 
     # print to stdout
@@ -90,9 +90,9 @@ def main(args):
         Adam(model.parameters(), lr=0.001),
         CrossEntropyLoss(),
         si_lambda=0.0001,
-        train_mb_size=128,
-        train_epochs=4,
-        eval_mb_size=128,
+        train_mb_size=32,
+        train_epochs=2,
+        eval_mb_size=32,
         device=device,
         evaluator=evaluation_plugin,
     )


### PR DESCRIPTION
Fix some minor issues if the following examples:

`ewc_mnist.py `
- Decay Factor must be None we using "separate" mode in EWC

`pytorchcv_models.py`
- Device was set to "CPU" manually, change it to use the argument

`simple_ctrl.py`
- Change the name of the metrics
- Add logger to the second strategy (line 115)

`standalone_metric.py`
- Add atribute _task_labels_ to metric update

`synaptic_intelligence.py`
- Remove _tb_log_exp_name_ from logger