### PR TITLE
speed up dataset concat in OCL scenarios

### DIFF
--- a/avalanche/benchmarks/utils/classification_dataset.py
+++ b/avalanche/benchmarks/utils/classification_dataset.py
@@ -110,6 +110,9 @@ class ClassificationDataset(AvalancheDataset, _ClassificationAttributesMixin):
         data = super().concat(other)
         return data.with_transforms(self._transform_groups.current_group)
 
+    def __hash__(self):
+        return id(self)
+
 
 def make_classification_dataset(
     dataset: SupportedDataset,
@@ -473,6 +476,15 @@ def classification_subset(
     if targets is not None:
         das.append(targets)
     if task_labels is not None:
+        # special treatment for task labels for backward compatibility
+        # if len(task_labels) != len(dataset):
+        #     pass
+        # else:
+        #     self._data_attributes[da.name] = da.subset(self._indices)
+        #
+        #     dasub = da.subset(indices)
+        #     self._data_attributes[da.name] = dasub
+
         das.append(task_labels)
     if len(das) == 0:
         das = None

--- a/avalanche/benchmarks/utils/classification_dataset.py
+++ b/avalanche/benchmarks/utils/classification_dataset.py
@@ -489,7 +489,8 @@ def classification_subset(
                 collate_fn=collate_fn,
             )
             # now add task labels
-            return ClassificationDataset([dataset],
+            return ClassificationDataset(
+                [dataset],
                 data_attributes=[dataset.targets, task_labels])
         else:
             das.append(task_labels)

--- a/avalanche/benchmarks/utils/classification_dataset.py
+++ b/avalanche/benchmarks/utils/classification_dataset.py
@@ -476,16 +476,24 @@ def classification_subset(
     if targets is not None:
         das.append(targets)
     if task_labels is not None:
-        # special treatment for task labels for backward compatibility
-        # if len(task_labels) != len(dataset):
-        #     pass
-        # else:
-        #     self._data_attributes[da.name] = da.subset(self._indices)
-        #
-        #     dasub = da.subset(indices)
-        #     self._data_attributes[da.name] = dasub
+        # special treatment for task labels depending on length for
+        # backward compatibility
+        if len(task_labels) != len(dataset):
+            # task labels are already subsampled
+            dataset = ClassificationDataset(
+                [dataset],
+                indices=indices,
+                data_attributes=das,
+                transform_groups=transform_gs,
+                frozen_transform_groups=frozen_transform_groups,
+                collate_fn=collate_fn,
+            )
+            # now add task labels
+            return ClassificationDataset([dataset],
+                data_attributes=[dataset.targets, task_labels])
+        else:
+            das.append(task_labels)
 
-        das.append(task_labels)
     if len(das) == 0:
         das = None
 

--- a/avalanche/benchmarks/utils/data.py
+++ b/avalanche/benchmarks/utils/data.py
@@ -125,6 +125,13 @@ class AvalancheDataset(FlatData):
             self._data_attributes = {}
         else:
             self._data_attributes = {da.name: da for da in data_attributes}
+            for da in data_attributes:
+                ld = sum(len(d) for d in self._datasets)
+                if len(da) != ld:
+                    raise ValueError(
+                        "Data attribute {} has length {} but the dataset "
+                        "has length {}".format(da.name, len(da), ld)
+                    )
         self._transform_groups = transform_groups
         self._frozen_transform_groups = frozen_transform_groups
         self.collate_fn = collate_fn

--- a/avalanche/benchmarks/utils/data.py
+++ b/avalanche/benchmarks/utils/data.py
@@ -194,13 +194,16 @@ class AvalancheDataset(FlatData):
             for da in self._data_attributes.values():
                 # TODO: this was the old behavior. How do we know what to do if
                 # we permute the entire dataset?
-                if len(da) != sum([len(d) for d in datasets]):
-                    self._data_attributes[da.name] = da
-                else:
-                    self._data_attributes[da.name] = da.subset(self._indices)
-
-                    dasub = da.subset(indices)
-                    self._data_attributes[da.name] = dasub
+                # DEPRECATED! always subset attributes
+                # if len(da) != sum([len(d) for d in datasets]):
+                #     self._data_attributes[da.name] = da
+                # else:
+                #     self._data_attributes[da.name] = da.subset(self._indices)
+                #
+                #     dasub = da.subset(indices)
+                #     self._data_attributes[da.name] = dasub
+                dasub = da.subset(self._indices)
+                self._data_attributes[da.name] = dasub
 
         # set attributes dynamically
         for el in self._data_attributes.values():

--- a/avalanche/benchmarks/utils/data.py
+++ b/avalanche/benchmarks/utils/data.py
@@ -195,6 +195,7 @@ class AvalancheDataset(FlatData):
                 # TODO: this was the old behavior. How do we know what to do if
                 # we permute the entire dataset?
                 # DEPRECATED! always subset attributes
+                # we keep this behavior only for `classification_subset`
                 # if len(da) != sum([len(d) for d in datasets]):
                 #     self._data_attributes[da.name] = da
                 # else:

--- a/avalanche/benchmarks/utils/flat_data.py
+++ b/avalanche/benchmarks/utils/flat_data.py
@@ -12,7 +12,11 @@
     Datasets with optimized concat/subset operations.
 """
 import bisect
-import collections
+try:
+    from collections import Hashable
+except ImportError:
+    from collections.abc import Hashable
+
 from typing import List
 
 from torch.utils.data import ConcatDataset
@@ -297,11 +301,11 @@ def _flatten_datasets_and_reindex(datasets, indices):
     the new dataset position in the list.
     """
     # find unique datasets
-    if not all(isinstance(d, collections.Hashable) for d in datasets):
+    if not all(isinstance(d, Hashable) for d in datasets):
         return datasets, indices
 
     dset_uniques = set(datasets)
-    if len(dset_uniques) == datasets:  # no duplicates. Nothing to do.
+    if len(dset_uniques) == len(datasets):  # no duplicates. Nothing to do.
         return datasets, indices
 
     # split the indices into <dataset-id, sample-id> pairs

--- a/avalanche/training/plugins/rwalk.py
+++ b/avalanche/training/plugins/rwalk.py
@@ -117,7 +117,7 @@ class RWalkPlugin(SupervisedPlugin):
     def _update_importance(self, strategy):
         importance = copy_params_dict(strategy.model, copy_grad=True)
         for k in importance.keys():
-            importance[k].data **= 2
+            importance[k].data = importance[k].data ** 2
 
         if self.iter_importance is None:
             self.iter_importance = importance

--- a/profiling/replay_buffers.py
+++ b/profiling/replay_buffers.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
 
     start = time.time()
     buffer = ReservoirSamplingBuffer(100)
-    for t, exp in tqdm(enumerate(split_online_stream(benchmark.train_stream[:2], 1))):
+    for t, exp in tqdm(enumerate(split_online_stream(benchmark.train_stream, 10))):
         buffer.update_from_dataset(exp.dataset)
         b = buffer.buffer
         # depths = _flatdata_depth(b)
@@ -36,7 +36,7 @@ if __name__ == '__main__':
 
     start = time.time()
     buffer = ParametricBuffer(100)
-    for exp in tqdm(split_online_stream(benchmark.train_stream[:2], 1)):
+    for exp in tqdm(split_online_stream(benchmark.train_stream, 10)):
         buffer.update(Mock(experience=exp, dataset=exp.dataset))
         bgs = buffer.buffer_datasets
 
@@ -52,10 +52,6 @@ if __name__ == '__main__':
         # lendsets = [len(b._datasets) for b in atts]
         # lentots = sum([len(b) for b in bgs])
         # print(f"ATTS depth={depths}, idxs={lenidxs}, dsets={lendsets}, len={lentots}")
-    for exp in tqdm(fixed_size_experience_split(experience, 2)):
-        buffer.update(Mock(experience=exp, dataset=exp.dataset))
-        bgs = buffer.buffer_datasets
-
     end = time.time()
     duration = end - start
     print("ParametricBuffer (random sampling) Duration: ", duration)

--- a/profiling/replay_buffers.py
+++ b/profiling/replay_buffers.py
@@ -1,53 +1,61 @@
 from unittest.mock import Mock
 
 import time
-from os.path import expanduser
-
 from tqdm import tqdm
 
-from avalanche.benchmarks import fixed_size_experience_split, SplitMNIST
-from avalanche.benchmarks.utils.flat_data import _flatdata_depth
+from avalanche.benchmarks import fixed_size_experience_split, SplitMNIST, split_online_stream
 from avalanche.training import ReservoirSamplingBuffer
 from avalanche.training import ParametricBuffer
 
-benchmark = SplitMNIST(
-    n_experiences=5,
-    dataset_root=expanduser("~") + "/.avalanche/data/mnist/",
-)
 
-experience = benchmark.train_stream[0]
-print("len experience: ", len(experience.dataset))
+if __name__ == '__main__':
+    benchmark = SplitMNIST(n_experiences=5)
 
-start = time.time()
-buffer = ReservoirSamplingBuffer(100)
-for exp in tqdm(fixed_size_experience_split(experience, 1)):
-    buffer.update_from_dataset(exp.dataset)
+    experience = benchmark.train_stream[0]
+    print("len experience: ", len(experience.dataset))
 
-end = time.time()
-duration = end - start
-print("ReservoirSampling Duration: ", duration)
+    start = time.time()
+    buffer = ReservoirSamplingBuffer(100)
+    for t, exp in tqdm(enumerate(split_online_stream(benchmark.train_stream[:2], 1))):
+        buffer.update_from_dataset(exp.dataset)
+        b = buffer.buffer
+        # depths = _flatdata_depth(b)
+        # lenidxs = len(b._indices)
+        # lendsets = len(b._datasets)
+        # print(f"DATA depth={depths}, idxs={lenidxs}, dsets={lendsets}")
+        #
+        # atts = [b.targets.data, b.targets_task_labels.data]
+        # depths = [_flatdata_depth(b) for b in atts]
+        # lenidxs = [len(b._indices) for b in atts]
+        # lendsets = [len(b._datasets) for b in atts]
+        # print(f"(t={t}) ATTS depth={depths}, idxs={lenidxs}, dsets={lendsets}")
 
+    end = time.time()
+    duration = end - start
+    print("ReservoirSampling Duration: ", duration)
 
-start = time.time()
-buffer = ParametricBuffer(100)
-for exp in tqdm(fixed_size_experience_split(experience, 1)):
-    buffer.update(Mock(experience=exp, dataset=exp.dataset))
-    bgs = buffer.buffer_datasets
+    start = time.time()
+    buffer = ParametricBuffer(100)
+    for exp in tqdm(split_online_stream(benchmark.train_stream[:2], 1)):
+        buffer.update(Mock(experience=exp, dataset=exp.dataset))
+        bgs = buffer.buffer_datasets
 
-    # depths = [_flatdata_depth(b) for b in bgs]
-    # lenidxs = [len(b._indices) for b in bgs]
-    # lendsets = [len(b._datasets) for b in bgs]
-    # lentots = sum([len(b) for b in bgs])
-    # print(f"DATA depth={depths}, idxs={lenidxs}, dsets={lendsets}, len={lentots}")
-    #
-    # atts = [bgs[0].targets.data, bgs[0].targets_task_labels.data]
-    # depths = [_flatdata_depth(b) for b in atts]
-    # lenidxs = [len(b._indices) for b in atts]
-    # lendsets = [len(b._datasets) for b in atts]
-    # lentots = sum([len(b) for b in bgs])
-    # print(f"ATTS depth={depths}, idxs={lenidxs}, dsets={lendsets}, len={lentots}")
+        # depths = [_flatdata_depth(b) for b in bgs]
+        # lenidxs = [len(b._indices) for b in bgs]
+        # lendsets = [len(b._datasets) for b in bgs]
+        # lentots = sum([len(b) for b in bgs])
+        # print(f"DATA depth={depths}, idxs={lenidxs}, dsets={lendsets}, len={lentots}")
+        #
+        # atts = [bgs[0].targets.data, bgs[0].targets_task_labels.data]
+        # depths = [_flatdata_depth(b) for b in atts]
+        # lenidxs = [len(b._indices) for b in atts]
+        # lendsets = [len(b._datasets) for b in atts]
+        # lentots = sum([len(b) for b in bgs])
+        # print(f"ATTS depth={depths}, idxs={lenidxs}, dsets={lendsets}, len={lentots}")
+    for exp in tqdm(fixed_size_experience_split(experience, 2)):
+        buffer.update(Mock(experience=exp, dataset=exp.dataset))
+        bgs = buffer.buffer_datasets
 
-
-end = time.time()
-duration = end - start
-print("ParametricBuffer (random sampling) Duration: ", duration)
+    end = time.time()
+    duration = end - start
+    print("ParametricBuffer (random sampling) Duration: ", duration)

--- a/tests/benchmarks/test_avalanche_dataset.py
+++ b/tests/benchmarks/test_avalanche_dataset.py
@@ -57,6 +57,17 @@ class FrozenTransformGroupsCenterCrop:
 
 class AvalancheDatasetTests(unittest.TestCase):
 
+    def test_avldata_subset_size(self):
+        data = [1, 2, 3, 4]
+        attr = DataAttribute(data, "a")
+        # avl data subset expects len(attribute) == len(dataset)
+        AvalancheDataset([data], data_attributes=[attr], indices=[0, 1])
+
+        # avl data should warn if len(attribute) != len(dataset)
+        with self.assertRaises(ValueError):
+            attr = DataAttribute(data[:2], "a")
+            AvalancheDataset([data], data_attributes=[attr], indices=[0, 1])
+
     def test_avalanche_dataset_creation_without_list(self):
         dataset_mnist = load_image_benchmark()
         dataset = AvalancheDataset(dataset_mnist)

--- a/tests/benchmarks/test_flat_data.py
+++ b/tests/benchmarks/test_flat_data.py
@@ -4,9 +4,12 @@ import random
 import torch
 
 from avalanche.benchmarks import fixed_size_experience_split
-from avalanche.benchmarks.utils import AvalancheDataset, concat_datasets
-from avalanche.benchmarks.utils.classification_dataset import ClassificationDataset
-from avalanche.benchmarks.utils.flat_data import FlatData, _flatten_datasets_and_reindex
+from avalanche.benchmarks.utils import AvalancheDataset, \
+    concat_datasets
+from avalanche.benchmarks.utils.classification_dataset import \
+    ClassificationDataset
+from avalanche.benchmarks.utils.flat_data import FlatData, \
+    _flatten_datasets_and_reindex
 from avalanche.benchmarks.utils.flat_data import (
     _flatdata_depth,
     _flatdata_print,
@@ -101,7 +104,8 @@ class FlatteningTests(unittest.TestCase):
         D1 = bm.train_stream[0].dataset
         ds, idxs = _flatten_datasets_and_reindex([D1, D1, D1], None)
 
-        print(f"len-ds: {len(ds)}, max={max(idxs)}, min={min(idxs)}, lens={[len(d) for d in ds]}")
+        print(f"len-ds: {len(ds)}, max={max(idxs)}, min={min(idxs)}, "
+              f"lens={[len(d) for d in ds]}")
         assert len(ds) == 1
         assert len(idxs) == 3 * len(D1)
         assert max(idxs) == len(D1) - 1
@@ -179,7 +183,8 @@ class FlatteningTests(unittest.TestCase):
         benchmark = get_fast_benchmark()
         buffer = ReservoirSamplingBuffer(100)
 
-        for t, exp in enumerate(fixed_size_experience_split(benchmark.train_stream[0], 1)):
+        for t, exp in enumerate(fixed_size_experience_split(
+                benchmark.train_stream[0], 1)):
             buffer.update_from_dataset(exp.dataset)
             b = buffer.buffer
             # depths = _flatdata_depth(b)
@@ -191,12 +196,14 @@ class FlatteningTests(unittest.TestCase):
             # depths = [_flatdata_depth(b) for b in atts]
             # lenidxs = [len(b._indices) for b in atts]
             # lendsets = [len(b._datasets) for b in atts]
-            # print(f"(t={t}) ATTS depth={depths}, idxs={lenidxs}, dsets={lendsets}")
+            # print(f"(t={t}) ATTS depth={depths}, idxs={lenidxs},
+            # dsets={lendsets}")
             if t > 5:
                 break
         assert len(b._datasets) == 1
 
-        for t, exp in enumerate(fixed_size_experience_split(benchmark.train_stream[1], 1)):
+        for t, exp in enumerate(fixed_size_experience_split(
+                benchmark.train_stream[1], 1)):
             buffer.update_from_dataset(exp.dataset)
             b = buffer.buffer
             # depths = _flatdata_depth(b)
@@ -208,7 +215,8 @@ class FlatteningTests(unittest.TestCase):
             # depths = [_flatdata_depth(b) for b in atts]
             # lenidxs = [len(b._indices) for b in atts]
             # lendsets = [len(b._datasets) for b in atts]
-            # print(f"(t={t}) ATTS depth={depths}, idxs={lenidxs}, dsets={lendsets}")
+            # print(f"(t={t}) ATTS depth={depths}, idxs={lenidxs},
+            # dsets={lendsets}")
             if t > 5:
                 break
         assert len(b._datasets) == 2

--- a/tests/benchmarks/test_flat_data.py
+++ b/tests/benchmarks/test_flat_data.py
@@ -3,11 +3,16 @@ import random
 
 import torch
 
-from avalanche.benchmarks.utils.flat_data import FlatData
+from avalanche.benchmarks import fixed_size_experience_split
+from avalanche.benchmarks.utils import AvalancheDataset, concat_datasets
+from avalanche.benchmarks.utils.classification_dataset import ClassificationDataset
+from avalanche.benchmarks.utils.flat_data import FlatData, _flatten_datasets_and_reindex
 from avalanche.benchmarks.utils.flat_data import (
     _flatdata_depth,
     _flatdata_print,
 )
+from avalanche.training import ReservoirSamplingBuffer
+from tests.unit_tests_utils import get_fast_benchmark
 
 
 class AvalancheDatasetTests(unittest.TestCase):
@@ -88,3 +93,122 @@ class AvalancheDatasetTests(unittest.TestCase):
             assert _flatdata_depth(dd) == 2
             assert len(dd._indices) == 12
             assert len(dd._datasets) == 1
+
+
+class FlatteningTests(unittest.TestCase):
+    def test_flatten_and_reindex(self):
+        bm = get_fast_benchmark()
+        D1 = bm.train_stream[0].dataset
+        ds, idxs = _flatten_datasets_and_reindex([D1, D1, D1], None)
+
+        print(f"len-ds: {len(ds)}, max={max(idxs)}, min={min(idxs)}, lens={[len(d) for d in ds]}")
+        assert len(ds) == 1
+        assert len(idxs) == 3 * len(D1)
+        assert max(idxs) == len(D1) - 1
+        assert min(idxs) == 0
+
+    def test_concat_flattens_same_dataset(self):
+        D = AvalancheDataset([[1, 2, 3]])
+        B = concat_datasets([])
+        B = B.concat(D)
+        B = D.concat(B)
+        print(f"DATA depth={_flatdata_depth(B)}, dsets={len(B._datasets)}")
+        assert _flatdata_depth(B) == 2
+        assert len(B._datasets) == 1
+        B = D.concat(B)
+        print(f"DATA depth={_flatdata_depth(B)}, dsets={len(B._datasets)}")
+        assert _flatdata_depth(B) == 2
+        assert len(B._datasets) == 1
+
+        B = D.concat(B)
+        print(f"DATA depth={_flatdata_depth(B)}, dsets={len(B._datasets)}")
+        assert _flatdata_depth(B) == 2
+        assert len(B._datasets) == 1
+
+    def test_concat_flattens_same_classification_dataset(self):
+        D = ClassificationDataset([[1, 2, 3]])
+        B = concat_datasets([])
+        B = B.concat(D)
+        B = D.concat(B)
+        print(f"DATA depth={_flatdata_depth(B)}, dsets={len(B._datasets)}")
+        assert _flatdata_depth(B) == 2
+        assert len(B._datasets) == 1
+        B = D.concat(B)
+        print(f"DATA depth={_flatdata_depth(B)}, dsets={len(B._datasets)}")
+        assert _flatdata_depth(B) == 2
+        assert len(B._datasets) == 1
+
+        B = D.concat(B)
+        print(f"DATA depth={_flatdata_depth(B)}, dsets={len(B._datasets)}")
+        assert _flatdata_depth(B) == 2
+        assert len(B._datasets) == 1
+
+    def test_concat_flattens_nc_scenario_dataset(self):
+        benchmark = get_fast_benchmark()
+        s = benchmark.train_stream
+        B = concat_datasets([s[1].dataset])
+        D1 = s[0].dataset
+
+        B1 = D1.concat(B)
+        print(f"DATA depth={_flatdata_depth(B1)}, dsets={len(B1._datasets)}")
+        B2 = D1.concat(B1)
+        print(f"DATA depth={_flatdata_depth(B2)}, dsets={len(B2._datasets)}")
+        B3 = D1.concat(B2)
+        print(f"DATA depth={_flatdata_depth(B3)}, dsets={len(B3._datasets)}")
+
+    def test_concat_flattens_nc_scenario_dataset2(self):
+        bm = get_fast_benchmark()
+        s = bm.train_stream
+
+        B = concat_datasets([])  # empty dataset
+        D1 = s[0].dataset
+        D2a = s[1].dataset
+        D2b = s[1].dataset
+
+        B1 = D1.concat(B)
+        print(f"DATA depth={_flatdata_depth(B1)}, dsets={len(B1._datasets)}")
+        assert len(B1._datasets) == 1
+        B2 = D2a.concat(B1)
+        print(f"DATA depth={_flatdata_depth(B2)}, dsets={len(B2._datasets)}")
+        assert len(B2._datasets) == 2
+        B3 = D2b.concat(B2)
+        print(f"DATA depth={_flatdata_depth(B3)}, dsets={len(B3._datasets)}")
+        assert len(B3._datasets) == 2
+
+    def test_flattening_replay_ocl(self):
+        benchmark = get_fast_benchmark()
+        buffer = ReservoirSamplingBuffer(100)
+
+        for t, exp in enumerate(fixed_size_experience_split(benchmark.train_stream[0], 1)):
+            buffer.update_from_dataset(exp.dataset)
+            b = buffer.buffer
+            # depths = _flatdata_depth(b)
+            # lenidxs = len(b._indices)
+            # lendsets = len(b._datasets)
+            # print(f"DATA depth={depths}, idxs={lenidxs}, dsets={lendsets}")
+            #
+            # atts = [b.targets.data, b.targets_task_labels.data]
+            # depths = [_flatdata_depth(b) for b in atts]
+            # lenidxs = [len(b._indices) for b in atts]
+            # lendsets = [len(b._datasets) for b in atts]
+            # print(f"(t={t}) ATTS depth={depths}, idxs={lenidxs}, dsets={lendsets}")
+            if t > 5:
+                break
+        assert len(b._datasets) == 1
+
+        for t, exp in enumerate(fixed_size_experience_split(benchmark.train_stream[1], 1)):
+            buffer.update_from_dataset(exp.dataset)
+            b = buffer.buffer
+            # depths = _flatdata_depth(b)
+            # lenidxs = len(b._indices)
+            # lendsets = len(b._datasets)
+            # print(f"DATA depth={depths}, idxs={lenidxs}, dsets={lendsets}")
+            #
+            # atts = [b.targets.data, b.targets_task_labels.data]
+            # depths = [_flatdata_depth(b) for b in atts]
+            # lenidxs = [len(b._indices) for b in atts]
+            # lendsets = [len(b._datasets) for b in atts]
+            # print(f"(t={t}) ATTS depth={depths}, idxs={lenidxs}, dsets={lendsets}")
+            if t > 5:
+                break
+        assert len(b._datasets) == 2

--- a/tests/benchmarks/test_flat_data.py
+++ b/tests/benchmarks/test_flat_data.py
@@ -155,10 +155,13 @@ class FlatteningTests(unittest.TestCase):
 
         B1 = D1.concat(B)
         print(f"DATA depth={_flatdata_depth(B1)}, dsets={len(B1._datasets)}")
+        assert len(B1._datasets) == 2
         B2 = D1.concat(B1)
         print(f"DATA depth={_flatdata_depth(B2)}, dsets={len(B2._datasets)}")
+        assert len(B2._datasets) == 2
         B3 = D1.concat(B2)
         print(f"DATA depth={_flatdata_depth(B3)}, dsets={len(B3._datasets)}")
+        assert len(B3._datasets) == 2
 
     def test_concat_flattens_nc_scenario_dataset2(self):
         bm = get_fast_benchmark()

--- a/tests/test_avalanche_classification_dataset.py
+++ b/tests/test_avalanche_classification_dataset.py
@@ -1364,7 +1364,8 @@ class TransformationSubsetTests(unittest.TestCase):
         full_task_labels[1000] = 2
         # First, test by passing len(task_labels) == len(dataset_mnist)
         dataset = classification_subset(
-            dataset_mnist, indices=[1000, 1007], task_labels=full_task_labels
+            dataset_mnist, indices=[1000, 1007],
+            task_labels=full_task_labels
         )
 
         x3, y3, t3 = dataset[0]
@@ -1376,7 +1377,8 @@ class TransformationSubsetTests(unittest.TestCase):
 
         # Secondly, test by passing len(task_labels) == len(indices)
         dataset = classification_subset(
-            dataset_mnist, indices=[1000, 1007], task_labels=[3, 5]
+            dataset_mnist, indices=[1000, 1007],
+            task_labels=[3, 5]
         )
 
         x3, y3, t3 = dataset[0]

--- a/tests/test_avalanche_classification_dataset.py
+++ b/tests/test_avalanche_classification_dataset.py
@@ -1715,7 +1715,7 @@ class AvalancheDatasetTransformOpsTests(unittest.TestCase):
 
         dataset_other = make_classification_dataset(dataset_reset)
         dataset_other = dataset_other.replace_current_transform_group(
-            (None, lambda l: l + 1)
+            (None, lambda lll: lll + 1)
         )
 
         _, y6, _ = dataset_other[0]

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -926,7 +926,7 @@ class StrategyTest(unittest.TestCase):
             mem_size=50,
             val_percentage=0.1,
             T=2,
-            stage_2_epochs=2,
+            stage_2_epochs=10,
             lamb=-1,
             lr=0.01,
             train_mb_size=10,

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -926,7 +926,7 @@ class StrategyTest(unittest.TestCase):
             mem_size=50,
             val_percentage=0.1,
             T=2,
-            stage_2_epochs=10,
+            stage_2_epochs=2,
             lamb=-1,
             lr=0.01,
             train_mb_size=10,


### PR DESCRIPTION
improve the flattening process by recognizing when the same dataset occurs multiple times in the dataset list:
- added `_flatten_and_reindex` to improve flattening
- added a `__hash__` method for `AvalancheDataset` to recognize multiple dataset occurrences

@lrzpellegrini can you check this?

**Update**: fixed it. Now it's fast for the entire stream:
```
(split MNIST OCL with exp-size=5 samples, 6000 iterations total)
6003it [00:15, 389.10it/s]
ReservoirSampling Duration:  15.429586410522461
6003it [00:29, 205.35it/s]
ParametricBuffer (random sampling) Duration:  29.233972787857056
```