### PR TITLE
huggingface and dictionary datasets support

### DIFF
--- a/avalanche/benchmarks/datasets/torchvision_wrapper.py
+++ b/avalanche/benchmarks/datasets/torchvision_wrapper.py
@@ -37,7 +37,7 @@ from torchvision.datasets import VOCSegmentation as torchVOCSegmentation
 from torchvision.datasets import Cityscapes as torchCityscapes
 from torchvision.datasets import SBDataset as torchSBDataset
 from torchvision.datasets import USPS as torchUSPS
-from torchvision.datasets import Kinetics400 as torchKinetics400
+from torchvision.datasets import Kinetics as torchKinetics
 from torchvision.datasets import HMDB51 as torchKHMDB51
 from torchvision.datasets import UCF101 as torchUCF101
 from torchvision.datasets import CelebA as torchCelebA
@@ -147,8 +147,8 @@ def USPS(*args, **kwargs):
     return torchUSPS(*args, **kwargs)
 
 
-def Kinetics400(*args, **kwargs):
-    return torchKinetics400(*args, **kwargs)
+def Kinetics(*args, **kwargs):
+    return torchKinetics(*args, **kwargs)
 
 
 def HMDB51(*args, **kwargs):
@@ -195,7 +195,7 @@ __all__ = [
     "Cityscapes",
     "SBDataset",
     "USPS",
-    "Kinetics400",
+    "Kinetics",
     "HMDB51",
     "UCF101",
     "CelebA",

--- a/avalanche/benchmarks/generators/benchmark_generators.py
+++ b/avalanche/benchmarks/generators/benchmark_generators.py
@@ -222,13 +222,13 @@ def nc_benchmark(
     train_dataset = make_classification_dataset(
         train_dataset,
         transform_groups=transform_groups,
-        initial_transform_group="train"
+        initial_transform_group="train",
     )
 
     test_dataset = make_classification_dataset(
         test_dataset,
         transform_groups=transform_groups,
-        initial_transform_group="eval"
+        initial_transform_group="eval",
     )
 
     return NCScenario(
@@ -344,13 +344,13 @@ def ni_benchmark(
     seq_train_dataset = make_classification_dataset(
         seq_train_dataset,
         transform_groups=transform_groups,
-        initial_transform_group="train"
+        initial_transform_group="train",
     )
 
     seq_test_dataset = make_classification_dataset(
         seq_test_dataset,
         transform_groups=transform_groups,
-        initial_transform_group="eval"
+        initial_transform_group="eval",
     )
 
     return NIScenario(

--- a/avalanche/benchmarks/utils/classification_dataset.py
+++ b/avalanche/benchmarks/utils/classification_dataset.py
@@ -440,9 +440,7 @@ def classification_subset(
         ):
             return dataset.subset(indices)
 
-    targets = _init_targets(
-        dataset, targets, check_shape=False
-    )
+    targets = _init_targets(dataset, targets, check_shape=False)
     task_labels = _init_task_labels(dataset, task_labels, check_shape=False)
     transform_gs = _init_transform_groups(
         transform_groups,
@@ -667,7 +665,7 @@ def concat_classification_datasets(
                 initial_transform_group=initial_transform_group,
                 task_labels=task_labels,
                 targets=targets,
-                collate_fn=collate_fn
+                collate_fn=collate_fn,
             )
         dds.append(dd)
     if (

--- a/avalanche/benchmarks/utils/data.py
+++ b/avalanche/benchmarks/utils/data.py
@@ -90,14 +90,16 @@ class AvalancheDataset(FlatData):
             applied by this dataset.
         :param transform_groups: Avalanche transform groups.
         """
-        if isinstance(datasets, TorchDataset) or \
-                isinstance(datasets, AvalancheDataset):
+        if isinstance(datasets, TorchDataset) or isinstance(
+            datasets, AvalancheDataset
+        ):
             warnings.warn(
                 "AvalancheDataset constructor has been changed. "
                 "Please check the documentation for the correct usage. You can"
                 " use `avalanche.benchmarks.utils.make_classification_dataset"
                 "if you need the old behavior.",
-                DeprecationWarning)
+                DeprecationWarning,
+            )
 
         # NOTES on implementation:
         # - raw datasets operations are implemented by _FlatData
@@ -254,7 +256,9 @@ class AvalancheDataset(FlatData):
         return element
 
     def __getitem__(self, idx) -> Union[T_co, Sequence[T_co]]:
-        elem = self._getitem_recursive_call(idx, self._transform_groups.current_group)
+        elem = self._getitem_recursive_call(
+            idx, self._transform_groups.current_group
+        )
         for da in self._data_attributes.values():
             if da.use_in_getitem:
                 if isinstance(elem, dict):
@@ -430,7 +434,4 @@ def _print_transforms(self):
     self._print_nonfrozen_transforms()
 
 
-__all__ = [
-    "AvalancheDataset",
-    "make_avalanche_dataset"
-]
+__all__ = ["AvalancheDataset", "make_avalanche_dataset"]

--- a/avalanche/benchmarks/utils/data.py
+++ b/avalanche/benchmarks/utils/data.py
@@ -254,14 +254,16 @@ class AvalancheDataset(FlatData):
         return element
 
     def __getitem__(self, idx) -> Union[T_co, Sequence[T_co]]:
-        elem = list(
-            self._getitem_recursive_call(
-                idx, self._transform_groups.current_group
-            )
-        )
+        elem = self._getitem_recursive_call(idx, self._transform_groups.current_group)
         for da in self._data_attributes.values():
             if da.use_in_getitem:
-                elem.append(da[idx])
+                if isinstance(elem, dict):
+                    elem[da.name] = da[idx]
+                elif isinstance(elem, tuple):
+                    elem = list(elem)
+                    elem.append(da[idx])
+                else:
+                    elem.append(da[idx])
         return elem
 
     def train(self):

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -76,7 +76,8 @@ class TaskBalancedDataLoader:
             raise ValueError(
                 "collate_mbatches is not needed anymore and it has been "
                 "deprecated. Data loaders will use the collate function"
-                "`data.collate_fn`.")
+                "`data.collate_fn`."
+            )
 
         self.data = data
         self.dataloaders: Dict[int, DataLoader] = dict()
@@ -139,7 +140,8 @@ class GroupBalancedDataLoader:
             raise ValueError(
                 "collate_mbatches is not needed anymore and it has been "
                 "deprecated. Data loaders will use the collate function"
-                "`data.collate_fn`.")
+                "`data.collate_fn`."
+            )
 
         self.datasets = datasets
         self.batch_sizes = []
@@ -187,7 +189,10 @@ class GroupBalancedDataLoader:
         samplers = []
         for dataset, mb_size in zip(self.datasets, self.batch_sizes):
             data_l, data_l_sampler = _make_data_loader(
-                dataset, self.distributed_sampling, self.loader_kwargs, mb_size,
+                dataset,
+                self.distributed_sampling,
+                self.loader_kwargs,
+                mb_size,
             )
 
             dataloaders.append(data_l)
@@ -352,7 +357,8 @@ class ReplayDataLoader:
             raise ValueError(
                 "collate_mbatches is not needed anymore and it has been "
                 "deprecated. Data loaders will use the collate function"
-                "`data.collate_fn`.")
+                "`data.collate_fn`."
+            )
 
         self.data = data
         self.memory = memory

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -53,7 +53,6 @@ class TaskBalancedDataLoader:
         self,
         data: make_classification_dataset,
         oversample_small_tasks: bool = False,
-        collate_mbatches=_default_collate_mbatches_fn,
         **kwargs
     ):
         """Task-balanced data loader for Avalanche's datasets.
@@ -70,21 +69,24 @@ class TaskBalancedDataLoader:
         :param data: an instance of `AvalancheDataset`.
         :param oversample_small_tasks: whether smaller tasks should be
             oversampled to match the largest one.
-        :param collate_mbatches: function that given a sequence of mini-batches
-            (one for each task) combines them into a single mini-batch. Used to
-            combine the mini-batches obtained separately from each task.
         :param kwargs: data loader arguments used to instantiate the loader for
             each task separately. See pytorch :class:`DataLoader`.
         """
+        if "collate_mbatches" in kwargs:
+            raise ValueError(
+                "collate_mbatches is not needed anymore and it has been "
+                "deprecated. Data loaders will use the collate function"
+                "`data.collate_fn`.")
+
         self.data = data
         self.dataloaders: Dict[int, DataLoader] = dict()
         self.oversample_small_tasks = oversample_small_tasks
-        self.collate_mbatches = collate_mbatches
 
         # split data by task.
         task_datasets = []
-        for task_label in self.data.task_set:
-            tdata = self.data.task_set[task_label]
+        for task_label in self.data.targets_task_labels.uniques:
+            tidxs = self.data.targets_task_labels.val_to_idx[task_label]
+            tdata = self.data.subset(tidxs)
             task_datasets.append(tdata)
 
         # the iteration logic is implemented by GroupBalancedDataLoader.
@@ -94,7 +96,6 @@ class TaskBalancedDataLoader:
             del kwargs["data"]
         # needed if they are passed as positional arguments
         kwargs["oversample_small_groups"] = oversample_small_tasks
-        kwargs["collate_mbatches"] = collate_mbatches
         self._dl = GroupBalancedDataLoader(datasets=task_datasets, **kwargs)
 
     def __iter__(self):
@@ -112,7 +113,6 @@ class GroupBalancedDataLoader:
         self,
         datasets: Sequence[make_classification_dataset],
         oversample_small_groups: bool = False,
-        collate_mbatches=_default_collate_mbatches_fn,
         batch_size: int = 32,
         distributed_sampling: bool = True,
         **kwargs
@@ -130,20 +130,30 @@ class GroupBalancedDataLoader:
         :param datasets: an instance of `AvalancheDataset`.
         :param oversample_small_groups: whether smaller groups should be
             oversampled to match the largest one.
-        :param collate_mbatches: function that given a sequence of mini-batches
-            (one for each task) combines them into a single mini-batch. Used to
-            combine the mini-batches obtained separately from each task.
         :param batch_size: the size of the batch. It must be greater than or
             equal to the number of groups.
         :param kwargs: data loader arguments used to instantiate the loader for
             each group separately. See pytorch :class:`DataLoader`.
         """
+        if "collate_mbatches" in kwargs:
+            raise ValueError(
+                "collate_mbatches is not needed anymore and it has been "
+                "deprecated. Data loaders will use the collate function"
+                "`data.collate_fn`.")
+
         self.datasets = datasets
         self.batch_sizes = []
         self.oversample_small_groups = oversample_small_groups
-        self.collate_mbatches = collate_mbatches
         self.distributed_sampling = distributed_sampling
         self.loader_kwargs = kwargs
+        if "collate_fn" in kwargs:
+            self.collate_fn = kwargs["collate_fn"]
+        else:
+            self.collate_fn = self.datasets[0].collate_fn
+
+        # collate is done after we have all batches
+        # so we set an empty collate for the internal dataloaders
+        self.loader_kwargs["collate_fn"] = lambda x: x
 
         # check if batch_size is larger than or equal to the number of datasets
         assert batch_size >= len(datasets)
@@ -177,7 +187,7 @@ class GroupBalancedDataLoader:
         samplers = []
         for dataset, mb_size in zip(self.datasets, self.batch_sizes):
             data_l, data_l_sampler = _make_data_loader(
-                dataset, self.distributed_sampling, self.loader_kwargs, mb_size
+                dataset, self.distributed_sampling, self.loader_kwargs, mb_size,
             )
 
             dataloaders.append(data_l)
@@ -217,8 +227,8 @@ class GroupBalancedDataLoader:
                         samplers[tid] = None
                         removed_dataloaders_idxs.append(tid)
                         continue
-                mb_curr.append(batch)
-            yield self.collate_mbatches(mb_curr)
+                mb_curr.extend(batch)
+            yield self.collate_fn(mb_curr)
 
             # clear empty data-loaders
             for tid in reversed(removed_dataloaders_idxs):
@@ -306,7 +316,6 @@ class ReplayDataLoader:
         data: make_classification_dataset,
         memory: make_classification_dataset = None,
         oversample_small_tasks: bool = False,
-        collate_mbatches=_default_collate_mbatches_fn,
         batch_size: int = 32,
         batch_size_mem: int = 32,
         task_balanced_dataloader: bool = False,
@@ -328,9 +337,6 @@ class ReplayDataLoader:
         :param memory: AvalancheDataset.
         :param oversample_small_tasks: whether smaller tasks should be
             oversampled to match the largest one.
-        :param collate_mbatches: function that given a sequence of mini-batches
-            (one for each task) combines them into a single mini-batch. Used to
-            combine the mini-batches obtained separately from each task.
         :param batch_size: the size of the data batch. It must be greater
             than or equal to the number of tasks.
         :param batch_size_mem: the size of the memory batch. If
@@ -342,19 +348,32 @@ class ReplayDataLoader:
         :param kwargs: data loader arguments used to instantiate the loader for
             each task separately. See pytorch :class:`DataLoader`.
         """
+        if "collate_mbatches" in kwargs:
+            raise ValueError(
+                "collate_mbatches is not needed anymore and it has been "
+                "deprecated. Data loaders will use the collate function"
+                "`data.collate_fn`.")
 
         self.data = data
         self.memory = memory
         self.oversample_small_tasks = oversample_small_tasks
         self.task_balanced_dataloader = task_balanced_dataloader
-        self.collate_mbatches = collate_mbatches
         self.data_batch_sizes: Union[int, Dict[int, int]] = dict()
         self.memory_batch_sizes: Union[int, Dict[int, int]] = dict()
         self.distributed_sampling = distributed_sampling
         self.loader_kwargs = kwargs
 
-        num_keys = len(self.memory.task_set)
+        if "collate_fn" in kwargs:
+            self.collate_fn = kwargs["collate_fn"]
+        else:
+            self.collate_fn = self.data.collate_fn
+
+        # collate is done after we have all batches
+        # so we set an empty collate for the internal dataloaders
+        self.loader_kwargs["collate_fn"] = lambda x: x
+
         if task_balanced_dataloader:
+            num_keys = len(self.memory.targets_task_labels.uniques)
             assert batch_size_mem >= num_keys, (
                 "Batch size must be greator or equal "
                 "to the number of tasks in the memory "
@@ -367,6 +386,7 @@ class ReplayDataLoader:
 
         # Create dataloader for memory items
         if task_balanced_dataloader:
+            num_keys = len(self.memory.targets_task_labels.uniques)
             single_group_batch_size = batch_size_mem // num_keys
             remaining_example = batch_size_mem % num_keys
         else:
@@ -481,7 +501,7 @@ class ReplayDataLoader:
                     mb_curr,
                 )
 
-                yield self.collate_mbatches(mb_curr)
+                yield self.collate_fn(mb_curr)
         except StopIteration:
             return
 
@@ -518,7 +538,7 @@ class ReplayDataLoader:
                     del iter_dataloaders[t]
                     del iter_samplers[t]
                     continue
-            mb_curr.append(tbatch)
+            mb_curr.extend(tbatch)
 
     def _create_loaders_and_samplers(self, data, batch_sizes):
         loaders = dict()

--- a/avalanche/benchmarks/utils/deprecated.py
+++ b/avalanche/benchmarks/utils/deprecated.py
@@ -2,37 +2,45 @@ import warnings
 from typing import Sequence, Callable, Any, Dict, Tuple, Union, List, Collection
 
 from avalanche.benchmarks.utils import SupportedDataset
-from avalanche.benchmarks.utils.classification_dataset import XTransform, \
-    YTransform, TTargetType, classification_subset, \
-    make_tensor_classification_dataset, concat_classification_datasets
+from avalanche.benchmarks.utils.classification_dataset import (
+    XTransform,
+    YTransform,
+    TTargetType,
+    classification_subset,
+    make_tensor_classification_dataset,
+    concat_classification_datasets,
+)
 
 
 def AvalanceDataset():
     warnings.warn(
         "AvalancheDataset has been deprecated and it will be removed in 0.4. "
         "Use `avalanche.benchmarks.ClassificationDataset` instead.`",
-        DeprecationWarning)
+        DeprecationWarning,
+    )
 
 
 def AvalancheSubset(
-        dataset: SupportedDataset,
-        indices: Sequence[int] = None,
-        *,
-        class_mapping: Sequence[int] = None,
-        transform: Callable[[Any], Any] = None,
-        target_transform: Callable[[int], int] = None,
-        transform_groups: Dict[str, Tuple[XTransform, YTransform]] = None,
-        initial_transform_group: str = None,
-        task_labels: Union[int, Sequence[int]] = None,
-        targets: Sequence[TTargetType] = None,
-        collate_fn: Callable[[List], Any] = None
+    dataset: SupportedDataset,
+    indices: Sequence[int] = None,
+    *,
+    class_mapping: Sequence[int] = None,
+    transform: Callable[[Any], Any] = None,
+    target_transform: Callable[[int], int] = None,
+    transform_groups: Dict[str, Tuple[XTransform, YTransform]] = None,
+    initial_transform_group: str = None,
+    task_labels: Union[int, Sequence[int]] = None,
+    targets: Sequence[TTargetType] = None,
+    collate_fn: Callable[[List], Any] = None,
 ):
     warnings.warn(
         "AvalancheDataset has been deprecated and it will be removed in 0.4. "
         "Please use `AvalancheDataset` `subset` method to create subsets.`",
-        DeprecationWarning)
+        DeprecationWarning,
+    )
     return classification_subset(
-        dataset, indices,
+        dataset,
+        indices,
         class_mapping=class_mapping,
         transform=transform,
         target_transform=target_transform,
@@ -40,25 +48,26 @@ def AvalancheSubset(
         initial_transform_group=initial_transform_group,
         task_labels=task_labels,
         targets=targets,
-        collate_fn=collate_fn
-        )
+        collate_fn=collate_fn,
+    )
 
 
 def AvalancheTensorDataset(
-        *dataset_tensors: Sequence,
-        transform: Callable[[Any], Any] = None,
-        target_transform: Callable[[int], int] = None,
-        transform_groups: Dict[str, Tuple[XTransform, YTransform]] = None,
-        initial_transform_group: str = "train",
-        task_labels: Union[int, Sequence[int]] = None,
-        targets: Union[Sequence[TTargetType], int] = None,
-        collate_fn: Callable[[List], Any] = None,
+    *dataset_tensors: Sequence,
+    transform: Callable[[Any], Any] = None,
+    target_transform: Callable[[int], int] = None,
+    transform_groups: Dict[str, Tuple[XTransform, YTransform]] = None,
+    initial_transform_group: str = "train",
+    task_labels: Union[int, Sequence[int]] = None,
+    targets: Union[Sequence[TTargetType], int] = None,
+    collate_fn: Callable[[List], Any] = None,
 ):
     warnings.warn(
         "AvalancheDataset has been deprecated and it will be removed in 0.4. "
         "Please use `avalanche.benchmarks.make_tensor_classification_dataset` "
         "instead.`",
-        DeprecationWarning)
+        DeprecationWarning,
+    )
     return make_tensor_classification_dataset(
         dataset_tensors,
         transform=transform,
@@ -67,27 +76,29 @@ def AvalancheTensorDataset(
         initial_transform_group=initial_transform_group,
         task_labels=task_labels,
         targets=targets,
-        collate_fn=collate_fn
+        collate_fn=collate_fn,
     )
 
 
 def AvalancheConcatDataset(
-        datasets: Collection[SupportedDataset],
-        *,
-        transform: Callable[[Any], Any] = None,
-        target_transform: Callable[[int], int] = None,
-        transform_groups: Dict[str, Tuple[XTransform, YTransform]] = None,
-        initial_transform_group: str = None,
-        task_labels: Union[int, Sequence[int], Sequence[Sequence[int]]] = None,
-        targets: Union[
-            Sequence[TTargetType], Sequence[Sequence[TTargetType]]
-        ] = None,
-        collate_fn: Callable[[List], Any] = None,
+    datasets: Collection[SupportedDataset],
+    *,
+    transform: Callable[[Any], Any] = None,
+    target_transform: Callable[[int], int] = None,
+    transform_groups: Dict[str, Tuple[XTransform, YTransform]] = None,
+    initial_transform_group: str = None,
+    task_labels: Union[int, Sequence[int], Sequence[Sequence[int]]] = None,
+    targets: Union[
+        Sequence[TTargetType], Sequence[Sequence[TTargetType]]
+    ] = None,
+    collate_fn: Callable[[List], Any] = None,
 ):
     warnings.warn(
         "AvalancheDataset has been deprecated and it will be removed in 0.4. "
         "Please use `AvalancheDataset` `concat` method to concatenate "
-        "datasets.`", DeprecationWarning)
+        "datasets.`",
+        DeprecationWarning,
+    )
     return concat_classification_datasets(
         datasets,
         transform=transform,
@@ -96,12 +107,12 @@ def AvalancheConcatDataset(
         initial_transform_group=initial_transform_group,
         task_labels=task_labels,
         targets=targets,
-        collate_fn=collate_fn
+        collate_fn=collate_fn,
     )
 
 
 __all__ = [
     "AvalancheSubset",
     "AvalancheTensorDataset",
-    "AvalancheConcatDataset"
+    "AvalancheConcatDataset",
 ]

--- a/avalanche/benchmarks/utils/flat_data.py
+++ b/avalanche/benchmarks/utils/flat_data.py
@@ -81,8 +81,7 @@ class FlatData(IDataset):
             else:
                 self_indices = self._get_indices()
                 new_indices = [self_indices[x] for x in indices]
-            return self.__class__(datasets=self._datasets,
-                                  indices=new_indices)
+            return self.__class__(datasets=self._datasets, indices=new_indices)
         return self.__class__(datasets=[self], indices=indices)
 
     def concat(self, other: "FlatData") -> "FlatData":
@@ -311,7 +310,7 @@ def _flatdata_print(dataset, indent=0):
         print(
             "\t" * indent
             + f"{dataset.__class__.__name__} (len={len(dataset)},subset={ss},"
-              f"cat={cc},cf={cf})"
+            f"cat={cc},cf={cf})"
         )
         for dd in dataset._datasets:
             _flatdata_print(dd, indent + 1)

--- a/avalanche/benchmarks/utils/flat_data.py
+++ b/avalanche/benchmarks/utils/flat_data.py
@@ -171,7 +171,7 @@ class FlatData(IDataset):
                 idx = idx
             else:
                 idx = idx - self._cumulative_sizes[dataset_idx - 1]
-        return dataset_idx, idx
+        return dataset_idx, int(idx)
 
     def __getitem__(self, idx):
         dataset_idx, idx = self._get_idx(idx)

--- a/avalanche/benchmarks/utils/transform_groups.py
+++ b/avalanche/benchmarks/utils/transform_groups.py
@@ -139,6 +139,13 @@ class EmptyTransformGroups(DefaultTransformGroups):
         super().__init__({})
         self.transform_groups = defaultdict(lambda: None)
 
+    def __call__(self, elem, group_name=None):
+        """Apply current transformation group to element."""
+        if self.transform_groups[group_name] is None:
+            return elem
+        else:
+            return super().__call__(elem, group_name=group_name)
+
 
 def _normalize_transform(transforms):
     """Normalize transform to MultiParamTransform."""

--- a/avalanche/training/plugins/lwf.py
+++ b/avalanche/training/plugins/lwf.py
@@ -25,7 +25,8 @@ class LwFPlugin(SupervisedPlugin):
         """
 
         strategy.loss += self.lwf(
-            strategy.mb_x, strategy.mb_output, strategy.model)
+            strategy.mb_x, strategy.mb_output, strategy.model
+        )
 
     def after_training_exp(self, strategy, **kwargs):
         """

--- a/avalanche/training/regularization.py
+++ b/avalanche/training/regularization.py
@@ -126,7 +126,4 @@ class LearningWithoutForgetting(RegularizationMethod):
                 ].union(pc)
 
 
-__all__ = [
-    "RegularizationMethod",
-    "LearningWithoutForgetting"
-]
+__all__ = ["RegularizationMethod", "LearningWithoutForgetting"]

--- a/avalanche/training/storage_policy.py
+++ b/avalanche/training/storage_policy.py
@@ -11,7 +11,7 @@ from torch.utils.data import DataLoader
 from avalanche.benchmarks.utils import (
     make_classification_dataset,
     classification_subset,
-    concat_classification_datasets,
+    AvalancheDataset,
 )
 from avalanche.models import FeatureExtractorBackbone
 from ..benchmarks.utils.utils import concat_datasets
@@ -34,7 +34,7 @@ class ExemplarsBuffer(ABC):
         """
         self.max_size = max_size
         """ Maximum size of the buffer. """
-        self._buffer: make_classification_dataset = concat_datasets([])
+        self._buffer: AvalancheDataset = concat_datasets([])
 
     @property
     def buffer(self) -> make_classification_dataset:
@@ -100,7 +100,7 @@ class ReservoirSamplingBuffer(ExemplarsBuffer):
         sorted_weights, sorted_idxs = cat_weights.sort(descending=True)
 
         buffer_idxs = sorted_idxs[: self.max_size]
-        self.buffer = classification_subset(cat_data, buffer_idxs)
+        self.buffer = cat_data.subset(buffer_idxs)
         self._buffer_weights = sorted_weights[: self.max_size]
 
     def resize(self, strategy, new_size):

--- a/examples/lamaml_cifar100.py
+++ b/examples/lamaml_cifar100.py
@@ -31,8 +31,11 @@ def main(args):
     )
 
     # --- SCENARIO CREATION
-    scenario = SplitTinyImageNet(n_experiences=20, return_task_id=True,
-                                 class_ids_from_zero_in_each_exp=True)
+    scenario = SplitTinyImageNet(
+        n_experiences=20,
+        return_task_id=True,
+        class_ids_from_zero_in_each_exp=True,
+    )
     config = {"scenario": "SplitCIFAR100"}
 
     # MODEL CREATION

--- a/examples/nlp.py
+++ b/examples/nlp.py
@@ -53,7 +53,7 @@ class CustomDataCollatorSeq2SeqBeta:
         # method won't pad them and needs them of the
         # same length to return tensors.
         if labels is not None:
-            max_label_length = max(len(l) for l in labels)
+            max_label_length = max(len(lab) for lab in labels)
             if self.pad_to_multiple_of is not None:
                 max_label_length = (
                     (max_label_length + self.pad_to_multiple_of - 1)

--- a/examples/nlp.py
+++ b/examples/nlp.py
@@ -1,0 +1,235 @@
+"""
+Example adapting Avalanche to use Huggingface models and datasets.
+To run this example you need huggingface datasets and transformers libraries.
+"""
+from avalanche.benchmarks.utils import DataAttribute, ConstantSequence
+from avalanche.training.plugins import ReplayPlugin
+
+from dataclasses import dataclass
+
+from transformers import PreTrainedTokenizerBase
+from typing import Optional, Union, Any
+
+from transformers.utils import PaddingStrategy
+import torch
+
+import avalanche
+import torch.nn
+
+from avalanche.benchmarks import CLScenario, CLStream, CLExperience
+from avalanche.evaluation.metrics import accuracy_metrics
+import avalanche.training.templates.base
+from avalanche.benchmarks.utils import AvalancheDataset
+from transformers import AutoTokenizer
+from transformers import T5ForConditionalGeneration
+from datasets import load_dataset
+import numpy as np
+
+
+@dataclass
+class CustomDataCollatorSeq2SeqBeta:
+    """The collator is a standard huggingface collate.
+    No need to change anything here.
+    """
+
+    tokenizer: PreTrainedTokenizerBase
+    model: Optional[Any] = None
+    padding: Union[bool, str, PaddingStrategy] = True
+    max_length: Optional[int] = None
+    pad_to_multiple_of: Optional[int] = None
+    label_pad_token_id: int = -100
+    return_tensors: str = "pt"
+
+    def __call__(self, features, return_tensors=None):
+
+        if return_tensors is None:
+            return_tensors = self.return_tensors
+        labels = (
+            [feature["labels"] for feature in features]
+            if "labels" in features[0].keys()
+            else None
+        )
+        # We have to pad the labels before calling `tokenizer.pad` as this
+        # method won't pad them and needs them of the
+        # same length to return tensors.
+        if labels is not None:
+            max_label_length = max(len(l) for l in labels)
+            if self.pad_to_multiple_of is not None:
+                max_label_length = (
+                    (max_label_length + self.pad_to_multiple_of - 1)
+                    // self.pad_to_multiple_of
+                    * self.pad_to_multiple_of
+                )
+
+            padding_side = self.tokenizer.padding_side
+            for feature in features:
+                remainder = [self.label_pad_token_id] * (
+                    max_label_length - len(feature["labels"])
+                )
+                if isinstance(feature["labels"], list):
+                    feature["labels"] = (
+                        feature["labels"] + remainder
+                        if padding_side == "right"
+                        else remainder + feature["labels"]
+                    )
+                elif padding_side == "right":
+                    feature["labels"] = np.concatenate(
+                        [feature["labels"], remainder]
+                    ).astype(np.int64)
+                else:
+                    feature["labels"] = np.concatenate(
+                        [remainder, feature["labels"]]
+                    ).astype(np.int64)
+
+        features = self.tokenizer.pad(
+            features,
+            padding=self.padding,
+            max_length=self.max_length,
+            pad_to_multiple_of=self.pad_to_multiple_of,
+            return_tensors=return_tensors,
+        )
+
+        # prepare decoder_input_ids
+        if (
+            labels is not None
+            and self.model is not None
+            and hasattr(self.model, "prepare_decoder_input_ids_from_labels")
+        ):
+            decoder_input_ids = (
+                self.model.prepare_decoder_input_ids_from_labels(
+                    labels=features["labels"]
+                )
+            )
+            features["decoder_input_ids"] = decoder_input_ids
+
+        return features
+
+
+class HGNaive(avalanche.training.Naive):
+    """There are only a couple of modifications needed to
+    use huggingface:
+    - we add a bunch of attributes corresponding to the batch items,
+        redefining mb_x and mb_y too
+    - _unpack_minibatch sends the dictionary values to the GPU device
+    - forward and criterion are adapted for machine translation tasks.
+    """
+
+    @property
+    def mb_attention_mask(self):
+        return self.mbatch["attention_mask"]
+
+    @property
+    def mb_x(self):
+        """Current mini-batch input."""
+        return self.mbatch["input_ids"]
+
+    @property
+    def mb_y(self):
+        """Current mini-batch target."""
+        return self.mbatch["labels"]
+
+    @property
+    def mb_decoder_in_ids(self):
+        """Current mini-batch target."""
+        return self.mbatch["decoder_input_ids"]
+
+    @property
+    def mb_token_type_ids(self):
+        return self.mbatch[3]
+
+    def _unpack_minibatch(self):
+        """HuggingFace minibatches are dictionaries of tensors.
+        Move tensors to the current device."""
+        for k in self.mbatch.keys():
+            self.mbatch[k] = self.mbatch[k].to(self.device)
+
+    def forward(self):
+        out = self.model(
+            input_ids=self.mb_x,
+            attention_mask=self.mb_attention_mask,
+            labels=self.mb_y,
+        )
+        return out.logits
+
+    def criterion(self):
+        mb_output = self.mb_output.view(-1, self.mb_output.size(-1))
+        ll = self._criterion(mb_output, self.mb_y.view(-1))
+        return ll
+
+
+def main():
+    tokenizer = AutoTokenizer.from_pretrained("t5-small", padding=True)
+    tokenizer.save_pretrained(
+        r"D:\MLDATA\NLP\hf_tokenizers"
+    )  # CHANGE DIRECTORY
+
+    prefix = "<2en>"
+    source_lang = "de"
+    target_lang = "en"
+    remote_data = load_dataset("news_commentary", "de-en")
+
+    def preprocess_function(examples):
+        inputs = [
+            prefix + example[source_lang] for example in examples["translation"]
+        ]
+        targets = [example[target_lang] for example in examples["translation"]]
+        model_inputs = tokenizer(inputs, max_length=128, truncation=True)
+        with tokenizer.as_target_tokenizer():
+            labels = tokenizer(targets, max_length=128, truncation=True)
+        model_inputs["labels"] = labels["input_ids"]
+        return model_inputs
+
+    remote_data = remote_data.map(preprocess_function, batched=True)
+    model = T5ForConditionalGeneration.from_pretrained("t5-small")
+    remote_data = remote_data.remove_columns(["id", "translation"])
+    remote_data.set_format(type="torch")
+    data_collator = CustomDataCollatorSeq2SeqBeta(
+        tokenizer=tokenizer, model=model
+    )
+
+    train_exps = []
+    for i in range(0, 2):
+        # We use very small experiences only to showcase the library.
+        # Adapt this to your own benchmark
+        exp_data = remote_data["train"].select(range(30 * i, 30 * (i + 1)))
+        tl = DataAttribute(
+            ConstantSequence(i, len(exp_data)), "targets_task_labels"
+        )
+
+        exp = CLExperience()
+        exp.dataset = AvalancheDataset(
+            [exp_data], data_attributes=[tl], collate_fn=data_collator
+        )
+        train_exps.append(exp)
+
+    benchmark = CLScenario(
+        [
+            CLStream("train", train_exps),
+            # add more stream here (validation, test, out-of-domain, ...)
+        ]
+    )
+    eval_plugin = avalanche.training.plugins.EvaluationPlugin(
+        avalanche.evaluation.metrics.loss_metrics(
+            epoch=True, experience=True, stream=True
+        ),
+        loggers=[avalanche.logging.InteractiveLogger()],
+        strict_checks=False,
+    )
+    plugins = [ReplayPlugin(mem_size=200)]
+    optimizer = torch.optim.Adam(model.parameters(), lr=2)
+    strategy = HGNaive(
+        model,
+        optimizer,
+        torch.nn.CrossEntropyLoss(ignore_index=-100),
+        evaluator=eval_plugin,
+        train_epochs=1,
+        train_mb_size=10,
+        plugins=plugins,
+    )
+    for experience in benchmark.train_stream:
+        strategy.train(experience, collate_fn=data_collator)
+        strategy.eval(benchmark.train_stream)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/scenarios/test_classification_scenario.py
+++ b/tests/benchmarks/scenarios/test_classification_scenario.py
@@ -40,7 +40,8 @@ class GenericCLScenarioTests(unittest.TestCase):
         test_t = torch.randint(0, 5, (200,))
         test_exps.append(
             make_tensor_classification_dataset(
-                test_x, test_y, task_labels=test_t)
+                test_x, test_y, task_labels=test_t
+            )
         )
 
         other_stream_exps = []
@@ -49,7 +50,8 @@ class GenericCLScenarioTests(unittest.TestCase):
         other_t = torch.randint(0, 5, (200,))
         other_stream_exps.append(
             make_tensor_classification_dataset(
-                other_x, other_y, task_labels=other_t)
+                other_x, other_y, task_labels=other_t
+            )
         )
 
         benchmark_instance = dataset_benchmark(
@@ -121,7 +123,8 @@ class GenericCLScenarioTests(unittest.TestCase):
         test_t = torch.randint(0, 5, (200,))
         test_exps.append(
             make_tensor_classification_dataset(
-                test_x, test_y, task_labels=test_t)
+                test_x, test_y, task_labels=test_t
+            )
         )
 
         other_stream_exps = []
@@ -130,7 +133,8 @@ class GenericCLScenarioTests(unittest.TestCase):
         other_t = torch.randint(0, 5, (200,))
         other_stream_exps.append(
             make_tensor_classification_dataset(
-                other_x, other_y, task_labels=other_t)
+                other_x, other_y, task_labels=other_t
+            )
         )
 
         benchmark_instance = dataset_benchmark(
@@ -541,7 +545,8 @@ class GenericCLScenarioTests(unittest.TestCase):
         test_t = torch.randint(0, 5, (200,))
         test_exps.append(
             make_tensor_classification_dataset(
-                test_x, test_y, task_labels=test_t)
+                test_x, test_y, task_labels=test_t
+            )
         )
 
         other_stream_exps = []
@@ -550,7 +555,8 @@ class GenericCLScenarioTests(unittest.TestCase):
         other_t = torch.randint(0, 5, (200,))
         other_stream_exps.append(
             make_tensor_classification_dataset(
-                other_x, other_y, task_labels=other_t)
+                other_x, other_y, task_labels=other_t
+            )
         )
 
         return train_exps, test_exps, other_stream_exps

--- a/tests/evaluation/test_image_samples.py
+++ b/tests/evaluation/test_image_samples.py
@@ -37,7 +37,8 @@ class ImageSamplesTests(unittest.TestCase):
         for mb in DataLoader(curr_exp.dataset, batch_size=32):
             break
         curr_dataset = make_tensor_classification_dataset(
-            *mb[:2], targets=mb[1])
+            *mb[:2], targets=mb[1]
+        )
 
         strategy_mock = MagicMock(
             eval_mb_size=32, experience=curr_exp, adapted_dataset=curr_dataset

--- a/tests/test_high_level_generators.py
+++ b/tests/test_high_level_generators.py
@@ -525,7 +525,8 @@ class HighLevelGeneratorTests(unittest.TestCase):
                 test_x = torch.zeros(50, *pattern_shape)
                 test_y = torch.zeros(50, dtype=torch.long)
                 experience_test = make_tensor_classification_dataset(
-                    test_x, test_y)
+                    test_x, test_y
+                )
 
                 def train_gen():
                     # Lazy generator of the training stream

--- a/tests/test_nc_sit_scenario.py
+++ b/tests/test_nc_sit_scenario.py
@@ -20,7 +20,6 @@ from tests.unit_tests_utils import DummyImageDataset
 
 
 class SITTests(unittest.TestCase):
-
     def test_sit_single_dataset(self):
         mnist_train = MNIST(
             root=default_dataset_location("mnist"),

--- a/tests/training/test_dictionary_mbatches.py
+++ b/tests/training/test_dictionary_mbatches.py
@@ -1,0 +1,109 @@
+import unittest
+
+from avalanche.benchmarks.utils import DataAttribute, ConstantSequence
+from avalanche.models import SimpleMLP
+from avalanche.training.plugins import ReplayPlugin
+
+import torch
+
+import avalanche
+import torch.nn
+
+from avalanche.benchmarks import CLScenario, CLStream, CLExperience
+from avalanche.evaluation.metrics import accuracy_metrics
+import avalanche.training.templates.base
+from avalanche.benchmarks.utils import AvalancheDataset
+
+
+def collate_dictionaries(dicts):
+    """
+    Collate a list of dictionaries into a single dictionary.
+    """
+    if len(dicts) == 0:
+        return
+
+    res = {}
+    for key in dicts[0].keys():
+        els = [d[key] for d in dicts]
+        if isinstance(els[0], torch.Tensor):
+            res[key] = torch.stack(els)
+        elif isinstance(els[0], int):
+            res[key] = torch.tensor(els)
+        else:
+            res[key] = els
+    return res
+
+
+class NaiveDictData(avalanche.training.Naive):
+    @property
+    def mb_x(self):
+        return self.mbatch["x"]
+
+    @property
+    def mb_y(self):
+        """Current mini-batch target."""
+        return self.mbatch["y"]
+
+    def mb_task_id(self):
+        return self.mbatch["targets_task_labels"]
+
+    def _unpack_minibatch(self):
+        """minibatches are dictionaries of tensors.
+        Move tensors to the current device."""
+        for k in self.mbatch.keys():
+            self.mbatch[k] = self.mbatch[k].to(self.device)
+
+
+class TestDictionaryDatasets(unittest.TestCase):
+    def test_dictionary_datasets(self):
+        rand_x = torch.randn(100, 10)
+        rand_y = torch.randint(0, 2, (100,))
+        data = [{"x": x, "y": y} for x, y in zip(rand_x, rand_y)]
+        avl_data = AvalancheDataset([data], collate_fn=collate_dictionaries)
+
+        real_sample = data[0]
+        avl_sample = avl_data[0]
+        for k, v in real_sample.items():
+            assert k in avl_sample
+            assert torch.equal(avl_sample[k], v)
+
+    def test_dictionary_train_replay(self):
+        rand_x = torch.randn(100, 10)
+        rand_y = torch.randint(0, 2, (100,))
+        data = [{"x": x, "y": y} for x, y in zip(rand_x, rand_y)]
+
+        train_exps, test_exps = [], []
+        for i in range(0, 2):
+            tl = ConstantSequence(i, len(data))
+            tl = DataAttribute(tl, "targets_task_labels", use_in_getitem=True)
+            av_data = AvalancheDataset(
+                [data], data_attributes=[tl], collate_fn=collate_dictionaries
+            )
+            exp = CLExperience()
+            exp.dataset = av_data
+            train_exps.append(exp)
+            test_exps.append(exp)
+
+        benchmark = CLScenario(
+            [CLStream("train", train_exps), CLStream("test", test_exps)]
+        )
+        eval_plugin = avalanche.training.plugins.EvaluationPlugin(
+            avalanche.evaluation.metrics.loss_metrics(
+                epoch=True, experience=True, stream=True
+            ),
+            loggers=[avalanche.logging.InteractiveLogger()],
+            strict_checks=False,
+        )
+
+        plugins = [ReplayPlugin(mem_size=200)]
+        model = SimpleMLP(input_size=10, num_classes=2)
+        optimizer = torch.optim.Adam(model.parameters(), lr=2)
+        strategy = NaiveDictData(
+            model,
+            optimizer,
+            evaluator=eval_plugin,
+            train_mb_size=10,
+            plugins=plugins,
+        )
+        for experience in benchmark.train_stream:
+            strategy.train(experience)


### PR DESCRIPTION
This PR adds a couple of changes to support datasets with dictionary elements.
- `AvalancheDataset` now allow dictionary elements
- BREAKING CHANGE: removed `collate_mbatches`. `ReplayDataLoader` does not need `collate_mbatches` anymore. It will use the collate from the original datasets.
- added test for dictionary datasets
- added huggingface example