### PR TITLE
Ensures r_max and d_max are on the same device as the rest of the variables in BatchRenorm2D

### DIFF
--- a/avalanche/models/batch_renorm.py
+++ b/avalanche/models/batch_renorm.py
@@ -74,6 +74,9 @@ class BatchRenorm2D(Module):
 
         device = self.gamma.device
 
+        self.r_max = self.r_max if isinstance(self.r_max, float) else self.r_max.to(device)
+        self.d_max = self.d_max if isinstance(self.d_max, float) else self.d_max.to(device)
+
         batch_ch_mean = torch.mean(x, dim=(0, 2, 3), keepdim=True).to(device)
         batch_ch_std = torch.sqrt(
             torch.var(x, dim=(0, 2, 3), keepdim=True, unbiased=False) + self.eps

--- a/avalanche/models/batch_renorm.py
+++ b/avalanche/models/batch_renorm.py
@@ -74,8 +74,10 @@ class BatchRenorm2D(Module):
 
         device = self.gamma.device
 
-        self.r_max = self.r_max if isinstance(self.r_max, float) else self.r_max.to(device)
-        self.d_max = self.d_max if isinstance(self.d_max, float) else self.d_max.to(device)
+        self.r_max = self.r_max if isinstance(self.r_max, float)\
+            else self.r_max.to(device)
+        self.d_max = self.d_max if isinstance(self.d_max, float)\
+            else self.d_max.to(device)
 
         batch_ch_mean = torch.mean(x, dim=(0, 2, 3), keepdim=True).to(device)
         batch_ch_std = torch.sqrt(


### PR DESCRIPTION
The `r_max` and `d_max` variables are created as python floats but at some point become tensors on the wrong device. It seems to happen during or at the end of the testing phase. 
This fixes a crash due to heterogeneous devices when the AR1 method is used on the Core50 dataset and using a CUDA device to train the model after evaluation.

Here is the train-eval loop I'm using, it crashed after the second "Start of experience":
```python
for exp_id, experience in enumerate(benchmark.train_stream):
    print("Start of experience ", experience.current_experience)
    cl_strategy.train(experience)
    print('Training completed')
    print('Computing accuracy on the current test set')
    cl_strategy.eval(benchmark.test_stream)
```