### PR TITLE
Add checkpointing tests for environment update action.

### DIFF
--- a/.github/workflows/environment-update.yml
+++ b/.github/workflows/environment-update.yml
@@ -56,7 +56,9 @@ jobs:
         id: unittest
         shell: bash -l -c "conda run -n avalanche-env --no-capture-output bash {0}"
         run: |
-          python -m unittest discover tests
+          python -m unittest discover tests &&
+          echo "Running checkpointing tests..." &&
+          bash ./tests/checkpointing/test_checkpointing.sh
       - name: checkout avalanche-docker repo
         if: always()
         uses: actions/checkout@v3


### PR DESCRIPTION
This adds checkpointing tests for environment update action.

Until PyTorch 1.13.1 is released, the checkpointing functionality will be broken (it's a bug on PyTorch 1.13.0).

Workaround: use PyTorch 1.12.*.