### PR TITLE
allow multiple eval when using checkpointing

### DIFF
--- a/avalanche/training/plugins/checkpoint.py
+++ b/avalanche/training/plugins/checkpoint.py
@@ -303,10 +303,6 @@ class FileSystemCheckpointStorage(CheckpointStorage):
             checkpoint_name: str,
             checkpoint_writer: Callable[[IO[bytes]], None]):
         checkpoint_file = self._make_checkpoint_file_path(checkpoint_name)
-        if checkpoint_file.exists():
-            raise RuntimeError(
-                f'Checkpoint file {str(checkpoint_file)} already exists.')
-
         checkpoint_file.parent.mkdir(exist_ok=True, parents=True)
 
         try:


### PR DESCRIPTION
The checkpointing plugins checks that the checkpoint does not exist already. The problem is that this does not allow multiple eval calls.

@lrzpellegrini is there any reason to raise an error in this scenario?