### PR TITLE
First update of apidoc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,4 +21,4 @@ sphinx-build -b coverage . _build
 in `conf.py` you find a list `undocumented_classes_to_ignore`. This keeps track of the classes that we don't want to add to the apidoc. Add a class here if you believe it should not be documented in the apidoc. Ideally, this should be kept to a minimum.
 
 ### Check for errors
-Due to a bug in sphinx, we have lots of warnings. You can silence them by changing the class template by renaming `_templates/autosummary/no-attributes-class.rst` into `_templates/autosummary/class.rst` to disable the documentation of attributes.
+Due to a bug in sphinx, we have lots of warnings. You can silence them by changing the class template by renaming `_templates/autosummary/documented-methods-class.rst` into `_templates/autosummary/class.rst` to disable the documentation of attributes.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -252,7 +252,12 @@ import pkgutil
 undocumented_classes_to_ignore = [
     # benchmarks
     'IDataset',
-
+    'TensorMNIST',
+    'SpeechCommandsData',
+    'ClassAccuracyPluginMetric',
+    'MeanScoresTrainPluginMetric',
+    'MeanScoresEvalPluginMetric',
+    'AMCAPluginMetric',
     'DictLVIS',
     'LvisEvaluator',
     'CocoEvaluator',

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -54,7 +54,6 @@ Stream Metrics
 
     StreamAccuracy
     StreamClassAccuracy
-    AMCAPluginMetric
     TrainedExperienceAccuracy
     StreamLoss
     StreamBWT
@@ -68,7 +67,6 @@ Stream Metrics
     StreamMaxRAM
     StreamMaxGPU
     StreamTopkAccuracy
-    MeanScoresEvalPluginMetric
 
 Experience Metrics
 ^^^^^^^^^^^^^^^^^^^^
@@ -111,7 +109,6 @@ Epoch Metrics
     EpochMAC
     EpochMaxRAM
     EpochMaxGPU
-    MeanScoresTrainPluginMetric
     EpochTopkAccuracy
 
 RunningEpoch Metrics
@@ -164,6 +161,9 @@ Standalone Metrics
    :toctree: generated
 
     Accuracy
+    LossMetric
+    TaskAwareAccuracy
+    TaskAwareLoss
     AverageMeanClassAccuracy
     BWT
     CPUUsage

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -45,6 +45,8 @@ Models
     MTSimpleCNN
     SimpleMLP
     MTSimpleMLP
+    SimpleSequenceClassifier
+    MTSimpleSequenceClassifier
     MobilenetV1
     NCMClassifier
     SLDAResNetModel  


### PR DESCRIPTION
Added some missing classes from the APIdoc. Restored `no_class_attributes.rst` files. Currently any of the doc templates are much slower than the default one, which however generates lots of warnings.