### PR TITLE
Added TensorMNIST to speed up computation, minor fix in agem and mas

### DIFF
--- a/avalanche/benchmarks/classic/cmnist.py
+++ b/avalanche/benchmarks/classic/cmnist.py
@@ -32,11 +32,11 @@ from ..utils import make_classification_dataset, DefaultTransformGroups
 from ..utils.data import make_avalanche_dataset
 
 _default_mnist_train_transform = Compose(
-    [ToTensor(), Normalize((0.1307,), (0.3081,))]
+    [Normalize((0.1307,), (0.3081,))]
 )
 
 _default_mnist_eval_transform = Compose(
-    [ToTensor(), Normalize((0.1307,), (0.3081,))]
+    [Normalize((0.1307,), (0.3081,))]
 )
 
 

--- a/avalanche/benchmarks/classic/ex_model.py
+++ b/avalanche/benchmarks/classic/ex_model.py
@@ -125,7 +125,7 @@ class ExMLMNIST(ExModelCLScenario):
         CURR_SEED = SEED_BENCHMARK_RUNS[run_id]
 
         transforms = Compose(
-            [Resize(32), ToTensor(), Normalize((0.1307,), (0.3081,))]
+            [Resize(32), Normalize((0.1307,), (0.3081,))]
         )
         if scenario == "split":
             benchmark = SplitMNIST(

--- a/avalanche/benchmarks/datasets/external_datasets/mnist.py
+++ b/avalanche/benchmarks/datasets/external_datasets/mnist.py
@@ -12,7 +12,8 @@ class TensorMNIST(MNIST):
         Returns:
             tuple: (image, target) where target is index of the target class.
         """
-        img, target = self.data[index].float().unsqueeze(0) / 255., int(self.targets[index])
+        img = self.data[index].float().unsqueeze(0) / 255.
+        target = int(self.targets[index])
 
         if self.transform is not None:
             img = self.transform(img)
@@ -36,7 +37,7 @@ def get_mnist_dataset(dataset_root):
 
 def load_MNIST(root, train, transform, target_transform):
     return TensorMNIST(root=root, train=train, transform=transform,
-                 target_transform=target_transform)
+                       target_transform=target_transform)
 
 
 @dill.register(TensorMNIST)

--- a/avalanche/benchmarks/datasets/external_datasets/mnist.py
+++ b/avalanche/benchmarks/datasets/external_datasets/mnist.py
@@ -1,27 +1,46 @@
 import dill
 from torchvision.datasets import MNIST
-
 from avalanche.benchmarks.datasets import default_dataset_location
+
+
+class TensorMNIST(MNIST):
+    def __getitem__(self, index: int):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: (image, target) where target is index of the target class.
+        """
+        img, target = self.data[index].float().unsqueeze(0) / 255., int(self.targets[index])
+
+        if self.transform is not None:
+            img = self.transform(img)
+
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        return img, target
 
 
 def get_mnist_dataset(dataset_root):
     if dataset_root is None:
         dataset_root = default_dataset_location("mnist")
 
-    train_set = MNIST(root=dataset_root, train=True, download=True)
+    train_set = TensorMNIST(root=dataset_root, train=True, download=True)
 
-    test_set = MNIST(root=dataset_root, train=False, download=True)
+    test_set = TensorMNIST(root=dataset_root, train=False, download=True)
 
     return train_set, test_set
 
 
 def load_MNIST(root, train, transform, target_transform):
-    return MNIST(root=root, train=train, transform=transform,
+    return TensorMNIST(root=root, train=train, transform=transform,
                  target_transform=target_transform)
 
 
-@dill.register(MNIST)
-def save_MNIST(pickler, obj: MNIST):
+@dill.register(TensorMNIST)
+def save_MNIST(pickler, obj: TensorMNIST):
     pickler.save_reduce(load_MNIST,
                         (obj.root, obj.train, obj.transform,
                          obj.target_transform), obj=obj)

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -311,7 +311,6 @@ class GroupBalancedInfiniteDataLoader:
         return self.max_len
 
 
-
 class ReplayDataLoader:
     """Custom data loader for rehearsal/replay strategies."""
 

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -257,11 +257,9 @@ class GroupBalancedInfiniteDataLoader:
     ):
         """Data loader that balances data from multiple datasets emitting an
         infinite stream.
-
         Mini-batches emitted by this dataloader are created by collating
         together mini-batches from each group. It may be used to balance data
         among classes, experiences, tasks, and so on.
-
         :param datasets: an instance of `AvalancheDataset`.
         :param collate_mbatches: function that given a sequence of mini-batches
             (one for each task) combines them into a single mini-batch. Used to
@@ -272,13 +270,30 @@ class GroupBalancedInfiniteDataLoader:
         self.datasets = datasets
         self.dataloaders = []
         self.collate_mbatches = collate_mbatches
-        self.kwargs = kwargs
 
         for data in self.datasets:
+            if _DistributedHelper.is_distributed and distributed_sampling:
+                seed = torch.randint(
+                    0,
+                    2 ** 32 - 1 - _DistributedHelper.world_size,
+                    (1,),
+                    dtype=torch.int64,
+                )
+                seed += _DistributedHelper.rank
+                generator = torch.Generator()
+                generator.manual_seed(int(seed))
+            else:
+                generator = None  # Default
+            infinite_sampler = RandomSampler(
+                data,
+                replacement=True,
+                num_samples=10 ** 10,
+                generator=generator,
+            )
             collate_from_data_or_kwargs(data, kwargs)
-            dl = DataLoader(data, **kwargs)
+            dl = DataLoader(data, sampler=infinite_sampler, **kwargs)
             self.dataloaders.append(dl)
-        self.fake_max_len = 10 ** 10
+        self.max_len = 10 ** 10
 
     def __iter__(self):
         iter_dataloaders = []
@@ -287,19 +302,14 @@ class GroupBalancedInfiniteDataLoader:
 
         while True:
             mb_curr = []
-            for t_id, t_loader in enumerate(iter_dataloaders):
-                try:
-                    batch = next(t_loader)
-                except StopIteration:
-                    # create on-the-fly new DataLoader when previous one ends
-                    iter_dataloaders[t_id] = iter(DataLoader(
-                        self.datasets[t_id], **self.kwargs))
-                    batch = next(iter_dataloaders[t_id])
+            for tid, t_loader in enumerate(iter_dataloaders):
+                batch = next(t_loader)
                 mb_curr.append(batch)
             yield self.collate_mbatches(mb_curr)
 
     def __len__(self):
-        return self.fake_max_len
+        return self.max_len
+
 
 
 class ReplayDataLoader:

--- a/avalanche/training/plugins/agem.py
+++ b/avalanche/training/plugins/agem.py
@@ -1,11 +1,9 @@
 import warnings
 import random
 from typing import List
-from time import time
 import torch
-from torch.utils.data import random_split
 
-from avalanche.benchmarks.utils import make_classification_dataset, AvalancheSubset
+from avalanche.benchmarks.utils import make_classification_dataset
 from avalanche.benchmarks.utils.data_loader import (
     GroupBalancedInfiniteDataLoader,
 )
@@ -23,22 +21,18 @@ class AGEMPlugin(SupervisedPlugin):
     This plugin does not use task identities.
     """
 
-    def __init__(self, patterns_per_experience: int, sample_size: int,
-                 sample_frequency: int = 50):
+    def __init__(self, patterns_per_experience: int, sample_size: int):
         """
         :param patterns_per_experience: number of patterns per experience in the
             memory.
         :param sample_size: number of patterns in memory sample when computing
             reference gradient.
-        :param sample_frequency: sample from the buffer every `sample_frequency`
-            iterations. Sample `sample_size`*`sample_frequency` samples to speedup.
         """
 
         super().__init__()
 
         self.patterns_per_experience = int(patterns_per_experience)
         self.sample_size = int(sample_size)
-        self.sample_frequency = sample_frequency
 
         self.buffers: List[
             make_classification_dataset

--- a/avalanche/training/plugins/agem.py
+++ b/avalanche/training/plugins/agem.py
@@ -43,7 +43,6 @@ class AGEMPlugin(SupervisedPlugin):
         self.buffer_dliter = None
 
         self.reference_gradients = None
-        self.memory_x, self.memory_y = None, None
 
     def before_training_iteration(self, strategy, **kwargs):
         """

--- a/avalanche/training/plugins/mas.py
+++ b/avalanche/training/plugins/mas.py
@@ -6,7 +6,8 @@ import torch
 
 from avalanche.models.utils import avalanche_forward
 from avalanche.training.plugins.strategy_plugin import SupervisedPlugin
-from avalanche.training.utils import copy_params_dict, zerolike_params_dict, ParamData
+from avalanche.training.utils import copy_params_dict, zerolike_params_dict, \
+    ParamData
 
 
 class MASPlugin(SupervisedPlugin):
@@ -109,7 +110,7 @@ class MASPlugin(SupervisedPlugin):
                     # to be None for all the heads different from the
                     # current one.
                     if param.grad is not None:
-                        importance[name].data += param.grad.abs() # * len(batch)
+                        importance[name].data += param.grad.abs()
 
         # Normalize importance
         for k in importance.keys():

--- a/avalanche/training/plugins/mas.py
+++ b/avalanche/training/plugins/mas.py
@@ -6,7 +6,7 @@ import torch
 
 from avalanche.models.utils import avalanche_forward
 from avalanche.training.plugins.strategy_plugin import SupervisedPlugin
-from avalanche.training.utils import copy_params_dict, zerolike_params_dict
+from avalanche.training.utils import copy_params_dict, zerolike_params_dict, ParamData
 
 
 class MASPlugin(SupervisedPlugin):
@@ -95,11 +95,11 @@ class MASPlugin(SupervisedPlugin):
             x = x.to(strategy.device)
 
             # Forward pass
-            strategy.model.zero_grad()
+            strategy.optimizer.zero_grad()
             out = avalanche_forward(strategy.model, x, t)
 
             # Average L2-Norm of the output
-            loss = torch.norm(out, p="fro", dim=1).mean()
+            loss = torch.norm(out, p="fro", dim=1).pow(2).mean()
             loss.backward()
 
             # Accumulate importance
@@ -109,17 +109,18 @@ class MASPlugin(SupervisedPlugin):
                     # to be None for all the heads different from the
                     # current one.
                     if param.grad is not None:
-                        importance[name].data += param.grad.abs() * len(batch)
+                        importance[name].data += param.grad.abs() # * len(batch)
 
         # Normalize importance
         for k in importance.keys():
-            importance[k].data /= len(dataloader)
+            importance[k].data /= float(len(dataloader))
 
         return importance
 
     def before_backward(self, strategy, **kwargs):
         # Check if the task is not the first
         exp_counter = strategy.clock.train_exp_counter
+
         if exp_counter == 0:
             return
 
@@ -144,29 +145,31 @@ class MASPlugin(SupervisedPlugin):
         # Update loss
         strategy.loss += self._lambda * loss_reg
 
-    def before_training(self, strategy, **kwargs):
-        # Parameters before the first task starts
-        if not self.params:
-            self.params = dict(copy_params_dict(strategy.model))
-
-        # Initialize Fisher information weight importance
-        if not self.importance:
-            self.importance = dict(zerolike_params_dict(strategy.model))
-
     def after_training_exp(self, strategy, **kwargs):
         self.params = dict(copy_params_dict(strategy.model))
+
+        # Get importance
+        exp_counter = strategy.clock.train_exp_counter
+        if exp_counter == 0:
+            self.importance = self._get_importance(strategy)
+            return
+        else:
+            curr_importance = self._get_importance(strategy)
 
         # Check if previous importance is available
         if not self.importance:
             raise ValueError("Importance is not available")
 
-        # Get importance
-        curr_importance = self._get_importance(strategy)
-
         # Update importance
-        for name in self.importance.keys():
+        for name in curr_importance.keys():
             new_shape = curr_importance[name].data.shape
-            self.importance[name].data = (
-                self.alpha * self.importance[name].expand(new_shape)
-                + (1 - self.alpha) * curr_importance[name].data
-            )
+            if name not in self.importance:
+                self.importance[name] = ParamData(
+                    name, curr_importance[name].shape,
+                    device=curr_importance[name].device,
+                    init_tensor=curr_importance[name].data.clone())
+            else:
+                self.importance[name].data = (
+                    self.alpha * self.importance[name].expand(new_shape)
+                    + (1 - self.alpha) * curr_importance[name].data
+                )

--- a/notebooks/from-zero-to-hero-tutorial/03_benchmarks.ipynb
+++ b/notebooks/from-zero-to-hero-tutorial/03_benchmarks.ipynb
@@ -3,10 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": true
    },
    "source": [
     "---\n",
@@ -21,11 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install avalanche-lib==0.2.0"
@@ -33,11 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## 🎯 Nomenclature\n",
     "\n",
@@ -74,11 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import torch\n",
@@ -125,23 +110,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from avalanche.benchmarks.utils import ImageFolder, DatasetFolder, FilelistDataset, AvalancheDataset"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "## 🛠️ Benchmarks Basics\n",
     "\n",
@@ -160,16 +138,15 @@
     "#### Scenarios\n",
     "\n",
     "So, as we have seen, each `scenario` object in _Avalanche_ has several useful attributes that characterizes the benchmark, including the two important `train` and `test streams`. Let's check what you can get from a scenario object more in details:"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from avalanche.benchmarks.classic import SplitMNIST\n",
@@ -220,11 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# each stream has a name: \"train\" or \"test\"\n",
@@ -254,11 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# we get the first experience\n",
@@ -299,11 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from avalanche.benchmarks.classic import CORe50, SplitTinyImageNet, \\\n",
@@ -331,11 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# creating the benchmark instance (scenario object)\n",
@@ -389,11 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from avalanche.benchmarks.generators import nc_benchmark, ni_benchmark"
@@ -409,11 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from torchvision.transforms import Compose, ToTensor, Normalize, RandomCrop\n",
@@ -446,11 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "scenario = ni_benchmark(\n",
@@ -478,11 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "scenario = nc_benchmark(\n",
@@ -517,11 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from avalanche.benchmarks.generators import filelist_benchmark, dataset_benchmark, \\\n",
@@ -570,11 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -671,11 +608,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "train_cifar10 = CIFAR10(\n",
@@ -735,11 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pattern_shape = (3, 32, 32)\n",
@@ -769,11 +698,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This completes the \"_Benchmark_\" tutorial for the \"_From Zero to Hero_\" series. We hope you enjoyed it!\n",
     "\n",

--- a/tests/evaluation/test_image_samples.py
+++ b/tests/evaluation/test_image_samples.py
@@ -53,15 +53,12 @@ class ImageSamplesTests(unittest.TestCase):
         scenario = SplitMNIST(5)
         curr_exp = scenario.train_stream[0]
 
-        # we use a ReSize transform because it's easy to detect if it's been
-        # applied without looking at the image.
-        curr_dataset = curr_exp.dataset.replace_current_transform_group(
-            Compose([Resize(8), ToTensor()])
-        )
-
         ##########################################
         # WITH AUGMENTATIONS
         ##########################################
+        curr_dataset = curr_exp.dataset.replace_current_transform_group(
+            Compose([Resize(8)])
+        )
         p_metric = ImagesSamplePlugin(
             n_cols=5,
             n_rows=5,
@@ -82,6 +79,11 @@ class ImageSamplesTests(unittest.TestCase):
         ##########################################
         # WITHOUT AUGMENTATIONS
         ##########################################
+        # we use a ReSize transform because it's easy to detect if it's been
+        # applied without looking at the image.
+        curr_dataset = curr_exp.dataset.replace_current_transform_group(
+            Compose([Resize(8), ToTensor()])
+        )
         p_metric = ImagesSamplePlugin(
             n_cols=5,
             n_rows=5,


### PR DESCRIPTION
The main change of the PR is related to the default MNIST dataset, which is now called `TorchMNIST`. The dataset does not return a PIL image anymore but directly a Torch tensor. 
This speeds up computation of strategies like A-GEM which access dataset items multiple times. The main bottleneck is due to the `ToPIL` transformation present in the default `MNIST` implementation (which requires a subsequent `ToTensor` transformation, thus increasing the total time).