### PR TITLE
FIX eval_streams

### DIFF
--- a/avalanche/benchmarks/utils/data.py
+++ b/avalanche/benchmarks/utils/data.py
@@ -101,6 +101,10 @@ class AvalancheDataset(FlatData):
                 DeprecationWarning,
             )
 
+        if issubclass(type(datasets), TorchDataset) or  \
+                issubclass(type(datasets), AvalancheDataset):
+            datasets = [datasets]
+
         # NOTES on implementation:
         # - raw datasets operations are implemented by _FlatData
         # - data attributes are implemented by DataAttribute

--- a/avalanche/training/templates/base.py
+++ b/avalanche/training/templates/base.py
@@ -1,4 +1,5 @@
 import warnings
+from collections import defaultdict
 from typing import Iterable, Sequence, Optional, Union, List
 
 import torch
@@ -90,6 +91,9 @@ class BaseTemplate:
         :param eval_streams: sequence of streams for evaluation.
             If None: use training experiences for evaluation.
             Use [] if you do not want to evaluate during training.
+            Experiences in `eval_streams` are grouped by stream name
+            when calling `eval`. If you use multiple streams, they must
+            have different names.
         """
         self.is_training = True
         self._stop_training = False
@@ -102,7 +106,7 @@ class BaseTemplate:
             experiences = [experiences]
         if eval_streams is None:
             eval_streams = [experiences]
-        self._eval_streams = eval_streams
+        self._eval_streams = _group_experiences_by_stream(eval_streams)
 
         self._before_training(**kwargs)
 
@@ -244,3 +248,20 @@ class BaseTemplate:
 
     def _after_eval_exp(self, **kwargs):
         trigger_plugins(self, "after_eval_exp", **kwargs)
+
+
+def _group_experiences_by_stream(eval_streams):
+    exps = []
+    # First, we unpack the list of experiences.
+    for exp in eval_streams:
+        if isinstance(exp, Iterable):
+            exps.extend(exp)
+        else:
+            exps.append(exp)
+    # Then, we group them by stream.
+    exps_by_stream = defaultdict(list)
+    for exp in exps:
+        sname = exp.origin_stream.name
+        exps_by_stream[sname].append(exp)
+    # Finally, we return a list of lists.
+    return list(exps_by_stream.values())

--- a/tests/test_avalanche_dataset.py
+++ b/tests/test_avalanche_dataset.py
@@ -56,6 +56,17 @@ class FrozenTransformGroupsCenterCrop:
 
 
 class AvalancheDatasetTests(unittest.TestCase):
+
+    def test_avalanche_dataset_creation_without_list(self):
+        dataset_mnist = load_image_benchmark()
+        dataset = AvalancheDataset(dataset_mnist)
+        self.assertIsInstance(dataset, AvalancheDataset)
+        self.assertEqual(len(dataset_mnist), len(dataset))
+
+        dataset = AvalancheDataset(dataset)
+        self.assertIsInstance(dataset, AvalancheDataset)
+        self.assertEqual(len(dataset_mnist), len(dataset))
+
     def test_disallowed_attribute_name(self):
         d_sz = 3
         xdata = torch.rand(d_sz, 2)

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -48,11 +48,37 @@ from avalanche.training.supervised.icarl import ICaRL
 from avalanche.training.supervised.joint_training import AlreadyTrainedError
 from avalanche.training.supervised.strategy_wrappers import PNNStrategy
 from avalanche.training.templates import SupervisedTemplate
+from avalanche.training.templates.base import _group_experiences_by_stream
 from avalanche.training.utils import get_last_fc_layer
 from tests.unit_tests_utils import get_fast_benchmark, get_device
 
 
 class BaseStrategyTest(unittest.TestCase):
+    def test_eval_streams_normalization(self):
+        benchmark = get_fast_benchmark()
+        train_len = len(benchmark.train_stream)
+        test_len = len(benchmark.test_stream)
+
+        res = _group_experiences_by_stream(benchmark.test_stream)
+        assert len(res) == 1
+        assert len(res[0]) == test_len
+
+        res = _group_experiences_by_stream([benchmark.test_stream])
+        assert len(res) == 1
+        assert len(res[0]) == test_len
+
+        res = _group_experiences_by_stream(
+            [*benchmark.test_stream, *benchmark.train_stream])
+        assert len(res) == 2
+        assert len(res[0]) == test_len
+        assert len(res[1]) == train_len
+
+        res = _group_experiences_by_stream(
+            [benchmark.test_stream, benchmark.train_stream])
+        assert len(res) == 2
+        assert len(res[0]) == test_len
+        assert len(res[1]) == train_len
+
     def test_periodic_eval(self):
         model = SimpleMLP(input_size=6, hidden_size=10)
         model.classifier = IncrementalClassifier(model.classifier.in_features)


### PR DESCRIPTION
- AvalancheDataset now accepts a single dataset instead of a list
- `eval_streams` now accepts a single stream instead of a list of streams

closes #1093 
closes #1156 
