### PR TITLE
Add "interactive" mode to ReplayPlugin

### DIFF
--- a/examples/online_replay.py
+++ b/examples/online_replay.py
@@ -100,7 +100,8 @@ def main(args):
     # CREATE THE STRATEGY INSTANCE (ONLINE-REPLAY)
     storage_policy = ReservoirSamplingBuffer(max_size=100)
     replay_plugin = ReplayPlugin(
-        mem_size=100, batch_size=1, storage_policy=storage_policy
+        mem_size=100, batch_size_mem=1, storage_policy=storage_policy,
+        interactive=True
     )
 
     cl_strategy = OnlineNaive(
@@ -108,7 +109,7 @@ def main(args):
         torch.optim.Adam(model.parameters(), lr=0.1),
         CrossEntropyLoss(),
         train_passes=1,
-        train_mb_size=1,
+        train_mb_size=10,
         eval_mb_size=32,
         device=device,
         evaluator=eval_plugin,
@@ -125,7 +126,7 @@ def main(args):
     for i, exp in enumerate(scenario.train_stream):
         # Create online scenario from experience exp
         ocl_benchmark = OnlineCLScenario(
-            original_streams=batch_streams, experiences=exp, experience_size=1
+            original_streams=batch_streams, experiences=exp, experience_size=10
         )
         # Train on the online train stream of the scenario
         cl_strategy.train(ocl_benchmark.train_stream)


### PR DESCRIPTION
This PR adds an additional option to ReplayPlugin that allows sample concatenation from the buffer before every training iteration. It can be used for implementing some online strategies.

*As for the online replay strategy, the issue of "significant slowdown" is still not solved. I noticed that the bottleneck is caused by buffer updates after every experience, and it only happens from the second experience. All other steps seem to work as they should. I also inspected the buffer update steps (for reservoir sampling),  and everything looked normal.