### PR TITLE
replay fix proposition

### DIFF
--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -334,6 +334,10 @@ class ReplayDataLoader:
         balanced using the task label (i.e. each mini-batch contains a balanced
         number of examples from all the tasks in the `data` and `memory`).
 
+        The length of the loader is determined only by the current 
+        task data and is the same than what it would be when creating a 
+        data loader for this dataset.
+
         If `oversample_small_tasks == True` smaller tasks are oversampled to
         match the largest task.
 

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -433,31 +433,6 @@ class ReplayDataLoader:
                     )[0]
                 )
 
-        if isinstance(self.memory_batch_sizes, int):
-            loaders_for_len_estimation.append(
-                _make_data_loader(
-                    memory,
-                    distributed_sampling,
-                    kwargs,
-                    self.memory_batch_sizes,
-                    force_no_workers=True,
-                )[0]
-            )
-        else:
-            for task_id in memory.task_set:
-                dataset = memory.task_set[task_id]
-                mb_sz = self.memory_batch_sizes[task_id]
-
-                loaders_for_len_estimation.append(
-                    _make_data_loader(
-                        dataset,
-                        distributed_sampling,
-                        kwargs,
-                        mb_sz,
-                        force_no_workers=True,
-                    )[0]
-                )
-
         self.max_len = max([len(d) for d in loaders_for_len_estimation])
 
     def __iter__(self):
@@ -477,15 +452,7 @@ class ReplayDataLoader:
         for t in loader_memory.keys():
             iter_buffer_dataloaders[t] = iter(loader_memory[t])
 
-        max_len = max(
-            [
-                len(d)
-                for d in chain(
-                    loader_data.values(),
-                    loader_memory.values(),
-                )
-            ]
-        )
+        max_len = max([len(d) for d in loader_data.values()])
 
         try:
             for it in range(max_len):

--- a/avalanche/training/plugins/replay.py
+++ b/avalanche/training/plugins/replay.py
@@ -75,6 +75,7 @@ class ReplayPlugin(SupervisedPlugin):
         strategy: "SupervisedTemplate",
         num_workers: int = 0,
         shuffle: bool = True,
+        drop_last: bool = False,
         **kwargs
     ):
         """
@@ -103,6 +104,7 @@ class ReplayPlugin(SupervisedPlugin):
             task_balanced_dataloader=self.task_balanced_dataloader,
             num_workers=num_workers,
             shuffle=shuffle,
+            drop_last=drop_last,
         )
 
     def after_training_exp(self, strategy: "SupervisedTemplate", **kwargs):

--- a/tests/benchmarks/test_replay_loader.py
+++ b/tests/benchmarks/test_replay_loader.py
@@ -40,6 +40,7 @@ class TestReplayDataLoader(unittest.TestCase):
             self.memory_set,
             batch_size=self._batch_size,
             batch_size_mem=self._batch_size,
+            oversample_small_tasks=True,
             drop_last=True,
             **kwargs
         )

--- a/tests/benchmarks/test_replay_loader.py
+++ b/tests/benchmarks/test_replay_loader.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import unittest
+
+import numpy as np
+import torch
+
+from avalanche.benchmarks.classic import SplitMNIST
+from avalanche.benchmarks.utils import AvalancheSubset
+from avalanche.benchmarks.utils.data_loader import ReplayDataLoader
+
+
+class TestReplayDataLoader(unittest.TestCase):
+    def setUp(self):
+        scenario = SplitMNIST(2)
+        dataset_for_current = scenario.train_stream[1].dataset
+        dataset_for_memory = scenario.train_stream[0].dataset
+
+        indices_small_set = np.random.choice(
+            np.arange(len(dataset_for_current)), size=1000, replace=False
+        )
+
+        indices_big_set = np.random.choice(
+            np.arange(len(dataset_for_current)), size=10000, replace=False
+        )
+
+        self.big_task_set = AvalancheSubset(dataset_for_current, indices_big_set)
+        self.small_task_set = AvalancheSubset(dataset_for_current, indices_small_set)
+
+        indices_memory = np.random.choice(
+            np.arange(len(dataset_for_memory)), size=2000, replace=False
+        )
+        self.memory_set = AvalancheSubset(dataset_for_memory, indices_memory)
+
+        self._batch_size = None
+        self._task_dataset = None
+
+    def _make_loader(self, **kwargs):
+        loader = ReplayDataLoader(
+            self._task_dataset,
+            self.memory_set,
+            batch_size=self._batch_size,
+            batch_size_mem=self._batch_size,
+            drop_last=True,
+            **kwargs
+        )
+        return loader
+
+    def _test_batch_size(self, loader):
+        for batch in loader:
+            self.assertEqual(len(batch[0]), self._batch_size * 2)
+
+    def _test_length(self, loader):
+        self.assertEqual(len(loader), self._length)
+
+    def _test_actual_length(self, loader):
+        counter = 0
+        for batch in loader:
+            counter += 1
+        self.assertEqual(counter, self._length)
+
+    def _launch_test_suite(self, loader):
+        self._test_batch_size(loader)
+        self._test_length(loader)
+        self._test_actual_length(loader)
+
+    def test_bigger_memory(self):
+        self._batch_size = 64
+        self._task_dataset = self.small_task_set
+        loader = self._make_loader()
+        self._launch_test_suite(loader)
+
+    def test_smaller_memory(self):
+        self._batch_size = 64
+        self._task_dataset = self.big_task_set
+        loader = self._make_loader()
+        self._launch_test_suite(loader)
+
+    def test_big_batch_size(self):
+        self._batch_size = 256
+        self._task_dataset = self.big_task_set
+        loader = self._make_loader()
+        self._launch_test_suite(loader)
+
+    def test_small_batch_size(self):
+        self._batch_size = 5
+        self._task_dataset = self.big_task_set
+        loader = self._make_loader()
+        self._launch_test_suite(loader)
+
+    @property
+    def _length(self):
+        return len(self._task_dataset) // self._batch_size
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/test_replay_loader.py
+++ b/tests/benchmarks/test_replay_loader.py
@@ -23,8 +23,10 @@ class TestReplayDataLoader(unittest.TestCase):
             np.arange(len(dataset_for_current)), size=10000, replace=False
         )
 
-        self.big_task_set = AvalancheSubset(dataset_for_current, indices_big_set)
-        self.small_task_set = AvalancheSubset(dataset_for_current, indices_small_set)
+        self.big_task_set = \
+            AvalancheSubset(dataset_for_current, indices_big_set)
+        self.small_task_set = \
+            AvalancheSubset(dataset_for_current, indices_small_set)
 
         indices_memory = np.random.choice(
             np.arange(len(dataset_for_memory)), size=2000, replace=False


### PR DESCRIPTION
Linked to issue #1274. I think this should  be enough for the fix, however I would prefer to wait for confirmation that this does not break anything. As far as I understood, loader_data is a dictionnary containing data for the potential multiple tasks present in the current experience. So, taking the maximum length over just this dictionnary should ensure we see all the data from current task, and loop on the other task dataloader if they are of unequal size. However, we don't want to take the maximum lenght also from replay loader since it can lead to the bug described in the above issue.

I also removed the part where the length of the memory buffers were added to the loaders used for length estimation.