### PR TITLE
Add `FromScratchTrainingPlugin`

### DIFF
--- a/avalanche/training/plugins/__init__.py
+++ b/avalanche/training/plugins/__init__.py
@@ -21,3 +21,4 @@ from .rwalk import RWalkPlugin
 from .mas import MASPlugin
 from .bic import BiCPlugin
 from .mir import MIRPlugin
+from .from_scratch_training import FromScratchTrainingPlugin

--- a/avalanche/training/plugins/from_scratch_training.py
+++ b/avalanche/training/plugins/from_scratch_training.py
@@ -1,0 +1,54 @@
+from copy import deepcopy
+
+from avalanche.training.plugins.strategy_plugin import SupervisedPlugin
+from avalanche.training.templates import SupervisedTemplate
+from avalanche.models.dynamic_optimizers import reset_optimizer
+
+
+class FromScratchTrainingPlugin(SupervisedPlugin):
+    """ From Scratch Training Plugin.
+
+    This plugin resets the strategy's model weights and optimizer state after
+    each experience. It expects the strategy to have a single model and
+    optimizer. It can be used with the Naive strategy to produce
+    "from-scratch training" baselines.
+    """
+
+    def __init__(
+            self,
+            reset_optimizer: bool = True
+    ):
+        """
+        Creates a `FromScratchTrainingPlugin` instance.
+
+        :param reset_optimizer: if True, the startegy's optimizer state is
+            reset after each experience.
+
+        """
+        super().__init__()
+        self.reset_optimizer = reset_optimizer
+        self.initial_weights = None
+
+    def before_training(self, strategy, *args, **kwargs):
+        """Called before `train` by the `BaseTemplate`."""
+
+        # Save model's initial weights in the first experience training step
+        if self.initial_weights is None:
+            # Save initial weights
+            self.initial_weights = deepcopy(strategy.model.state_dict())
+
+    def before_training_exp(self, strategy: SupervisedTemplate,
+                            *args, **kwargs):
+        """Called after `train_exp` by the `BaseTemplate`."""
+        # Copy the initial weights to the model
+        for (n, p) in strategy.model.named_parameters():
+            if n in self.initial_weights.keys():
+                if p.data.shape == self.initial_weights[n].data.shape:
+                    p.data.copy_(self.initial_weights[n].data)
+
+        # Update the initial weights (in case new parameters are added)
+        self.initial_weights = deepcopy(strategy.model.state_dict())
+
+        # Reset the optimizer state
+        if self.reset_optimizer:
+            reset_optimizer(strategy.optimizer, strategy.model)

--- a/avalanche/training/plugins/from_scratch_training.py
+++ b/avalanche/training/plugins/from_scratch_training.py
@@ -1,11 +1,11 @@
 from copy import deepcopy
 
-from avalanche.training.plugins.strategy_plugin import SupervisedPlugin
-from avalanche.training.templates import SupervisedTemplate
+from avalanche.core import BaseSGDPlugin
+from avalanche.training.templates import BaseSGDTemplate
 from avalanche.models.dynamic_optimizers import reset_optimizer
 
 
-class FromScratchTrainingPlugin(SupervisedPlugin):
+class FromScratchTrainingPlugin(BaseSGDPlugin):
     """ From Scratch Training Plugin.
 
     This plugin resets the strategy's model weights and optimizer state after
@@ -29,7 +29,7 @@ class FromScratchTrainingPlugin(SupervisedPlugin):
         self.reset_optimizer = reset_optimizer
         self.initial_weights = None
 
-    def before_training(self, strategy, *args, **kwargs):
+    def before_training(self, strategy: BaseSGDTemplate, *args, **kwargs):
         """Called before `train` by the `BaseTemplate`."""
 
         # Save model's initial weights in the first experience training step
@@ -37,8 +37,7 @@ class FromScratchTrainingPlugin(SupervisedPlugin):
             # Save initial weights
             self.initial_weights = deepcopy(strategy.model.state_dict())
 
-    def before_training_exp(self, strategy: SupervisedTemplate,
-                            *args, **kwargs):
+    def before_training_exp(self, strategy: BaseSGDTemplate, *args, **kwargs):
         """Called after `train_exp` by the `BaseTemplate`."""
         # Copy the initial weights to the model
         for (n, p) in strategy.model.named_parameters():

--- a/examples/from_scratch_training.py
+++ b/examples/from_scratch_training.py
@@ -1,0 +1,65 @@
+import torch
+from os.path import expanduser
+
+"""
+A simple example on how to use the Naive strategy.
+"""
+
+from avalanche.models import SimpleMLP
+from avalanche.evaluation.metrics import (
+    accuracy_metrics,
+    loss_metrics,
+)
+from avalanche.training.plugins import EvaluationPlugin
+from avalanche.benchmarks.classic import SplitMNIST
+from avalanche.logging import InteractiveLogger
+from avalanche.training.supervised import (
+    FromScratchTraining
+)
+
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
+
+    # create the benchmark
+    benchmark = SplitMNIST(
+        n_experiences=5,
+        dataset_root=expanduser("~") + "/.avalanche/data/mnist/"
+    )
+
+    # choose some metrics and evaluation method
+    interactive_logger = InteractiveLogger()
+    eval_plugin = EvaluationPlugin(
+        accuracy_metrics(
+            minibatch=True, epoch=True, experience=True, stream=True
+        ),
+        loss_metrics(minibatch=True, epoch=True, experience=True, stream=True),
+        loggers=[interactive_logger],
+    )
+
+    model = SimpleMLP(hidden_size=128)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    criterion = torch.nn.CrossEntropyLoss()
+
+    # create strategy
+    strategy = FromScratchTraining(
+        model,
+        optimizer,
+        criterion,
+        reset_optimizer=True,
+        train_epochs=1,
+        device=device,
+        train_mb_size=32,
+        evaluator=eval_plugin,
+    )
+
+    # train on the selected benchmark with the chosen strategy
+    for experience in benchmark.train_stream:
+        print("Start training on experience ", experience.current_experience)
+        strategy.train(experience)
+        strategy.eval(benchmark.test_stream[:])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a new plugin called FromScratchTraining that resets the model's weights and optimizer state after each training experience. It is used as a baseline for comparison with sequential fine-tuning in some papers. 

Minor: we can change the plugin's name if it's wordy. Another potential name could be: "StrategyResetter" 