### PR TITLE
Fixed TensorImage being treated as an unsupported logging type

### DIFF
--- a/avalanche/logging/wandb_logger.py
+++ b/avalanche/logging/wandb_logger.py
@@ -164,7 +164,8 @@ class WandBLogger(BaseLogger, SupervisedPlugin):
 
         if not isinstance(
             value,
-            (Image, TensorImage, Tensor, Figure, float, int, self.wandb.viz.CustomChart),
+            (Image, TensorImage, Tensor, Figure, float, int,
+             self.wandb.viz.CustomChart),
         ):
             # Unsupported type
             return

--- a/avalanche/logging/wandb_logger.py
+++ b/avalanche/logging/wandb_logger.py
@@ -164,7 +164,7 @@ class WandBLogger(BaseLogger, SupervisedPlugin):
 
         if not isinstance(
             value,
-            (Image, Tensor, Figure, float, int, self.wandb.viz.CustomChart),
+            (Image, TensorImage, Tensor, Figure, float, int, self.wandb.viz.CustomChart),
         ):
             # Unsupported type
             return


### PR DESCRIPTION
Values of type TensorImage were being treated as unsupported despite having their own code branch line 186.