### PR TITLE
Outdated imports of `training.strategies` fixed in docstring and gitbook

### DIFF
--- a/avalanche/training/__init__.py
+++ b/avalanche/training/__init__.py
@@ -2,7 +2,7 @@
 The :py:mod:`training` module provides a generic continual learning training
 class (:py:class:`BaseTemplate`) and implementations of the most common
 CL strategies. These are provided either as standalone strategies in
-:py:mod:`training.strategies` or as plugins (:py:mod:`training.plugins`) that
+:py:mod:`training.supervised` or as plugins (:py:mod:`training.plugins`) that
 can be easily combined with your own strategy.
 """
 from .supervised import *

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -41,7 +41,7 @@ from avalanche.benchmarks.classic import PermutedMNIST
 from avalanche.training.plugins import EvaluationPlugin
 from avalanche.evaluation.metrics import accuracy_metrics
 from avalanche.models import SimpleMLP
-from avalanche.training.strategies import Naive
+from avalanche.training.supervised import Naive
 
 # Config
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
Hi guys, this is an interesting project you are working on. I've just started going through the code samples and stumbled upon some imports of `avalanche.training.strategies` which doesn't exist in the repo.