### PR TITLE
Adding ER-ACE strategy

### DIFF
--- a/avalanche/training/regularization.py
+++ b/avalanche/training/regularization.py
@@ -189,7 +189,9 @@ class ACECriterion(RegularizationMethod):
         loss_buffer = F.cross_entropy(out_buffer, target_buffer)
         oh_target_in = F.one_hot(target_in, num_classes=out_in.shape[1])
         oh_target_in = oh_target_in[:, list(self.new_classes)]
-        loss_current = cross_entropy_with_oh_targets(out_in[:, list(self.new_classes)], oh_target_in)
+        loss_current = cross_entropy_with_oh_targets(
+                out_in[:, list(self.new_classes)], oh_target_in
+        )
         return (loss_buffer + loss_current) / 2
 
     @property

--- a/avalanche/training/supervised/__init__.py
+++ b/avalanche/training/supervised/__init__.py
@@ -9,4 +9,4 @@ from .strategy_wrappers import *
 from .strategy_wrappers_online import *
 from .deep_slda import *
 from .icarl import ICaRL
-from .er_acl import ER_ACL, OnlineER_ACL
+from .er_ace import ER_ACE, OnlineER_ACE

--- a/avalanche/training/supervised/__init__.py
+++ b/avalanche/training/supervised/__init__.py
@@ -9,3 +9,4 @@ from .strategy_wrappers import *
 from .strategy_wrappers_online import *
 from .deep_slda import *
 from .icarl import ICaRL
+from .er_acl import ER_ACL, OnlineER_ACL

--- a/avalanche/training/supervised/er_ace.py
+++ b/avalanche/training/supervised/er_ace.py
@@ -105,10 +105,6 @@ class OnlineER_ACE(OnlineSupervisedTemplate):
         self.replay_loader = None
         self.ace_criterion = ACECriterion()
 
-    def _before_training_iteration(self, **kwargs):
-        self.ace_criterion.update(self.mb_y)
-        super()._before_training_iteration(**kwargs)
-
     def training_epoch(self, **kwargs):
         """Training epoch.
 
@@ -168,7 +164,7 @@ class OnlineER_ACE(OnlineSupervisedTemplate):
 
     def _before_training_exp(self, **kwargs):
         self.storage_policy.update(self, **kwargs)
-
+        self.ace_criterion.update(torch.tensor(self.experience.dataset.targets))
         # Take all classes for ER ACE loss
         buffer = self.storage_policy.buffer
         if len(buffer) >= self.batch_size_mem:
@@ -259,10 +255,6 @@ class ER_ACE(SupervisedTemplate):
         self.replay_loader = None
         self.ace_criterion = ACECriterion()
 
-    def _before_training_iteration(self, **kwargs):
-        self.ace_criterion.update(self.mb_y)
-        super()._before_training_iteration(**kwargs)
-
     def training_epoch(self, **kwargs):
         """Training epoch.
 
@@ -323,6 +315,7 @@ class ER_ACE(SupervisedTemplate):
     def _before_training_exp(self, **kwargs):
         # Update buffer before training exp so that we have current data in
         self.storage_policy.update(self, **kwargs)
