### PR TITLE
Add `class_ids_from_zero_in_each_exp`  to classic benchmarks

### DIFF
--- a/avalanche/benchmarks/classic/ccifar10.py
+++ b/avalanche/benchmarks/classic/ccifar10.py
@@ -48,6 +48,7 @@ def SplitCIFAR10(
     seed: Optional[int] = None,
     fixed_class_order: Optional[Sequence[int]] = None,
     shuffle: bool = True,
+    class_ids_from_zero_in_each_exp: bool = False,
     train_transform: Optional[Any] = _default_cifar10_train_transform,
     eval_transform: Optional[Any] = _default_cifar10_eval_transform,
     dataset_root: Union[str, Path] = None
@@ -97,6 +98,10 @@ def SplitCIFAR10(
         Defaults to None.
     :param shuffle: If true, the class order in the incremental experiences is
         randomly shuffled. Default to True.
+    :param class_ids_from_zero_in_each_exp: If True, original class IDs
+        will be mapped to range [0, n_classes_in_exp) for each experience.
+        Defaults to False. Mutually exclusive with the
+        ``class_ids_from_zero_from_first_exp`` parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -125,7 +130,7 @@ def SplitCIFAR10(
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
         per_exp_classes={0: 5} if first_exp_with_half_classes else None,
-        class_ids_from_zero_in_each_exp=False,
+        class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/ccifar100.py
+++ b/avalanche/benchmarks/classic/ccifar100.py
@@ -53,6 +53,7 @@ def SplitCIFAR100(
     seed: Optional[int] = None,
     fixed_class_order: Optional[Sequence[int]] = None,
     shuffle: bool = True,
+    class_ids_from_zero_in_each_exp: bool = False,
     train_transform: Optional[Any] = _default_cifar100_train_transform,
     eval_transform: Optional[Any] = _default_cifar100_eval_transform,
     dataset_root: Union[str, Path] = None
@@ -102,6 +103,10 @@ def SplitCIFAR100(
         Defaults to None.
     :param shuffle: If true, the class order in the incremental experiences is
         randomly shuffled. Default to True.
+    :param class_ids_from_zero_in_each_exp: If True, original class IDs
+        will be mapped to range [0, n_classes_in_exp) for each experience.
+        Defaults to False. Mutually exclusive with the
+        ``class_ids_from_zero_from_first_exp`` parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -130,7 +135,7 @@ def SplitCIFAR100(
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
         per_exp_classes={0: 50} if first_exp_with_half_classes else None,
-        class_ids_from_zero_in_each_exp=False,
+        class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/ccub200.py
+++ b/avalanche/benchmarks/classic/ccub200.py
@@ -50,6 +50,7 @@ def SplitCUB200(
     seed=0,
     fixed_class_order=None,
     shuffle=False,
+    class_ids_from_zero_in_each_exp: bool = False,
     train_transform: Optional[Any] = _default_train_transform,
     eval_transform: Optional[Any] = _default_eval_transform,
     dataset_root: Union[str, Path] = None
@@ -94,6 +95,10 @@ def SplitCUB200(
         Defaults to None.
     :param shuffle: If true, the class order in the incremental experiences is
         randomly shuffled. Default to false.
+    :param class_ids_from_zero_in_each_exp: If True, original class IDs
+        will be mapped to range [0, n_classes_in_exp) for each experience.
+        Defaults to False. Mutually exclusive with the
+        ``class_ids_from_zero_from_first_exp`` parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -130,6 +135,7 @@ def SplitCUB200(
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
         one_dataset_per_exp=True,
+        class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/cfashion_mnist.py
+++ b/avalanche/benchmarks/classic/cfashion_mnist.py
@@ -39,6 +39,7 @@ def SplitFMNIST(
     seed: Optional[int] = None,
     fixed_class_order: Optional[Sequence[int]] = None,
     shuffle: bool = True,
+    class_ids_from_zero_in_each_exp: bool = False,
     train_transform: Optional[Any] = _default_fmnist_train_transform,
     eval_transform: Optional[Any] = _default_fmnist_eval_transform,
     dataset_root: Union[str, Path] = None
@@ -91,6 +92,10 @@ def SplitFMNIST(
         Defaults to None.
     :param shuffle: If true, the class order in the incremental experiences is
         randomly shuffled. Default to True.
+    :param class_ids_from_zero_in_each_exp: If True, original class IDs
+        will be mapped to range [0, n_classes_in_exp) for each experience.
+        Defaults to False. Mutually exclusive with the
+        ``class_ids_from_zero_from_first_exp`` parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -120,6 +125,7 @@ def SplitFMNIST(
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
         per_exp_classes={0: 5} if first_batch_with_half_classes else None,
+        class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/cimagenet.py
+++ b/avalanche/benchmarks/classic/cimagenet.py
@@ -51,6 +51,7 @@ def SplitImageNet(
     seed=0,
     fixed_class_order=None,
     shuffle: bool = True,
+    class_ids_from_zero_in_each_exp: bool = False,
     train_transform: Optional[Any] = _default_train_transform,
     eval_transform: Optional[Any] = _default_eval_transform
 ):
@@ -103,6 +104,10 @@ def SplitImageNet(
         Defaults to None.
     :param shuffle: If true, the class order in the incremental experiences is
         randomly shuffled. Default to True.
+    :param class_ids_from_zero_in_each_exp: If True, original class IDs
+        will be mapped to range [0, n_classes_in_exp) for each experience.
+        Defaults to False. Mutually exclusive with the
+        ``class_ids_from_zero_from_first_exp`` parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -130,7 +135,7 @@ def SplitImageNet(
         seed=seed,
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
-        class_ids_from_zero_in_each_exp=False,
+        class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/cinaturalist.py
+++ b/avalanche/benchmarks/classic/cinaturalist.py
@@ -51,6 +51,7 @@ def SplitInaturalist(
     return_task_id=False,
     download=False,
     seed=0,
+    class_ids_from_zero_in_each_exp: bool = False,
     train_transform: Optional[Any] = _default_train_transform,
     eval_transform: Optional[Any] = _default_eval_transform,
     dataset_root: Union[str, Path] = None
@@ -105,6 +106,10 @@ def SplitInaturalist(
         experience. If False, all experiences will have a task ID of 0.
     :param seed: A valid int used to initialize the random number generator.
         Can be None.
+    :param class_ids_from_zero_in_each_exp: If True, original class IDs
+        will be mapped to range [0, n_classes_in_exp) for each experience.
+        Defaults to False. Mutually exclusive with the
+        ``class_ids_from_zero_from_first_exp`` parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -152,7 +157,7 @@ def SplitInaturalist(
         n_experiences=len(super_categories),
         task_labels=return_task_id,
         seed=seed,
-        class_ids_from_zero_in_each_exp=False,
+        class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/cmnist.py
+++ b/avalanche/benchmarks/classic/cmnist.py
@@ -75,6 +75,7 @@ def SplitMNIST(
     seed: Optional[int] = None,
     fixed_class_order: Optional[Sequence[int]] = None,
     shuffle: bool = True,
+    class_ids_from_zero_in_each_exp: bool = False,
     train_transform: Optional[Any] = _default_mnist_train_transform,
     eval_transform: Optional[Any] = _default_mnist_eval_transform,
     dataset_root: Union[str, Path] = None
@@ -118,6 +119,10 @@ def SplitMNIST(
         Defaults to None.
     :param shuffle: If true, the class order in the incremental experiences is
         randomly shuffled. Default to True.
+    :param class_ids_from_zero_in_each_exp: If True, original class IDs
+        will be mapped to range [0, n_classes_in_exp) for each experience.
+        Defaults to False. Mutually exclusive with the
+        ``class_ids_from_zero_from_first_exp`` parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -146,7 +151,7 @@ def SplitMNIST(
         seed=seed,
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
-        class_ids_from_zero_in_each_exp=False,
+        class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/comniglot.py
+++ b/avalanche/benchmarks/classic/comniglot.py
@@ -73,6 +73,7 @@ def SplitOmniglot(
     seed: Optional[int] = None,
     fixed_class_order: Optional[Sequence[int]] = None,
     shuffle: bool = True,
+    class_ids_from_zero_in_each_exp: bool = False,
     train_transform: Optional[Any] = _default_omniglot_train_transform,
     eval_transform: Optional[Any] = _default_omniglot_eval_transform,
     dataset_root: Union[str, Path] = None
@@ -118,6 +119,10 @@ def SplitOmniglot(
         Defaults to None.
     :param shuffle: If true, the class order in the incremental experiences is
         randomly shuffled. Default to True.
+    :param class_ids_from_zero_in_each_exp: If True, original class IDs
+        will be mapped to range [0, n_classes_in_exp) for each experience.
+        Defaults to False. Mutually exclusive with the
+        ``class_ids_from_zero_from_first_exp`` parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -145,7 +150,7 @@ def SplitOmniglot(
         seed=seed,
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
-        class_ids_from_zero_in_each_exp=False,
+        class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/ctiny_imagenet.py
+++ b/avalanche/benchmarks/classic/ctiny_imagenet.py
@@ -47,6 +47,7 @@ def SplitTinyImageNet(
     seed=0,
     fixed_class_order=None,
     shuffle: bool = True,
+    class_ids_from_zero_in_each_exp: bool = False,
     train_transform: Optional[Any] = _default_train_transform,
     eval_transform: Optional[Any] = _default_eval_transform,
     dataset_root: Union[str, Path] = None
@@ -88,6 +89,10 @@ def SplitTinyImageNet(
         Defaults to None.
     :param shuffle: If true, the class order in the incremental experiences is
         randomly shuffled. Default to True.
+    :param class_ids_from_zero_in_each_exp: If True, original class IDs
+        will be mapped to range [0, n_classes_in_exp) for each experience.
+        Defaults to False. Mutually exclusive with the
+        ``class_ids_from_zero_from_first_exp`` parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -117,7 +122,7 @@ def SplitTinyImageNet(
         seed=seed,
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
-        class_ids_from_zero_in_each_exp=False,
+        class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/examples/lamaml_cifar100.py
+++ b/examples/lamaml_cifar100.py
@@ -32,7 +32,7 @@ def main(args):
 
     # --- SCENARIO CREATION
     scenario = SplitTinyImageNet(n_experiences=20, return_task_id=True,
-                             class_ids_from_zero_in_each_exp=True)
+                                 class_ids_from_zero_in_each_exp=True)
     config = {"scenario": "SplitCIFAR100"}
 
     # MODEL CREATION

--- a/examples/lamaml_cifar100.py
+++ b/examples/lamaml_cifar100.py
@@ -8,9 +8,9 @@ import torch
 import wandb
 from torch.nn import CrossEntropyLoss
 import torch.optim.lr_scheduler
-from avalanche.benchmarks.classic import SplitCIFAR100
+from avalanche.benchmarks.classic import SplitCIFAR100, SplitTinyImageNet
 from avalanche.models import MTSimpleCNN
-from avalanche.training.supervised import LaMAML
+from avalanche.training.supervised.lamaml import LaMAML
 from avalanche.training.plugins import ReplayPlugin
 from avalanche.training.storage_policy import ReservoirSamplingBuffer
 from avalanche.evaluation.metrics import (
@@ -31,7 +31,8 @@ def main(args):
     )
 
     # --- SCENARIO CREATION
-    scenario = SplitCIFAR100(n_experiences=20, return_task_id=True)
+    scenario = SplitTinyImageNet(n_experiences=20, return_task_id=True,
+                             class_ids_from_zero_in_each_exp=True)
     config = {"scenario": "SplitCIFAR100"}
 
     # MODEL CREATION


### PR DESCRIPTION
Minor updates: this PR adds the optional parameter `class_ids_from_zero_in_each_exp` to some classific benchmarks set to False by default. 