### PR TITLE
FIX MultiTaskDecorator

### DIFF
--- a/avalanche/models/dynamic_modules.py
+++ b/avalanche/models/dynamic_modules.py
@@ -90,8 +90,8 @@ class MultiTaskModule(DynamicModule):
 
     def __init__(self):
         super().__init__()
-        self.known_train_tasks_labels = set()
         self.max_class_label = 0
+        self.known_train_tasks_labels = set()
         """ Set of task labels encountered up to now. """
 
     def adaptation(self, experience: CLExperience = None):
@@ -111,9 +111,9 @@ class MultiTaskModule(DynamicModule):
         :param experience: the current experience.
         :return:
         """
-        dataset = experience.dataset
+        curr_classes = experience.classes_in_this_experience
         self.max_class_label = max(
-            self.max_class_label, max(dataset.targets) + 1
+            self.max_class_label, max(curr_classes) + 1
         )
         if self.training:
             self.train_adaptation(experience)
@@ -125,11 +125,7 @@ class MultiTaskModule(DynamicModule):
 
     def train_adaptation(self, experience: CLExperience = None):
         """Update known task labels."""
-        dataset = experience.dataset
-        task_labels = dataset.targets_task_labels
-        if isinstance(task_labels, ConstantSequence):
-            # task label is unique. Don't check duplicates.
-            task_labels = [task_labels[0]]
+        task_labels = experience.task_labels
         self.known_train_tasks_labels = self.known_train_tasks_labels.union(
             set(task_labels)
         )

--- a/avalanche/models/helper_method.py
+++ b/avalanche/models/helper_method.py
@@ -27,6 +27,9 @@ class MultiTaskDecorator(MultiTaskModule):
         :param classifier_name: attribute name of the existing classification
                                 layer inside the module
         """
+        for m in model.modules():
+            assert not isinstance(m, MultiTaskModule)
+
         self.__dict__["_initialized"] = False
         super().__init__()
         self.model = model
@@ -70,6 +73,20 @@ class MultiTaskDecorator(MultiTaskModule):
         out = self.model(x)
         return getattr(self, self.classifier_name)(
             out.view(out.size(0), -1), task_labels=task_label
+        )
+
+    def forward_all_tasks(self, x: torch.Tensor):
+        """compute the output given the input `x` and task label.
+        By default, it considers only tasks seen at training time.
+
+        :param x:
+        :return: all the possible outputs are returned as a dictionary
+            with task IDs as keys and the output of the corresponding
+            task as output.
+        """
+        out = self.model(x)
+        return getattr(self, self.classifier_name)(
+            out.view(out.size(0), -1), task_labels=None
         )
 
     def __getattr__(self, name):


### PR DESCRIPTION
Speed up MultiTaskDecorator when `task_labels=None` by avoiding the recomputation of the hidden layers.