### PR TITLE
Detection dependency fix

### DIFF
--- a/avalanche/evaluation/metrics/__init__.py
+++ b/avalanche/evaluation/metrics/__init__.py
@@ -5,7 +5,6 @@ from .checkpoint import *
 from .class_accuracy import *
 from .confusion_matrix import *
 from .cpu_usage import *
-from .detection import DetectionMetrics
 from .disk_usage import *
 from .forgetting_bwt import *
 from .forward_transfer import *

--- a/examples/detection.py
+++ b/examples/detection.py
@@ -29,9 +29,9 @@ from avalanche.training.supervised.naive_object_detection import (
 
 from avalanche.evaluation.metrics import (
     timing_metrics,
-    loss_metrics,
-    DetectionMetrics
+    loss_metrics
 )
+from avalanche.evaluation.metrics.detection import DetectionMetrics
 from avalanche.logging import InteractiveLogger
 from avalanche.training.plugins import LRSchedulerPlugin, EvaluationPlugin
 import argparse


### PR DESCRIPTION
Fixed an error that was raised when installing avalanche without the optional detection dependencies.

I'm afraid we'll need to create ad hoc tests to prevent similar problems in the future.