+        self.ace_criterion.update(torch.tensor(self.experience.dataset.targets))
         buffer = self.storage_policy.buffer
         if len(buffer) >= self.batch_size_mem:
             self.replay_loader = cycle(

--- a/avalanche/training/supervised/er_ace.py
+++ b/avalanche/training/supervised/er_ace.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import copy
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 
 import numpy as np
 import torch
@@ -9,6 +9,7 @@ from torch.nn import CrossEntropyLoss, Module
 from torch.optim import Optimizer
 
 from avalanche.benchmarks.utils import concat_datasets
+from avalanche.core import SupervisedPlugin
 from avalanche.models.utils import avalanche_forward
 from avalanche.training import ACECriterion
 from avalanche.training.plugins.evaluation import default_evaluator
@@ -37,7 +38,7 @@ def er_ace_criterion(
 class OnlineER_ACE(OnlineSupervisedTemplate):
     """
     ER ACE Online version, as originally proposed in
-    "New Insights on Reducing Abrupt Representation 
+    "New Insights on Reducing Abrupt Representation
     Change in Online Continual Learning"
     by Lucas Caccia et. al.
     https://openreview.net/forum?id=N8MaByOzUfb
@@ -54,7 +55,7 @@ class OnlineER_ACE(OnlineSupervisedTemplate):
         train_passes: int = 1,
         eval_mb_size: Optional[int] = 1,
         device="cpu",
-        plugins: Optional[Sequence["BaseSGDPlugin"]] = None,
+        plugins: Optional[List[SupervisedPlugin]] = None,
         evaluator=default_evaluator(),
         eval_every=-1,
         peval_mode="experience",
@@ -188,13 +189,13 @@ class OnlineER_ACE(OnlineSupervisedTemplate):
 class ER_ACE(SupervisedTemplate):
     """
     ER ACE, as proposed in
-    "New Insights on Reducing Abrupt Representation 
+    "New Insights on Reducing Abrupt Representation
     Change in Online Continual Learning"
     by Lucas Caccia et. al.
     https://openreview.net/forum?id=N8MaByOzUfb
 
-    This version is adapted to non-online scenario, 
-    the difference with OnlineER_ACE is that it introduces 
+    This version is adapted to non-online scenario,
+    the difference with OnlineER_ACE is that it introduces
     all of the exemples from the new classes in the buffer at the
     beggining of the task instead of introducing them progressively.
     """
@@ -210,7 +211,7 @@ class ER_ACE(SupervisedTemplate):
         train_epochs: int = 1,
         eval_mb_size: Optional[int] = 1,
         device="cpu",
-        plugins: Optional[Sequence["BaseSGDPlugin"]] = None,
+        plugins: Optional[List[SupervisedPlugin]] = None,
         evaluator=default_evaluator(),
         eval_every=-1,
         peval_mode="epoch",

--- a/avalanche/training/supervised/er_acl.py
+++ b/avalanche/training/supervised/er_acl.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+import copy
+from typing import Optional, Sequence
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.nn import CrossEntropyLoss, Module
+from torch.optim import Optimizer
+
+from avalanche.benchmarks.utils import concat_datasets
+from avalanche.models.utils import avalanche_forward
+from avalanche.training.plugins.evaluation import default_evaluator
+from avalanche.training.storage_policy import ClassBalancedBuffer
+from avalanche.training.templates import (OnlineSupervisedTemplate,
+                                          SupervisedTemplate)
+
+
+def cycle(loader):
+    while True:
+        for batch in loader:
+            yield batch
+
+
+def er_acl_criterion(
+    out_in, target_in, out_buffer, target_buffer, all_classes, new_classes
+):
+    loss_buffer = F.cross_entropy(out_buffer, target_buffer)
+    loss_current = F.cross_entropy(
+        out_in[:, len(all_classes) - len(new_classes) :],
+        target_in - (len(all_classes) - len(new_classes)),
+    )
+    return loss_buffer + loss_current
+
+
+class OnlineER_ACL(OnlineSupervisedTemplate):
+    """
+    ER ACL Online version, as originally proposed in
+    "New Insights on Reducing Abrupt Representation Change in Online Continual Learning"
+    by Lucas Caccia et. al.
+    https://openreview.net/forum?id=N8MaByOzUfb
+    """
+
+    def __init__(
+        self,
+        model: Module,
+        optimizer: Optimizer,
+        criterion=CrossEntropyLoss(),
+        mem_size: int = 200,
+        batch_size_mem: int = None,
+        train_mb_size: int = 1,
+        train_passes: int = 1,
+        eval_mb_size: Optional[int] = 1,
+        device="cpu",
+        plugins: Optional[Sequence["BaseSGDPlugin"]] = None,
+        evaluator=default_evaluator(),
+        eval_every=-1,
+        peval_mode="experience",
+    ):
+        """Init.
+
+        :param model: PyTorch model.
+        :param optimizer: PyTorch optimizer.
+        :param criterion: loss function.
+        :param mem_size: int       : Fixed memory size
+        :param batch_size_mem: int : Size of the batch sampled from the buffer
+        :param train_mb_size: mini-batch size for training.
+        :param train_passes: number of training passes.
+        :param eval_mb_size: mini-batch size for eval.
+        :param device: PyTorch device where the model will be allocated.
+        :param plugins: (optional) list of StrategyPlugins.
+        :param evaluator: (optional) instance of EvaluationPlugin for logging
+            and metric computations. None to remove logging.
+        :param eval_every: the frequency of the calls to `eval` inside the
+            training loop. -1 disables the evaluation. 0 means `eval` is called
+            only at the end of the learning experience. Values >0 mean that
+            `eval` is called every `eval_every` experiences and at the end of
+            the learning experience.
+        :param peval_mode: one of {'experience', 'iteration'}. Decides whether
+            the periodic evaluation during training should execute every
+            `eval_every` experience or iterations (Default='experience').
+        """
+        super().__init__(
+            model,
+            optimizer,
+            criterion,
+            train_mb_size,
+            train_passes,
+            eval_mb_size,
+            device,
+            plugins,
+            evaluator,
+            eval_every,
+            peval_mode,
+        )
+
+        self.mem_size = mem_size
+        self.batch_size_mem = batch_size_mem
+        self.storage_policy = ClassBalancedBuffer(
+            max_size=self.mem_size, adaptive_size=True
+        )
+        self.replay_loader = None
+
+        # Use this that way we do not depend on
+        # the ones present in self.experience attributes
+        self.old_classes = set()
+        self.new_classes = set()
+
+    def _before_training_iteration(self, **kwargs):
+        # Update self.classes_seen_so_far and self.new_classes
+        current_classes = set(torch.unique(self.mb_y).cpu().numpy())
+        inter_new = current_classes.intersection(self.new_classes)
+        inter_old = current_classes.intersection(self.old_classes)
+        if len(self.new_classes) == 0:
+            self.new_classes = current_classes
+        elif len(inter_new) == 0:
+            # Intersection is null, new task has arrived
+            self.old_classes.update(self.new_classes)
+            self.new_classes = current_classes
+        elif len(inter_new) > 0 and (
+            len(current_classes.union(self.new_classes)) > len(self.new_classes)
+        ):
+            self.new_classes.update(current_classes)
+        elif len(inter_new) > 0 and len(inter_old) > 0:
+            raise ValueError(
+                "Online ER ACL strategy cannot handle mixing of same classes in different tasks"
+            )
+        super()._before_training_iteration(**kwargs)
+
+    @property
+    def classes_seen_so_far(self):
+        return self.new_classes.union(self.old_classes)
+
+    def training_epoch(self, **kwargs):
+        """Training epoch.
+
+        :param kwargs:
+        :return:
+        """
+        for self.mbatch in self.dataloader:
+            if self._stop_training:
+                break
+
+            self._unpack_minibatch()
+            self._before_training_iteration(**kwargs)
+
+            if (
+                len(self.new_classes) != len(self.classes_seen_so_far)
+            ) and self.replay_loader is not None:
+                self.mb_buffer_x, self.mb_buffer_y, self.mb_buffer_tid = next(
+                    self.replay_loader
+                )
+                self.mb_buffer_x, self.mb_buffer_y, self.mb_buffer_tid = (
+                    self.mb_buffer_x.to(self.device),
+                    self.mb_buffer_y.to(self.device),
+                    self.mb_buffer_tid.to(self.device),
+                )
+
+            self.optimizer.zero_grad()
+            self.loss = 0
+
+            # Forward
+            self._before_forward(**kwargs)
+            self.mb_output = self.forward()
+            if (
+                len(self.new_classes) != len(self.classes_seen_so_far)
+            ) and self.replay_loader is not None:
+                self.mb_buffer_out = avalanche_forward(
+                    self.model, self.mb_buffer_x, self.mb_buffer_tid
+                )
+            self._after_forward(**kwargs)
+
+            # Loss & Backward
+            if (
+                len(self.new_classes) == len(self.classes_seen_so_far)
+            ) or self.replay_loader is None:
+                self.loss += self.criterion()
+            else:
+                self.loss += self.er_acl_criterion()
+
+            self._before_backward(**kwargs)
+            self.backward()
+            self._after_backward(**kwargs)
+
+            # Optimization step
+            self._before_update(**kwargs)
+            self.optimizer_step()
+            self._after_update(**kwargs)
+
+            self._after_training_iteration(**kwargs)
+
+    def _before_training_exp(self, **kwargs):
+        ##############################
+        #  Update Buffer and Loader  #
+        ##############################
+        self.storage_policy.update(self, **kwargs)
+
+        # Take all classes for ER ACL loss
+        buffer = self.storage_policy.buffer
+        if len(buffer) >= self.batch_size_mem:
+            self.replay_loader = cycle(
+                torch.utils.data.DataLoader(
+                    buffer,
+                    batch_size=self.batch_size_mem,
+                    shuffle=True,
+                    drop_last=True,
+                )
+            )
+        else:
+            self.replay_loader = None
+
+        super()._before_training_exp(**kwargs)
+
+    def er_acl_criterion(self):
+        return er_acl_criterion(
+            self.mb_output,
+            self.mb_y,
+            self.mb_buffer_out,
+            self.mb_buffer_y,
+            self.classes_seen_so_far,
+            self.new_classes,
+        )
+
+
+class ER_ACL(SupervisedTemplate):
+    """
+    ER ACL, as proposed in
+    "New Insights on Reducing Abrupt Representation Change in Online Continual Learning"
+    by Lucas Caccia et. al.
+    https://openreview.net/forum?id=N8MaByOzUfb
+
+    This version is adapted to non-online scenario, the difference with OnlineER_ACL
+    is that it introduces all of the exemples from the new classes in the buffer at the
+    beggining of the task instead of introducing them progressively.
+    """
+
+    def __init__(
+        self,
+        model: Module,
+        optimizer: Optimizer,
+        criterion=CrossEntropyLoss(),
+        mem_size: int = 200,
+        batch_size_mem: int = 10,
+        train_mb_size: int = 1,
+        train_epochs: int = 1,
+        eval_mb_size: Optional[int] = 1,
+        device="cpu",
+        plugins: Optional[Sequence["BaseSGDPlugin"]] = None,
+        evaluator=default_evaluator(),
+        eval_every=-1,
+        peval_mode="epoch",
+    ):
+        """
+        :param model: PyTorch model.
+        :param optimizer: PyTorch optimizer.
+        :param criterion: loss function.
+        :param mem_size: int       : Fixed memory size
+        :param batch_size_mem: int : Size of the batch sampled from the buffer
+        :param train_mb_size: mini-batch size for training.
+        :param train_epochs: number of training epochs.
+        :param eval_mb_size: mini-batch size for eval.
+        :param device: PyTorch device where the model will be allocated.
+        :param plugins: (optional) list of StrategyPlugins.
+        :param evaluator: (optional) instance of EvaluationPlugin for logging
+            and metric computations. None to remove logging.
+        :param eval_every: the frequency of the calls to `eval` inside the
+            training loop. -1 disables the evaluation. 0 means `eval` is called
+            only at the end of the learning experience. Values >0 mean that
+            `eval` is called every `eval_every` epochs and at the end of the
+            learning experience.
+        :param peval_mode: one of {'epoch', 'iteration'}. Decides whether the
+            periodic evaluation during training should execute every
+            `eval_every` epochs or iterations (Default='epoch').
+        """
+        super().__init__(
+            model,
+            optimizer,
+            criterion,
+            train_mb_size,
+            train_epochs,
+            eval_mb_size,
+            device,
+            plugins,
+            evaluator,
+            eval_every,
+            peval_mode,
+        )
+
+        self.mem_size = mem_size
+        self.batch_size_mem = batch_size_mem
+        self.storage_policy = ClassBalancedBuffer(
+            max_size=self.mem_size, adaptive_size=True
+        )
+        self.replay_loader = None
+
+    @property
+    def new_classes(self):
+        return np.unique(self.experience.classes_in_this_experience)
+
+    @property
+    def classes_seen_so_far(self):
+        return np.unique(self.experience.classes_seen_so_far)
+
+    def training_epoch(self, **kwargs):
+        """Training epoch.
+
+        :param kwargs:
+        :return:
+        """
+        for self.mbatch in self.dataloader:
+            if self._stop_training:
+                break
+
+            self._unpack_minibatch()
+            self._before_training_iteration(**kwargs)
+
+            if len(self.new_classes) != len(self.classes_seen_so_far):
+                self.mb_buffer_x, self.mb_buffer_y, self.mb_buffer_tid = next(
+                    self.replay_loader
+                )
+                self.mb_buffer_x, self.mb_buffer_y, self.mb_buffer_tid = (
+                    self.mb_buffer_x.to(self.device),
+                    self.mb_buffer_y.to(self.device),
+                    self.mb_buffer_tid.to(self.device),
+                )
+
+            self.optimizer.zero_grad()
+            self.loss = 0
+
+            # Forward
+            self._before_forward(**kwargs)
+            self.mb_output = self.forward()
+            if len(self.new_classes) != len(self.classes_seen_so_far):
+                self.mb_buffer_out = avalanche_forward(
+                    self.model, self.mb_buffer_x, self.mb_buffer_tid
+                )
+            self._after_forward(**kwargs)
+
+            # Loss & Backward
+            if len(self.new_classes) == len(self.classes_seen_so_far):
+                self.loss += self.criterion()
+            else:
+                self.loss += self.er_acl_criterion()
+
+            self._before_backward(**kwargs)
+            self.backward()
+            self._after_backward(**kwargs)
+
+            # Optimization step
+            self._before_update(**kwargs)
+            self.optimizer_step()
+            self._after_update(**kwargs)
+
+            self._after_training_iteration(**kwargs)
+
+    def _before_training_exp(self, **kwargs):
+        # Update buffer before training exp so that we have current data in
+        self.storage_policy.update(self, **kwargs)
+        buffer = self.storage_policy.buffer
+        if len(buffer) >= self.batch_size_mem:
+            self.replay_loader = cycle(
+                torch.utils.data.DataLoader(
+                    buffer,
+                    batch_size=self.batch_size_mem,
+                    shuffle=True,
+                    drop_last=True,
+                )
+            )
+        super()._before_training_exp(**kwargs)
+
+    def er_acl_criterion(self):
+        return er_acl_criterion(
+            self.mb_output,
+            self.mb_y,
+            self.mb_buffer_out,
+            self.mb_buffer_y,
+            self.classes_seen_so_far,
+            self.new_classes,
+        )

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -44,7 +44,7 @@ from avalanche.training.supervised import (
     MAS,
     BiC,
     MIR,
-    ER_ACL,
+    ER_ACE,
 )
 from avalanche.training.supervised.cumulative import Cumulative
 from avalanche.training.supervised.icarl import ICaRL
@@ -974,12 +974,12 @@ class StrategyTest(unittest.TestCase):
         )
         self.run_strategy(benchmark, strategy)
 
-    def test_eracl(self):
+    def test_erace(self):
         # SIT scenario
         model, optimizer, criterion, benchmark = self.init_scenario(
             multi_task=False
         )
-        strategy = ER_ACL(
+        strategy = ER_ACE(
             model,
             optimizer,
             criterion,

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -44,6 +44,7 @@ from avalanche.training.supervised import (
     MAS,
     BiC,
     MIR,
+    ER_ACL,
 )
 from avalanche.training.supervised.cumulative import Cumulative
 from avalanche.training.supervised.icarl import ICaRL
@@ -972,6 +973,25 @@ class StrategyTest(unittest.TestCase):
             train_epochs=2,
         )
         self.run_strategy(benchmark, strategy)
+
+    def test_eracl(self):
+        # SIT scenario
+        model, optimizer, criterion, benchmark = self.init_scenario(
+            multi_task=False
+        )
+        strategy = ER_ACL(
+            model,
+            optimizer,
+            criterion,
+            mem_size=1000,
+            batch_size_mem=10,
+            train_mb_size=10,
+            device=self.device,
+            eval_mb_size=50,
+            train_epochs=2,
+        )
+        self.run_strategy(benchmark, strategy)
+
 
     def load_benchmark(self, use_task_labels=False):
         """

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -992,7 +992,6 @@ class StrategyTest(unittest.TestCase):
         )
         self.run_strategy(benchmark, strategy)
 
-
     def load_benchmark(self, use_task_labels=False):
         """
         Returns a NC benchmark from a fake dataset of 10 classes, 5 experiences,


### PR DESCRIPTION
Started to implement the ER-ACE strategy from the "New Insights on Reducing Abrupt Representation Change in Online Continual Learning" paper [openreview link](https://openreview.net/forum?id=N8MaByOzUfb).

The implementation is still not 100% ready but I need your input on a few things. 

First of all, I have created two strategies. One for the online setting (using Online Scenario), and one for the non online setting. It felt a bit bad to do this since they are basically doing nearly the same thing (the only difference is how the replay buffer is updated), but I don't really know how to do things differently. Do you think it's mandatory to have two different strategies for the two different settings (as it is done for Naive and OnlineNaive) ? If you have a better Idea of how to split these, let me know.

Secondly, the test I created is not passing because the scenario that it uses does not set classes_start_from_zero_from_first_exp=True. I think the only place I need to modify is in the er_acl_criterion function, 
```{python}
def er_acl_criterion(
    out_in, target_in, out_buffer, target_buffer, all_classes, new_classes
):
    loss_buffer = F.cross_entropy(out_buffer, target_buffer)
    loss_current = F.cross_entropy(
        out_in[:, len(all_classes) - len(new_classes) :],
        target_in - (len(all_classes) - len(new_classes)),
    )
    return loss_buffer + loss_current
```
where right now I retire an offset (len(all_classes) - len(new_classes) to the target, and it fails when the target is not bigger than the value of len(classes_seen_so_far). I'm still thinking about a fix for this but again, if you have an idea let me know.
