### PR TITLE
Add repr and str special methods to DataAttribute

### DIFF
--- a/avalanche/benchmarks/utils/data_attribute.py
+++ b/avalanche/benchmarks/utils/data_attribute.py
@@ -57,6 +57,12 @@ class DataAttribute:
     def __len__(self):
         return len(self.data)
 
+    def __repr__(self):
+        return str(self.data[:])
+
+    def __str__(self):
+        return str(self.data[:])
+
     @property
     def data(self):
         return self._data


### PR DESCRIPTION
Since `attribute.data[:]` returns a list, both special methods  return `str(self.data[:])`