### PR TITLE
AMCA metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ logs/
 doc_html/*
 .coverage
 tb_data/
+csvlogs/
 docs/generated/

--- a/avalanche/evaluation/metric_definitions.py
+++ b/avalanche/evaluation/metric_definitions.py
@@ -390,7 +390,8 @@ class ExtendedPluginMetricValue:
         """
 
 
-class ExtendedGenericPluginMetric(GenericPluginMetric[TResult]):
+class ExtendedGenericPluginMetric(
+        GenericPluginMetric[List[ExtendedPluginMetricValue]]):
     """
     A generified version of :class:`GenericPluginMetric` which supports emitting
     multiple metrics from a single metric instance.
@@ -451,5 +452,6 @@ __all__ = [
     "Metric",
     "PluginMetric",
     "GenericPluginMetric",
+    "ExtendedPluginMetricValue",
     "ExtendedGenericPluginMetric"
 ]

--- a/avalanche/evaluation/metric_definitions.py
+++ b/avalanche/evaluation/metric_definitions.py
@@ -334,10 +334,16 @@ class GenericPluginMetric(PluginMetric[TResult]):
             self.reset(strategy)
 
 
-MultiValuesTypes = Literal['multi_groups', 'multi_values']
+class _ExtendedPluginMetricValue:
+    """
+    A data structure used to describe a metric value.
 
+    Mainly used to compose the final "name" or "path" of a metric.
 
-class ExtendedPluginMetricValue:
+    For the moment, this class should be considered an internal utility. Use it
+    at your own risk!
+    """
+
     def __init__(
             self,
             *,
@@ -390,8 +396,8 @@ class ExtendedPluginMetricValue:
         """
 
 
-class ExtendedGenericPluginMetric(
-        GenericPluginMetric[List[ExtendedPluginMetricValue]]):
+class _ExtendedGenericPluginMetric(
+        GenericPluginMetric[List[_ExtendedPluginMetricValue]]):
     """
     A generified version of :class:`GenericPluginMetric` which supports emitting
     multiple metrics from a single metric instance.
@@ -402,6 +408,9 @@ class ExtendedGenericPluginMetric(
 
     The resulting metric name will be given by the implementation of the
     :meth:`metric_value_name` method.
+
+    For the moment, this class should be considered an internal utility. Use it
+    at your own risk!
     """
 
     def __init__(self, *args, **kwargs):
@@ -422,7 +431,7 @@ class ExtendedGenericPluginMetric(
 
         metrics = []
         for m_value in emitted_values:
-            if not isinstance(m_value, ExtendedPluginMetricValue):
+            if not isinstance(m_value, _ExtendedPluginMetricValue):
                 raise RuntimeError(
                     'Emitted a value that is not of type '
                     'ExtendedPluginMetricValue'
@@ -438,10 +447,10 @@ class ExtendedGenericPluginMetric(
 
         return metrics
 
-    def result(self, strategy) -> List[ExtendedPluginMetricValue]:
+    def result(self, strategy) -> List[_ExtendedPluginMetricValue]:
         return self._metric.result()
 
-    def metric_value_name(self, m_value: ExtendedPluginMetricValue) -> str:
+    def metric_value_name(self, m_value: _ExtendedPluginMetricValue) -> str:
         return generic_get_metric_name(
             default_metric_name_template,
             vars(m_value)
@@ -452,6 +461,6 @@ __all__ = [
     "Metric",
     "PluginMetric",
     "GenericPluginMetric",
-    "ExtendedPluginMetricValue",
-    "ExtendedGenericPluginMetric"
+    "_ExtendedPluginMetricValue",
+    "_ExtendedGenericPluginMetric"
 ]

--- a/avalanche/evaluation/metric_definitions.py
+++ b/avalanche/evaluation/metric_definitions.py
@@ -215,10 +215,11 @@ class GenericPluginMetric(PluginMetric[TResult]):
         super(GenericPluginMetric, self).__init__()
         assert mode in {"train", "eval"}
         if mode == "train":
-            assert reset_at in {"iteration", "epoch", "experience", "stream"}
+            assert reset_at in {"iteration", "epoch", "experience", "stream",
+                                "never"}
             assert emit_at in {"iteration", "epoch", "experience", "stream"}
         else:
-            assert reset_at in {"iteration", "experience", "stream"}
+            assert reset_at in {"iteration", "experience", "stream", "never"}
             assert emit_at in {"iteration", "experience", "stream"}
         self._metric = metric
         self._reset_at = reset_at

--- a/avalanche/evaluation/metric_utils.py
+++ b/avalanche/evaluation/metric_utils.py
@@ -9,8 +9,8 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from typing import Dict, Union, Iterable, Sequence, Tuple, TYPE_CHECKING, List, \
-    Optional, Callable, Any
+from typing import Dict, Union, Iterable, Sequence, Tuple, TYPE_CHECKING,\
+    List, Callable, Any
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/avalanche/evaluation/metric_utils.py
+++ b/avalanche/evaluation/metric_utils.py
@@ -9,7 +9,8 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from typing import Dict, Union, Iterable, Sequence, Tuple, TYPE_CHECKING, List
+from typing import Dict, Union, Iterable, Sequence, Tuple, TYPE_CHECKING, List, \
+    Optional, Callable, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -280,6 +281,44 @@ def bytes2human(n):
     return "%sB" % n
 
 
+def default_metric_name_template(metric_info: Dict[str, Any]):
+    add_task = metric_info.get('task_label', None) is not None
+    add_phase = metric_info.get('phase_name', None) is not None
+    add_experience = metric_info.get('experience_id', None) is not None
+    add_stream = metric_info.get('stream_name', None) is not None
+
+    if 'metric_name' not in metric_info:
+        raise RuntimeError('Key metric_name missing from value dictionary.')
+
+    result_template = '{metric_name}/'
+    if add_phase:
+        result_template += '{phase_name}_phase/'
+
+    if add_stream:
+        result_template += '{stream_name}_stream/'
+
+    if add_task:
+        result_template += 'Task{task_label:03}/'
+
+    if add_experience:
+        result_template += 'Exp{experience_id:03}/'
+
+    return result_template[:-1]
+
+
+def generic_get_metric_name(
+        value_name_template: Union[str, Callable[[Dict[str, Any]], str]],
+        metric_info: Dict[str, Any]):
+
+    if isinstance(value_name_template, str):
+        name_template = value_name_template
+    else:
+        name_template = value_name_template(metric_info)
+
+    # https://stackoverflow.com/a/17895844
+    return name_template.format(**metric_info)
+
+
 def get_metric_name(
     metric: Union["PluginMetric", str],
     strategy: "SupervisedTemplate",
@@ -307,35 +346,54 @@ def get_metric_name(
 
     phase_name, task_label = phase_and_task(strategy)
     stream = stream_type(strategy.experience)
-    base_name = "{}/{}_phase/{}_stream".format(str(metric), phase_name, stream)
-    exp_name = "/Exp{:03}".format(strategy.experience.current_experience)
+    experience_id = strategy.experience.current_experience
+    if type(add_task) == bool and add_task is False:
+        task_label = None
+    elif type(add_task) == int:
+        task_label = add_task
 
-    # task label not present - do not print task
-    if task_label is None and type(add_task) == bool:
-        add_task = False
-    else:
-        # task label is present and printed
-        if type(add_task) == bool and add_task is True:
-            task_name = "/Task{:03}".format(task_label)
-        # print user-defined task label
-        elif type(add_task) == int:
-            task_name = "/Task{:03}".format(add_task)
-            add_task = True
-        # else case is add_task=False
+    if not add_experience:
+        experience_id = None
 
-    if add_experience and not add_task:
-        return base_name + exp_name
-    elif add_experience and add_task:
-        return base_name + task_name + exp_name
-    elif not add_experience and not add_task:
-        return base_name
-    elif not add_experience and add_task:
-        return base_name + task_name
+    # # task label not present - do not print task
+    # if task_label is None and type(add_task) == bool:
+    #     add_task = False
+    # else:
+    #     # task label is present and printed
+    #     if type(add_task) == bool and add_task is True:
+    #         task_name = "/Task{:03}".format(task_label)
+    #     # print user-defined task label
+    #     elif type(add_task) == int:
+    #         task_name = "/Task{:03}".format(add_task)
+    #         add_task = True
+    #     # else case is add_task=False
+
+    return generic_get_metric_name(
+        default_metric_name_template,
+        {
+            'metric_name': str(metric),
+            'task_label': task_label,
+            'phase_name': phase_name,
+            'experience_id': experience_id,
+            'stream_name': stream
+        }
+    )
+    #
+    # if add_experience and not add_task:
+    #     return base_name + exp_name
+    # elif add_experience and add_task:
+    #     return base_name + task_name + exp_name
+    # elif not add_experience and not add_task:
+    #     return base_name
+    # elif not add_experience and add_task:
+    #     return base_name + task_name
 
 
 __all__ = [
     "default_cm_image_creator",
     "phase_and_task",
+    "default_metric_name_template",
+    "generic_get_metric_name",
     "get_metric_name",
     "stream_type",
     "bytes2human",

--- a/avalanche/evaluation/metric_utils.py
+++ b/avalanche/evaluation/metric_utils.py
@@ -355,19 +355,6 @@ def get_metric_name(
     if not add_experience:
         experience_id = None
 
-    # # task label not present - do not print task
-    # if task_label is None and type(add_task) == bool:
-    #     add_task = False
-    # else:
-    #     # task label is present and printed
-    #     if type(add_task) == bool and add_task is True:
-    #         task_name = "/Task{:03}".format(task_label)
-    #     # print user-defined task label
-    #     elif type(add_task) == int:
-    #         task_name = "/Task{:03}".format(add_task)
-    #         add_task = True
-    #     # else case is add_task=False
-
     return generic_get_metric_name(
         default_metric_name_template,
         {
@@ -378,15 +365,6 @@ def get_metric_name(
             'stream_name': stream
         }
     )
-    #
-    # if add_experience and not add_task:
-    #     return base_name + exp_name
-    # elif add_experience and add_task:
-    #     return base_name + task_name + exp_name
-    # elif not add_experience and not add_task:
-    #     return base_name
-    # elif not add_experience and add_task:
-    #     return base_name + task_name
 
 
 __all__ = [

--- a/avalanche/evaluation/metric_utils.py
+++ b/avalanche/evaluation/metric_utils.py
@@ -281,7 +281,7 @@ def bytes2human(n):
 
 
 def get_metric_name(
-    metric: "PluginMetric",
+    metric: Union["PluginMetric", str],
     strategy: "SupervisedTemplate",
     add_experience=False,
     add_task=True,

--- a/avalanche/evaluation/metrics/__init__.py
+++ b/avalanche/evaluation/metrics/__init__.py
@@ -1,6 +1,7 @@
 from .mean import *
 from .accuracy import *
 from .checkpoint import *
+from .class_accuracy import *
 from .confusion_matrix import *
 from .cpu_usage import *
 from .disk_usage import *

--- a/avalanche/evaluation/metrics/__init__.py
+++ b/avalanche/evaluation/metrics/__init__.py
@@ -1,5 +1,6 @@
 from .mean import *
 from .accuracy import *
+from .amca import *
 from .checkpoint import *
 from .class_accuracy import *
 from .confusion_matrix import *

--- a/avalanche/evaluation/metrics/amca.py
+++ b/avalanche/evaluation/metrics/amca.py
@@ -8,7 +8,10 @@
 # E-mail: contact@continualai.org                                              #
 # Website: www.continualai.org                                                 #
 ################################################################################
-from statistics import fmean
+try:
+    from statistics import fmean
+except ImportError:
+    from statistics import mean as fmean
 from typing import Dict, List, Union, TYPE_CHECKING, Optional, Sequence, Set
 from collections import defaultdict, OrderedDict
 

--- a/avalanche/evaluation/metrics/amca.py
+++ b/avalanche/evaluation/metrics/amca.py
@@ -15,8 +15,7 @@ from collections import defaultdict, OrderedDict
 import torch
 from torch import Tensor
 from avalanche.evaluation import Metric, PluginMetric, \
-    ExtendedGenericPluginMetric
-from avalanche.evaluation.metric_definitions import ExtendedPluginMetricValue
+    _ExtendedGenericPluginMetric, _ExtendedPluginMetricValue
 from avalanche.evaluation.metric_utils import generic_get_metric_name
 from avalanche.evaluation.metrics.class_accuracy import ClassAccuracy, \
     TrackedClassesType
@@ -301,7 +300,7 @@ class MultiStreamAMCA(Metric[Dict[str, Dict[int, float]]]):
                stream_name in self._limit_streams
 
 
-class AMCAPluginMetric(ExtendedGenericPluginMetric):
+class AMCAPluginMetric(_ExtendedGenericPluginMetric):
     """
     Base class for all class accuracy plugin metrics
     """
@@ -351,7 +350,7 @@ class AMCAPluginMetric(ExtendedGenericPluginMetric):
             self._ms_amca.set_stream(strategy.experience.origin_stream.name)
         return super().before_eval_exp(strategy)
 
-    def result(self, strategy) -> List[ExtendedPluginMetricValue]:
+    def result(self, strategy) -> List[_ExtendedPluginMetricValue]:
         if self._is_training and self._ignore_validation:
             # Running a validation, ignore it
             return []
@@ -362,7 +361,7 @@ class AMCAPluginMetric(ExtendedGenericPluginMetric):
         for stream_name, stream_accs in stream_amca.items():
             for task_id, task_amca in stream_accs.items():
                 metric_values.append(
-                    ExtendedPluginMetricValue(
+                    _ExtendedPluginMetricValue(
                         metric_name=str(self),
                         metric_value=task_amca,
                         phase_name='eval',
@@ -374,7 +373,7 @@ class AMCAPluginMetric(ExtendedGenericPluginMetric):
 
         return metric_values
 
-    def metric_value_name(self, m_value: ExtendedPluginMetricValue) -> str:
+    def metric_value_name(self, m_value: _ExtendedPluginMetricValue) -> str:
         return generic_get_metric_name(
             AMCAPluginMetric.VALUE_NAME,
             vars(m_value)

--- a/avalanche/evaluation/metrics/amca.py
+++ b/avalanche/evaluation/metrics/amca.py
@@ -9,14 +9,15 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 from statistics import fmean
-from typing import Dict, List, Union, TYPE_CHECKING
+from typing import Dict, List, Union, TYPE_CHECKING, Optional
 from collections import defaultdict, OrderedDict
 
 import torch
 from torch import Tensor
 from avalanche.evaluation import Metric, PluginMetric, \
     GenericPluginMetric
-from avalanche.evaluation.metrics import ClassAccuracy
+from avalanche.evaluation.metrics.class_accuracy import ClassAccuracy, \
+    TrackedClassesType
 
 if TYPE_CHECKING:
     from avalanche.training.templates import SupervisedTemplate
@@ -52,7 +53,9 @@ class AverageMeanClassAccuracy(Metric[Dict[int, float]]):
     (that is, the `reset` method will hardly be useful when using this metric).
     """
 
-    def __init__(self, classes=None):
+    def __init__(
+            self,
+            classes: Optional[TrackedClassesType] = None):
         """
         Creates an instance of the standalone AMCA metric.
 
@@ -135,7 +138,7 @@ class AverageMeanClassAccuracy(Metric[Dict[int, float]]):
         return mean_accs
 
     def next_train_experience(self):
-        for task_id, mean_class_acc in self._get_curr_task_acc():
+        for task_id, mean_class_acc in self._get_curr_task_acc().items():
             self._prev_exps_accuracies[task_id].append(mean_class_acc)
         self._class_accuracies.reset()
 

--- a/avalanche/evaluation/metrics/amca.py
+++ b/avalanche/evaluation/metrics/amca.py
@@ -1,0 +1,247 @@
+################################################################################
+# Copyright (c) 2021 ContinualAI.                                              #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 26-05-2022                                                             #
+# Author(s): Eli Verwimp, Lorenzo Pellegrini                                   #
+# E-mail: contact@continualai.org                                              #
+# Website: www.continualai.org                                                 #
+################################################################################
+from statistics import fmean
+from typing import Dict, List, Union, TYPE_CHECKING
+from collections import defaultdict, OrderedDict
+
+import torch
+from torch import Tensor
+from avalanche.evaluation import Metric, PluginMetric, \
+    GenericPluginMetric
+from avalanche.evaluation.metrics import ClassAccuracy
+
+if TYPE_CHECKING:
+    from avalanche.training.templates import SupervisedTemplate
+
+
+class AverageMeanClassAccuracy(Metric[Dict[int, float]]):
+    # TODO: unit tests
+    """
+    The Average Mean Class Accuracy (AMCA) metric. This is a standalone metric
+    used to compute more specific ones.
+
+    Instances of this metric keeps the running average accuracy
+    over multiple <prediction, target> pairs of Tensors,
+    provided incrementally.
+    The "prediction" and "target" tensors may contain plain labels or
+    one-hot/logit vectors.
+
+    Each time `result` is called, this metric emits the average mean accuracy
+    as the average accuracy of all previous experiences (also considering the
+    accuracy in the current experience).
+    The metric expects that the `next_train_experience()` method will be called
+    after each experience. This is needed to consolidate the current mean
+    accuracy. After calling `next_train_experience()`, a new experience with
+    accuracy 0.0 is immediately started. If you need to obtain the AMCA up to
+    experience `t-1`, obtain the `result()` before calling `next_experience()`.
+
+    The set of classes to be tracked can be reduced (please refer to the
+    constructor parameters).
+
+    The reset method will bring the metric to its initial state
+    (tracked classes will be kept). By default, this metric in its initial state
+    will return a `{task_id -> amca}` dictionary in which all AMCAs are set to 0
+    (that is, the `reset` method will hardly be useful when using this metric).
+    """
+
+    def __init__(self, classes=None):
+        """
+        Creates an instance of the standalone AMCA metric.
+
+        By default, this metric in its initial state will return an empty
+        dictionary. The metric can be updated by using the `update` method
+        while the running AMCA can be retrieved using the `result` method.
+
+        By using the `classes` parameter, one can restrict the list of classes
+        to be tracked and in addition will initialize the accuracy for that
+        class to 0.0.
+
+        Setting the `classes` parameter is very important, as the mean class
+        accuracy may vary based on this! If the test set is fixed and contains
+        at least a sample for each class, then it is safe to leave `classes`
+        to None.
+
+        :param classes: The classes to keep track of. If None (default), all
+            classes seen are tracked. Otherwise, it can be a dict of classes
+            to be tracked (as "task-id" -> "list of class ids") or, if running
+            a task-free benchmark (with only task "0"), a simple list of class
+            ids. By passing this parameter, the list of classes to be considered
+            is created immediately. This will ensure that the mean class
+            accuracy is correctly computed. In addition, this can be used to
+            restrict the classes that should be considered when computing the
+            mean class accuracy.
+        """
+        self._class_accuracies = ClassAccuracy(classes=classes)
+        """
+        A dictionary "task_id -> {class_id -> Mean}".
+        """
+
+        # Here a Mean metric could be used as well. However, that could make it
+        # difficult to compute the running AMCA...
+        self._prev_exps_accuracies: Dict[int, List[float]] = defaultdict(list)
+        """
+        The mean class accuracy of previous experiences as a dictionary
+        `{task_id -> [accuracies]}`.
+        """
+
+    @torch.no_grad()
+    def update(self,
+               predicted_y: Tensor,
+               true_y: Tensor,
+               task_labels: Union[int, Tensor]) -> None:
+        """
+        Update the running accuracy given the true and predicted labels for each
+        class.
+
+        :param predicted_y: The model prediction. Both labels and logit vectors
+            are supported.
+        :param true_y: The ground truth. Both labels and one-hot vectors
+            are supported.
+        :param task_labels: the int task label associated to the current
+            experience or the task labels vector showing the task label
+            for each pattern.
+        :return: None.
+        """
+        self._class_accuracies.update(predicted_y, true_y, task_labels)
+
+    def result(self) -> Dict[int, float]:
+        """
+        Retrieves the running AMCA for each task.
+
+        Calling this method will not change the internal state of the metric.
+
+        :return: A dictionary `{task_id -> amca}`. The
+            running AMCA of each task is a float value between 0 and 1.
+        """
+        curr_task_acc = self._get_curr_task_acc()
+
+        all_task_ids = set(self._prev_exps_accuracies.keys())
+        all_task_ids = all_task_ids.union(curr_task_acc.keys())
+
+        mean_accs = OrderedDict()
+        for task_id in sorted(all_task_ids):
+            prev_accs = self._prev_exps_accuracies.get(task_id, list())
+            curr_acc = curr_task_acc.get(task_id, 0)
+            mean_accs[task_id] = fmean(prev_accs + [curr_acc])
+
+        return mean_accs
+
+    def next_train_experience(self):
+        for task_id, mean_class_acc in self._get_curr_task_acc():
+            self._prev_exps_accuracies[task_id].append(mean_class_acc)
+        self._class_accuracies.reset()
+
+    def reset(self) -> None:
+        """
+        Resets the metric.
+
+        :return: None.
+        """
+        self._class_accuracies.reset()
+        self._prev_exps_accuracies.clear()
+
+    def _get_curr_task_acc(self):
+        task_acc = dict()
+        class_acc = self._class_accuracies.result()
+        for task_id, task_classes in class_acc.items():
+            class_accuracies = list(task_classes.values())
+            mean_class_acc = fmean(class_accuracies)
+
+            task_acc[task_id] = mean_class_acc
+        return task_acc
+
+
+class AverageClassAccuracyPluginMetric(GenericPluginMetric[float]):
+    """
+    Base class for all class accuracy plugin metrics
+    """
+
+    def __init__(self, emit_at, mode, classes=None):
+        self._amca= AverageMeanClassAccuracy(classes=classes)
+        super().__init__(
+            self._amca, reset_at='never', emit_at=emit_at,
+            mode=mode)
+
+    def update(self, strategy):
+        self._amca.update(
+            strategy.mb_output,
+            strategy.mb_y,
+            self._get_task_labels(strategy))
+
+    def before_training_exp(self, *args, **kwargs):
+        self._amca.next_train_experience()
+        return super().before_training_exp(*args, **kwargs)
+
+    @staticmethod
+    def _get_task_labels(strategy: "SupervisedTemplate"):
+        if hasattr(strategy, 'mb_task_id'):
+            # Common situation
+            return strategy.mb_task_id
+
+        if hasattr(strategy.experience, "task_labels"):
+            task_labels = strategy.experience.task_labels
+        else:
+            task_labels = [0]  # add fixed task label if not available.
+
+        if len(task_labels) > 1:
+            # task labels defined for each pattern
+            # fall back to single task case
+            task_label = 0
+        else:
+            task_label = task_labels[0]
+        return task_label
+
+
+class StreamAMCA(AverageClassAccuracyPluginMetric):
+    """
+    At the end of the entire stream of test experiences, this plugin metric
+    reports the AMCA so far.
+
+    This metric only works at eval time.
+    """
+    def __init__(self):
+        """
+        Creates an instance of StreamAMCA metric
+        """
+        super().__init__(
+            emit_at='stream',
+            mode='eval')
+
+    def __str__(self):
+        return "Top1_AMCA_Stream"
+
+
+def amca_metrics(*, stream=True) \
+        -> List[PluginMetric]:
+    """
+    Helper method that can be used to obtain the desired set of
+    plugin metrics.
+
+    :param stream: If True, will return a metric able to log
+        the Average Mean Class Accuracy (AMCA) after testing on the stream of
+        experiences of the evaluation stream.
+
+    :return: A list of plugin metrics.
+    """
+    metrics = []
+
+    if stream:
+        metrics.append(StreamAMCA())
+
+    return metrics
+
+
+__all__ = [
+    'AverageMeanClassAccuracy',
+    'AverageClassAccuracyPluginMetric',
+    'StreamAMCA',
+    'amca_metrics'
+]

--- a/avalanche/evaluation/metrics/class_accuracy.py
+++ b/avalanche/evaluation/metrics/class_accuracy.py
@@ -39,7 +39,9 @@ class ClassAccuracy(Metric[Dict[int, Dict[int, float]]]):
     constructor parameters).
 
     The reset method will bring the metric to its initial state. By default,
-    this metric in its initial state will return an empty dictionary.
+    this metric in its initial state will return a
+    `{task_id -> {class_id -> accuracy}}` dictionary in which all accuracies are
+    set to 0.
     """
 
     def __init__(self, classes=None):
@@ -190,7 +192,6 @@ class ClassAccuracyPluginMetric(ExtendedGenericPluginMetric[float]):
     """
     Base class for all class accuracy plugin metrics
     """
-
     def __init__(self, reset_at, emit_at, mode, classes=None):
         self._class_accuracy = ClassAccuracy(classes=classes)
         super(ClassAccuracyPluginMetric, self).__init__(
@@ -235,7 +236,6 @@ class MinibatchClassAccuracy(ClassAccuracyPluginMetric):
     If a more coarse-grained logging is needed, consider using
     :class:`EpochClassAccuracy` instead.
     """
-
     def __init__(self):
         """
         Creates an instance of the MinibatchClassAccuracy metric.
@@ -259,7 +259,6 @@ class EpochClassAccuracy(ClassAccuracyPluginMetric):
     the overall number of patterns encountered in that epoch (separately
     for each class).
     """
-
     def __init__(self):
         """
         Creates an instance of the EpochClassAccuracy metric.

--- a/avalanche/evaluation/metrics/class_accuracy.py
+++ b/avalanche/evaluation/metrics/class_accuracy.py
@@ -9,17 +9,20 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 
-from typing import Dict, List, Set, Union
+from typing import Dict, List, Set, Union, TYPE_CHECKING
 from collections import defaultdict, OrderedDict
 
 import torch
 from torch import Tensor
-from avalanche.evaluation import Metric, GenericPluginMetric, PluginMetric
+from avalanche.evaluation import Metric, PluginMetric, \
+    ExtendedGenericPluginMetric
 from avalanche.evaluation.metrics import Mean
+
+if TYPE_CHECKING:
+    from avalanche.training.templates import SupervisedTemplate
 
 
 class ClassAccuracy(Metric[Dict[int, Dict[int, float]]]):
-    # TODO: unit tests
     """
     The Class Accuracy metric. This is a standalone metric
     used to compute more specific ones.
@@ -32,6 +35,8 @@ class ClassAccuracy(Metric[Dict[int, Dict[int, float]]]):
 
     Each time `result` is called, this metric emits the average accuracy
     for all classes seen and across all predictions made since the last `reset`.
+    The set of classes to be tracked can be reduced (please refer to the
+    constructor parameters).
 
     The reset method will bring the metric to its initial state. By default,
     this metric in its initial state will return an empty dictionary.
@@ -161,7 +166,7 @@ class ClassAccuracy(Metric[Dict[int, Dict[int, float]]]):
             running_class_accuracies[task_label] = OrderedDict()
             for class_id in sorted(task_dict.keys()):
                 running_class_accuracies[task_label][class_id] = \
-                    task_dict[class_id]
+                    task_dict[class_id].result()
 
         return running_class_accuracies
 
@@ -172,31 +177,55 @@ class ClassAccuracy(Metric[Dict[int, Dict[int, float]]]):
         :return: None.
         """
         self._class_accuracies = defaultdict(lambda: defaultdict(Mean))
+        for task_id, task_classes in self.classes.items():
+            for c in task_classes:
+                self._class_accuracies[task_id][c].reset()
 
     @staticmethod
     def _ensure_int_classes(classes_iterable):
         return set(int(c) for c in classes_iterable)
 
 
-class ClassAccuracyPluginMetric(GenericPluginMetric[float]):
+class ClassAccuracyPluginMetric(ExtendedGenericPluginMetric[float]):
     """
-    Base class for all class accuracies plugin metrics
+    Base class for all class accuracy plugin metrics
     """
 
     def __init__(self, reset_at, emit_at, mode, classes=None):
-        raise NotImplementedError()  # TODO: work in progress
-        self._class_accuracy = ClassAccuracy(classes)
+        self._class_accuracy = ClassAccuracy(classes=classes)
         super(ClassAccuracyPluginMetric, self).__init__(
             self._class_accuracy, reset_at=reset_at, emit_at=emit_at,
             mode=mode)
 
     def update(self, strategy):
-        self._class_accuracy.update(strategy.mb_output, strategy.mb_y)
+        self._class_accuracy.update(
+            strategy.mb_output,
+            strategy.mb_y,
+            self._get_task_labels(strategy))
+
+    @staticmethod
+    def _get_task_labels(strategy: "SupervisedTemplate"):
+        if hasattr(strategy, 'mb_task_id'):
+            # Common situation
+            return strategy.mb_task_id
+
+        if hasattr(strategy.experience, "task_labels"):
+            task_labels = strategy.experience.task_labels
+        else:
+            task_labels = [0]  # add fixed task label if not available.
+
+        if len(task_labels) > 1:
+            # task labels defined for each pattern
+            # fall back to single task case
+            task_label = 0
+        else:
+            task_label = task_labels[0]
+        return task_label
 
 
 class MinibatchClassAccuracy(ClassAccuracyPluginMetric):
     """
-    The minibatch plugin accuracy metric.
+    The minibatch plugin class accuracy metric.
     This metric only works at training time.
 
     This metric computes the average accuracy over patterns
@@ -204,16 +233,17 @@ class MinibatchClassAccuracy(ClassAccuracyPluginMetric):
     It reports the result after each iteration.
 
     If a more coarse-grained logging is needed, consider using
-    :class:`EpochAccuracy` instead.
+    :class:`EpochClassAccuracy` instead.
     """
 
     def __init__(self):
         """
-        Creates an instance of the MinibatchAccuracy metric.
+        Creates an instance of the MinibatchClassAccuracy metric.
         """
-        raise NotImplementedError()  # TODO: work in progress
-        super(MinibatchClassAccuracy, self).__init__(
-            reset_at='iteration', emit_at='iteration', mode='train')
+        super().__init__(
+            reset_at='iteration',
+            emit_at='iteration',
+            mode='train')
 
     def __str__(self):
         return "Top1_ClassAcc_MB"
@@ -221,21 +251,23 @@ class MinibatchClassAccuracy(ClassAccuracyPluginMetric):
 
 class EpochClassAccuracy(ClassAccuracyPluginMetric):
     """
-    The average accuracy over a single training epoch.
+    The average class accuracy over a single training epoch.
     This plugin metric only works at training time.
 
     The accuracy will be logged after each training epoch by computing
     the number of correctly predicted patterns during the epoch divided by
-    the overall number of patterns encountered in that epoch.
+    the overall number of patterns encountered in that epoch (separately
+    for each class).
     """
 
     def __init__(self):
         """
-        Creates an instance of the EpochAccuracy metric.
+        Creates an instance of the EpochClassAccuracy metric.
         """
-        raise NotImplementedError()  # TODO: work in progress
-        super(EpochClassAccuracy, self).__init__(
-            reset_at='epoch', emit_at='epoch', mode='train')
+        super().__init__(
+            reset_at='epoch',
+            emit_at='epoch',
+            mode='train')
 
     def __str__(self):
         return "Top1_ClassAcc_Epoch"
@@ -243,22 +275,23 @@ class EpochClassAccuracy(ClassAccuracyPluginMetric):
 
 class RunningEpochClassAccuracy(ClassAccuracyPluginMetric):
     """
-    The average accuracy across all minibatches up to the current
+    The average class accuracy across all minibatches up to the current
     epoch iteration.
     This plugin metric only works at training time.
 
     At each iteration, this metric logs the accuracy averaged over all patterns
-    seen so far in the current epoch.
+    seen so far in the current epoch (separately for each class).
     The metric resets its state after each training epoch.
     """
-    raise NotImplementedError()  # TODO: work in progress
     def __init__(self):
         """
-        Creates an instance of the RunningEpochAccuracy metric.
+        Creates an instance of the RunningEpochClassAccuracy metric.
         """
 
-        super(RunningEpochClassAccuracy, self).__init__(
-            reset_at='epoch', emit_at='iteration', mode='train')
+        super().__init__(
+            reset_at='epoch',
+            emit_at='iteration',
+            mode='train')
 
     def __str__(self):
         return "Top1_RunningClassAcc_Epoch"
@@ -267,16 +300,19 @@ class RunningEpochClassAccuracy(ClassAccuracyPluginMetric):
 class ExperienceClassAccuracy(ClassAccuracyPluginMetric):
     """
     At the end of each experience, this plugin metric reports
-    the average accuracy over all patterns seen in that experience.
+    the average accuracy over all patterns seen in that experience (separately
+    for each class).
+
     This metric only works at eval time.
     """
-    raise NotImplementedError()  # TODO: work in progress
     def __init__(self):
         """
-        Creates an instance of ExperienceAccuracy metric
+        Creates an instance of ExperienceClassAccuracy metric
         """
-        super(ExperienceClassAccuracy, self).__init__(
-            reset_at='experience', emit_at='experience', mode='eval')
+        super().__init__(
+            reset_at='experience',
+            emit_at='experience',
+            mode='eval')
 
     def __str__(self):
         return "Top1_ClassAcc_Exp"
@@ -285,16 +321,19 @@ class ExperienceClassAccuracy(ClassAccuracyPluginMetric):
 class StreamClassAccuracy(ClassAccuracyPluginMetric):
     """
     At the end of the entire stream of experiences, this plugin metric
-    reports the average accuracy over all patterns seen in all experiences.
+    reports the average accuracy over all patterns seen in all experiences
+    (separately for each class).
+
     This metric only works at eval time.
     """
-    raise NotImplementedError()  # TODO: work in progress
     def __init__(self):
         """
-        Creates an instance of StreamAccuracy metric
+        Creates an instance of StreamClassAccuracy metric
         """
-        super(StreamClassAccuracy, self).__init__(
-            reset_at='stream', emit_at='stream', mode='eval')
+        super().__init__(
+            reset_at='stream',
+            emit_at='stream',
+            mode='eval')
 
     def __str__(self):
         return "Top1_ClassAcc_Stream"
@@ -308,19 +347,19 @@ def class_accuracy_metrics(*, minibatch=False, epoch=False, epoch_running=False,
     plugin metrics.
 
     :param minibatch: If True, will return a metric able to log
-        the minibatch accuracy at training time.
+        the per-class minibatch accuracy at training time.
     :param epoch: If True, will return a metric able to log
-        the epoch accuracy at training time.
+        the per-class epoch accuracy at training time.
     :param epoch_running: If True, will return a metric able to log
-        the running epoch accuracy at training time.
+        the per-class  running epoch accuracy at training time.
     :param experience: If True, will return a metric able to log
-        the accuracy on each evaluation experience.
+        the per-class accuracy on each evaluation experience.
     :param stream: If True, will return a metric able to log
-        the accuracy averaged over the entire evaluation stream of experiences.
+        the per-class accuracy averaged over the entire evaluation stream of
+        experiences.
 
     :return: A list of plugin metrics.
     """
-    raise NotImplementedError()  # TODO: work in progress
     metrics = []
     if minibatch:
         metrics.append(MinibatchClassAccuracy())

--- a/avalanche/evaluation/metrics/class_accuracy.py
+++ b/avalanche/evaluation/metrics/class_accuracy.py
@@ -15,8 +15,7 @@ from collections import defaultdict, OrderedDict
 import torch
 from torch import Tensor
 from avalanche.evaluation import Metric, PluginMetric, \
-    ExtendedGenericPluginMetric
-from avalanche.evaluation.metric_definitions import ExtendedPluginMetricValue
+    _ExtendedGenericPluginMetric, _ExtendedPluginMetricValue
 from avalanche.evaluation.metric_utils import default_metric_name_template, \
     generic_get_metric_name
 from avalanche.evaluation.metrics import Mean
@@ -201,7 +200,7 @@ class ClassAccuracy(Metric[Dict[int, Dict[int, float]]]):
         return set(int(c) for c in classes_iterable)
 
 
-class ClassAccuracyPluginMetric(ExtendedGenericPluginMetric):
+class ClassAccuracyPluginMetric(_ExtendedGenericPluginMetric):
     """
     Base class for all class accuracy plugin metrics
     """
@@ -219,7 +218,7 @@ class ClassAccuracyPluginMetric(ExtendedGenericPluginMetric):
             strategy.mb_task_id)
 
     def result(self, strategy: "SupervisedTemplate") -> \
-            List[ExtendedPluginMetricValue]:
+            List[_ExtendedPluginMetricValue]:
         metric_values = []
         task_accuracies = self._class_accuracy.result()
         phase_name = "train" if strategy.is_training else 'eval'
@@ -229,7 +228,7 @@ class ClassAccuracyPluginMetric(ExtendedGenericPluginMetric):
         for task_id, task_classes in task_accuracies.items():
             for class_id, class_accuracy in task_classes.items():
                 metric_values.append(
-                    ExtendedPluginMetricValue(
+                    _ExtendedPluginMetricValue(
                         metric_name=str(self),
                         metric_value=class_accuracy,
                         phase_name=phase_name,
@@ -242,7 +241,7 @@ class ClassAccuracyPluginMetric(ExtendedGenericPluginMetric):
 
         return metric_values
 
-    def metric_value_name(self, m_value: ExtendedPluginMetricValue) -> str:
+    def metric_value_name(self, m_value: _ExtendedPluginMetricValue) -> str:
         m_value_values = vars(m_value)
         add_exp = self._emit_at == "experience"
         if not add_exp:

--- a/avalanche/evaluation/metrics/class_accuracy.py
+++ b/avalanche/evaluation/metrics/class_accuracy.py
@@ -160,7 +160,8 @@ class ClassAccuracy(Metric[Dict[int, Dict[int, float]]]):
             task_dict = self._class_accuracies[task_label]
             running_class_accuracies[task_label] = OrderedDict()
             for class_id in sorted(task_dict.keys()):
-                running_class_accuracies[class_id] = task_dict[class_id]
+                running_class_accuracies[task_label][class_id] = \
+                    task_dict[class_id]
 
         return running_class_accuracies
 

--- a/avalanche/evaluation/metrics/class_accuracy.py
+++ b/avalanche/evaluation/metrics/class_accuracy.py
@@ -1,0 +1,350 @@
+################################################################################
+# Copyright (c) 2021 ContinualAI.                                              #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 26-05-2022                                                             #
+# Author(s): Eli Verwimp, Lorenzo Pellegrini                                   #
+# E-mail: contact@continualai.org                                              #
+# Website: www.continualai.org                                                 #
+################################################################################
+
+from typing import Dict, List, Set, Union
+from collections import defaultdict, OrderedDict
+
+import torch
+from torch import Tensor
+from avalanche.evaluation import Metric, GenericPluginMetric, PluginMetric
+from avalanche.evaluation.metrics import Mean
+
+
+class ClassAccuracy(Metric[Dict[int, Dict[int, float]]]):
+    # TODO: unit tests
+    """
+    The Class Accuracy metric. This is a standalone metric
+    used to compute more specific ones.
+
+    Instances of this metric keeps the running average accuracy
+    over multiple <prediction, target> pairs of Tensors,
+    provided incrementally.
+    The "prediction" and "target" tensors may contain plain labels or
+    one-hot/logit vectors.
+
+    Each time `result` is called, this metric emits the average accuracy
+    for all classes seen and across all predictions made since the last `reset`.
+
+    The reset method will bring the metric to its initial state. By default,
+    this metric in its initial state will return an empty dictionary.
+    """
+
+    def __init__(self, classes=None):
+        """
+        Creates an instance of the standalone Accuracy metric.
+
+        By default, this metric in its initial state will return an empty
+        dictionary. The metric can be updated by using the `update` method
+        while the running accuracies can be retrieved using the `result` method.
+
+        By using the `classes` parameter, one can restrict the list of classes
+        to be tracked and in addition can immediately create plots for
+        yet-to-be-seen classes.
+
+        :param classes: The classes to keep track of. If None (default), all
+            classes seen are tracked. Otherwise, it can be a dict of classes
+            to be tracked (as "task-id" -> "list of class ids") or, if running
+            a task-free benchmark (with only task "0"), a simple list of class
+            ids. By passing this parameter, the plot of each class is
+            created immediately (with a default value of 0.0) and plots
+            will be aligned across all classes. In addition, this can be used to
+            restrict the classes for which the accuracy should be logged.
+        """
+
+        self.classes: Dict[int, Set[int]] = defaultdict(set)
+        """
+        The list of tracked classes.
+        """
+
+        self.dynamic_classes = False
+        """
+        If True, newly encountered classes will be tracked.
+        """
+
+        self._class_accuracies: Dict[int, Dict[int, Mean]] = \
+            defaultdict(lambda: defaultdict(Mean))
+        """
+        A dictionary "task_id -> {class_id -> Mean}".
+        """
+
+        if classes is not None:
+            if isinstance(classes, dict):
+                # Task-id -> classes dict
+                self.classes = {
+                    task_id: self._ensure_int_classes(class_list)
+                    for task_id, class_list in classes.items()}
+            else:
+                # Assume is a plain iterable
+                self.classes = {0: self._ensure_int_classes(classes)}
+        else:
+            self.dynamic_classes = True
+
+    @torch.no_grad()
+    def update(self,
+               predicted_y: Tensor,
+               true_y: Tensor,
+               task_labels: Union[int, Tensor]) -> None:
+        """
+        Update the running accuracy given the true and predicted labels for each
+        class.
+
+        :param predicted_y: The model prediction. Both labels and logit vectors
+            are supported.
+        :param true_y: The ground truth. Both labels and one-hot vectors
+            are supported.
+        :param task_labels: the int task label associated to the current
+            experience or the task labels vector showing the task label
+            for each pattern.
+        :return: None.
+        """
+        if len(true_y) != len(predicted_y):
+            raise ValueError('Size mismatch for true_y and predicted_y tensors')
+
+        if isinstance(task_labels, Tensor) and len(task_labels) != len(true_y):
+            raise ValueError("Size mismatch for true_y and task_labels tensors")
+
+        if not isinstance(task_labels, (int, Tensor)):
+            raise ValueError(
+                f"Task label type: {type(task_labels)}, "
+                f"expected int or Tensor"
+            )
+
+        if isinstance(task_labels, int):
+            task_labels = [task_labels] * len(true_y)
+
+        true_y = torch.as_tensor(true_y)
+        predicted_y = torch.as_tensor(predicted_y)
+
+        # Check if logits or labels
+        if len(predicted_y.shape) > 1:
+            # Logits -> transform to labels
+            predicted_y = torch.max(predicted_y, 1)[1]
+
+        if len(true_y.shape) > 1:
+            # Logits -> transform to labels
+            true_y = torch.max(true_y, 1)[1]
+
+        for pred, true, t in zip(predicted_y, true_y, task_labels):
+            t = int(t)
+
+            if self.dynamic_classes:
+                self.classes[t].add(int(true))
+            else:
+                if t not in self.classes:
+                    continue
+                if int(true) not in self.classes[t]:
+                    continue
+
+            true_positives = (pred == true).float().item()  # 1.0 or 0.0
+            self._class_accuracies[t][int(true)].update(true_positives, 1)
+
+    def result(self) -> Dict[int, Dict[int, float]]:
+        """
+        Retrieves the running accuracy for each class.
+
+        Calling this method will not change the internal state of the metric.
+
+        :return: A dictionary `{task_id -> {class_id -> running_accuracy}}`. The
+            running accuracy of each class is a float value between 0 and 1.
+        """
+        running_class_accuracies = OrderedDict()
+        for task_label in sorted(self._class_accuracies.keys()):
+            task_dict = self._class_accuracies[task_label]
+            running_class_accuracies[task_label] = OrderedDict()
+            for class_id in sorted(task_dict.keys()):
+                running_class_accuracies[class_id] = task_dict[class_id]
+
+        return running_class_accuracies
+
+    def reset(self) -> None:
+        """
+        Resets the metric.
+
+        :return: None.
+        """
+        self._class_accuracies = defaultdict(lambda: defaultdict(Mean))
+
+    @staticmethod
+    def _ensure_int_classes(classes_iterable):
+        return set(int(c) for c in classes_iterable)
+
+
+class ClassAccuracyPluginMetric(GenericPluginMetric[float]):
+    """
+    Base class for all class accuracies plugin metrics
+    """
+
+    def __init__(self, reset_at, emit_at, mode, classes=None):
+        raise NotImplementedError()  # TODO: work in progress
+        self._class_accuracy = ClassAccuracy(classes)
+        super(ClassAccuracyPluginMetric, self).__init__(
+            self._class_accuracy, reset_at=reset_at, emit_at=emit_at,
+            mode=mode)
+
+    def update(self, strategy):
+        self._class_accuracy.update(strategy.mb_output, strategy.mb_y)
+
+
+class MinibatchClassAccuracy(ClassAccuracyPluginMetric):
+    """
+    The minibatch plugin accuracy metric.
+    This metric only works at training time.
+
+    This metric computes the average accuracy over patterns
+    from a single minibatch.
+    It reports the result after each iteration.
+
+    If a more coarse-grained logging is needed, consider using
+    :class:`EpochAccuracy` instead.
+    """
+
+    def __init__(self):
+        """
+        Creates an instance of the MinibatchAccuracy metric.
+        """
+        raise NotImplementedError()  # TODO: work in progress
+        super(MinibatchClassAccuracy, self).__init__(
+            reset_at='iteration', emit_at='iteration', mode='train')
+
+    def __str__(self):
+        return "Top1_ClassAcc_MB"
+
+
+class EpochClassAccuracy(ClassAccuracyPluginMetric):
+    """
+    The average accuracy over a single training epoch.
+    This plugin metric only works at training time.
+
+    The accuracy will be logged after each training epoch by computing
+    the number of correctly predicted patterns during the epoch divided by
+    the overall number of patterns encountered in that epoch.
+    """
+
+    def __init__(self):
+        """
+        Creates an instance of the EpochAccuracy metric.
+        """
+        raise NotImplementedError()  # TODO: work in progress
+        super(EpochClassAccuracy, self).__init__(
+            reset_at='epoch', emit_at='epoch', mode='train')
+
+    def __str__(self):
+        return "Top1_ClassAcc_Epoch"
+
+
+class RunningEpochClassAccuracy(ClassAccuracyPluginMetric):
+    """
+    The average accuracy across all minibatches up to the current
+    epoch iteration.
+    This plugin metric only works at training time.
+
+    At each iteration, this metric logs the accuracy averaged over all patterns
+    seen so far in the current epoch.
+    The metric resets its state after each training epoch.
+    """
+    raise NotImplementedError()  # TODO: work in progress
+    def __init__(self):
+        """
+        Creates an instance of the RunningEpochAccuracy metric.
+        """
+
+        super(RunningEpochClassAccuracy, self).__init__(
+            reset_at='epoch', emit_at='iteration', mode='train')
+
+    def __str__(self):
+        return "Top1_RunningClassAcc_Epoch"
+
+
+class ExperienceClassAccuracy(ClassAccuracyPluginMetric):
+    """
+    At the end of each experience, this plugin metric reports
+    the average accuracy over all patterns seen in that experience.
+    This metric only works at eval time.
+    """
+    raise NotImplementedError()  # TODO: work in progress
+    def __init__(self):
+        """
+        Creates an instance of ExperienceAccuracy metric
+        """
+        super(ExperienceClassAccuracy, self).__init__(
+            reset_at='experience', emit_at='experience', mode='eval')
+
+    def __str__(self):
+        return "Top1_ClassAcc_Exp"
+
+
+class StreamClassAccuracy(ClassAccuracyPluginMetric):
+    """
+    At the end of the entire stream of experiences, this plugin metric
+    reports the average accuracy over all patterns seen in all experiences.
+    This metric only works at eval time.
+    """
+    raise NotImplementedError()  # TODO: work in progress
+    def __init__(self):
+        """
+        Creates an instance of StreamAccuracy metric
+        """
+        super(StreamClassAccuracy, self).__init__(
+            reset_at='stream', emit_at='stream', mode='eval')
+
+    def __str__(self):
+        return "Top1_ClassAcc_Stream"
+
+
+def class_accuracy_metrics(*, minibatch=False, epoch=False, epoch_running=False,
+                           experience=False, stream=False) \
+        -> List[PluginMetric]:
+    """
+    Helper method that can be used to obtain the desired set of
+    plugin metrics.
+
+    :param minibatch: If True, will return a metric able to log
+        the minibatch accuracy at training time.
+    :param epoch: If True, will return a metric able to log
+        the epoch accuracy at training time.
+    :param epoch_running: If True, will return a metric able to log
+        the running epoch accuracy at training time.
+    :param experience: If True, will return a metric able to log
+        the accuracy on each evaluation experience.
+    :param stream: If True, will return a metric able to log
+        the accuracy averaged over the entire evaluation stream of experiences.
+
+    :return: A list of plugin metrics.
+    """
+    raise NotImplementedError()  # TODO: work in progress
+    metrics = []
+    if minibatch:
+        metrics.append(MinibatchClassAccuracy())
+
+    if epoch:
+        metrics.append(EpochClassAccuracy())
+
+    if epoch_running:
+        metrics.append(RunningEpochClassAccuracy())
+
+    if experience:
+        metrics.append(ExperienceClassAccuracy())
+
+    if stream:
+        metrics.append(StreamClassAccuracy())
+
+    return metrics
+
+
+__all__ = [
+    'ClassAccuracy',
+    'MinibatchClassAccuracy',
+    'EpochClassAccuracy',
+    'RunningEpochClassAccuracy',
+    'ExperienceClassAccuracy',
+    'StreamClassAccuracy',
+    'class_accuracy_metrics'
+]

--- a/examples/eval_plugin.py
+++ b/examples/eval_plugin.py
@@ -39,10 +39,11 @@ from avalanche.evaluation.metrics import (
     disk_usage_metrics,
     MAC_metrics,
     bwt_metrics,
-    forward_transfer_metrics,
+    forward_transfer_metrics, class_accuracy_metrics, amca_metrics,
 )
 from avalanche.models import SimpleMLP
-from avalanche.logging import InteractiveLogger, TextLogger, CSVLogger
+from avalanche.logging import InteractiveLogger, TextLogger, CSVLogger, \
+    TensorboardLogger
 from avalanche.training.plugins import EvaluationPlugin
 from avalanche.training.supervised import Naive
 
@@ -104,6 +105,8 @@ def main(args):
 
     csv_logger = CSVLogger()
 
+    tb_logger = TensorboardLogger()
+
     eval_plugin = EvaluationPlugin(
         accuracy_metrics(
             minibatch=True,
@@ -119,6 +122,12 @@ def main(args):
             experience=True,
             stream=True,
         ),
+        class_accuracy_metrics(
+            epoch=True,
+            stream=True,
+            classes=list(range(scenario.n_classes))
+        ),
+        amca_metrics(),
         forgetting_metrics(experience=True, stream=True),
         bwt_metrics(experience=True, stream=True),
         forward_transfer_metrics(experience=True, stream=True),
@@ -151,7 +160,7 @@ def main(args):
             minibatch=True, epoch=True, experience=True, stream=True
         ),
         MAC_metrics(minibatch=True, epoch=True, experience=True),
-        loggers=[interactive_logger, text_logger, csv_logger],
+        loggers=[interactive_logger, text_logger, csv_logger, tb_logger],
         collect_all=True,
     )  # collect all metrics (set to True by default)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -496,7 +496,7 @@ class GeneralMetricTests(unittest.TestCase):
             # Should call next_experience first
             metric.update(my_out, my_y, 0)
 
-        metric.next_experience('test')
+        metric.set_stream('test')
         metric.update(my_out, my_y, 0)
         self.assertDictEqual(metric.result(), {
             'test': {
@@ -516,7 +516,7 @@ class GeneralMetricTests(unittest.TestCase):
             # Again, should call next_experience first, even after reset
             metric.update(my_out, my_y, 0)
 
-        metric.next_experience('test')
+        metric.set_stream('test')
         metric.update(my_out, my_y, 0)
         self.assertDictEqual(metric.result(), {
             'test': {
@@ -524,7 +524,7 @@ class GeneralMetricTests(unittest.TestCase):
             }
         })
 
-        metric.next_experience('train')
+        metric.set_stream('train')
         self.assertDictEqual(metric.result(), {
             'test': {
                 0: my_amca
@@ -541,17 +541,19 @@ class GeneralMetricTests(unittest.TestCase):
                 1: my_amca2
             }
         })
-        metric.next_experience('test')
+
+        metric.set_stream('test')
         self.assertDictEqual(metric.result(), {
             'test': {
-                0: my_amca / 2
+                0: my_amca
             },
             'train': {
                 1: my_amca2
             }
         })
 
-        metric.next_experience('train')
+        metric.finish_phase()
+        metric.set_stream('train')
         self.assertDictEqual(metric.result(), {
             'test': {
                 0: my_amca / 2


### PR DESCRIPTION
This PR adds support for the Class Accuracy and Average Mean Class Accuracy metrics. This extends the #679 PR.

- Class Accuracy computes the per-class accuracy. It will do so separately for each task.
- The AMCA metric will compute its value for each `stream/task` and it will work only on the eval phase. In addition, it will automatically ignore periodic evaluations (this behavior can be customized).

Creating the AMCA metric has been quite rough, as this is the first stateful metric (others are computed and reset within the scope of a phase or less). @AntonioCarta @AndreaCossu can you give this a look? I introduced an extended metric mechanism and generalized the existing "value naming" procedure.
