### PR TITLE
Update Models Examples in the Zero-to-Hero Tutorial

### DIFF
--- a/docs/gitbook/from-zero-to-hero-tutorial/02_models.md
+++ b/docs/gitbook/from-zero-to-hero-tutorial/02_models.md
@@ -43,7 +43,7 @@ model = IncrementalClassifier(in_features=784)
 
 print(model)
 for exp in benchmark.train_stream:
-    model.adaptation(exp.dataset)
+    model.adaptation(exp)
     print(model)
 ```
 
@@ -65,7 +65,7 @@ model = MultiHeadClassifier(in_features=784)
 
 print(model)
 for exp in benchmark.train_stream:
-    model.adaptation(exp.dataset)
+    model.adaptation(exp)
     print(model)
 ```
 


### PR DESCRIPTION
In the models tutorial on the Zero-To-Hero page, there are a couple of code blocks explaining model expansion and multi-task modules. 

Both codeblocks use this line
```
model.adaptation(exp.dataset)
```
leading to these errors (for the two examples): 

**Dynamic Model Expansion**
```
IncrementalClassifier(
  (classifier): Linear(in_features=784, out_features=2, bias=True)
)
Traceback (most recent call last):
  File "examples/playground.py", line 9, in <module>
    model.adaptation(exp.dataset)
  File "/home/niniack/anaconda3/envs/avalanche-dev-env/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/home/niniack/git/avalanche/avalanche/models/dynamic_modules.py", line 232, in adaptation
    curr_classes = experience.classes_in_this_experience
AttributeError: 'AvalancheSubset' object has no attribute 'classes_in_this_experience'
```
**Multi-Task models**
```
MultiHeadClassifier(
  (classifiers): ModuleDict(
    (0): IncrementalClassifier(
      (classifier): Linear(in_features=784, out_features=2, bias=True)
    )
  )
)
Traceback (most recent call last):
  File "examples/playground.py", line 9, in <module>
    model.adaptation(exp.dataset)
  File "/home/niniack/git/avalanche/avalanche/models/dynamic_modules.py", line 328, in adaptation
    super().adaptation(experience)
  File "/home/niniack/git/avalanche/avalanche/models/dynamic_modules.py", line 114, in adaptation
    dataset = experience.dataset
AttributeError: 'AvalancheSubset' object has no attribute 'dataset'
```

Simple fix: 
```
model.adaptation(exp)
```

