### PR TITLE
Packaged csv files for mini imagenet

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include extra_dependencies.txt
+include avalanche/benchmarks/datasets/mini_imagenet/csv_files/*.csv

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setuptools.setup(
         'setuptools<=59.5.0'
     ],
     extras_require=get_extra_requires('extra_dependencies.txt',
-                                      add_all=True)
+                                      add_all=True),
+    include_package_data=True
 )
 


### PR DESCRIPTION
The next release should now include `csv_files` folder needed to build `MiniImagenetDataset`. 