### PR TITLE
Update OnlineObservation and Template Docstrings

### DIFF
--- a/avalanche/benchmarks/scenarios/online_scenario.py
+++ b/avalanche/benchmarks/scenarios/online_scenario.py
@@ -221,7 +221,8 @@ class OnlineCLScenario(CLScenario):
             :func:`fixed_size_experience_split_strategy`.
         : param access_task_boundaries: If True the attributes related to task
             boundaries such as `is_first_subexp` and `is_last_subexp` become
-            accessible during training.
+            accessible during training. For models with dynamic modules, this
+            parameter must be set to True.
         """
         if stream_split_strategy == "fixed_size_split":
 

--- a/avalanche/benchmarks/scenarios/online_scenario.py
+++ b/avalanche/benchmarks/scenarios/online_scenario.py
@@ -94,6 +94,7 @@ def fixed_size_experience_split(
     def gen():
         exp_dataset = experience.dataset
         exp_indices = list(range(len(exp_dataset)))
+        exp_targets = torch.LongTensor(list(exp_dataset.targets))
 
         if shuffle:
             exp_indices = torch.as_tensor(exp_indices)[
@@ -124,6 +125,12 @@ def fixed_size_experience_split(
                 access_task_boundaries=access_task_boundaries,
             )
             exp.dataset = exp_dataset.subset(exp_indices[init_idx:final_idx])
+
+            # Add sub-experience attributes
+            exp.classes_in_this_experience = list(
+                exp_targets[exp_indices[init_idx:final_idx]].unique().numpy())
+            exp.task_labels = experience.task_labels
+
             is_first = False
             yield exp
             init_idx = final_idx

--- a/avalanche/benchmarks/scenarios/online_scenario.py
+++ b/avalanche/benchmarks/scenarios/online_scenario.py
@@ -228,8 +228,7 @@ class OnlineCLScenario(CLScenario):
             :func:`fixed_size_experience_split_strategy`.
         : param access_task_boundaries: If True the attributes related to task
             boundaries such as `is_first_subexp` and `is_last_subexp` become
-            accessible during training. For models with dynamic modules, this
-            parameter must be set to True.
+            accessible during training.
         """
         if stream_split_strategy == "fixed_size_split":
 

--- a/avalanche/training/templates/common_templates.py
+++ b/avalanche/training/templates/common_templates.py
@@ -16,11 +16,11 @@ class SupervisedTemplate(BatchObservation, SupervisedProblem, SGDUpdate,
                          BaseSGDTemplate):
     """Base class for continual learning strategies.
 
-    BaseTemplate is the super class of all task-based continual learning
-    strategies. It implements a basic training loop and callback system
-    that allows to execute code at each experience of the training loop.
-    Plugins can be used to implement callbacks to augment the training
-    loop with additional behavior (e.g. a memory buffer for replay).
+    SupervisedTemplate is the super class of all supervised task-based
+    continual learning strategies. It implements a basic training loop and
+    callback system that allows to execute code at each experience of the
+    training loop. Plugins can be used to implement callbacks to augment the
+    training loop with additional behavior (e.g. a memory buffer for replay).
 
     **Scenarios**
     This strategy supports several continual learning scenarios:
@@ -55,8 +55,6 @@ class SupervisedTemplate(BatchObservation, SupervisedProblem, SGDUpdate,
                 make_eval_dataloader
                 eval_epoch  # for each epoch
                     # forward
-                    # backward
-                    # model update
 
     """
 
@@ -81,7 +79,10 @@ class SupervisedTemplate(BatchObservation, SupervisedProblem, SGDUpdate,
         :param model: PyTorch model.
         :param optimizer: PyTorch optimizer.
         :param criterion: loss function.
-        :param train_mb_size: mini-batch size for training.
+        :param train_mb_size: mini-batch size for training. The default
+            dataloader is a task-balanced dataloader that divides each
+            mini-batch evenly between samples from all existing tasks in
+            the dataset.
         :param train_epochs: number of training epochs.
         :param eval_mb_size: mini-batch size for eval.
         :param device: PyTorch device where the model will be allocated.
@@ -129,11 +130,12 @@ class SupervisedMetaLearningTemplate(BatchObservation, SupervisedProblem,
                                      MetaUpdate, BaseSGDTemplate):
     """Base class for continual learning strategies.
 
-    BaseTemplate is the super class of all task-based continual learning
-    strategies. It implements a basic training loop and callback system
-    that allows to execute code at each experience of the training loop.
-    Plugins can be used to implement callbacks to augment the training
-    loop with additional behavior (e.g. a memory buffer for replay).
+    SupervisedMetaLearningTemplate is the super class of all supervised
+    meta-learning task-based continual learning strategies. It implements a
+    basic training loop and callback system that allows to execute code at
+    each experience of the training loop. Plugins can be used to implement
+    callbacks to augment the training loop with additional behavior
+    (e.g. a memory buffer for replay).
 
     **Scenarios**
     This strategy supports several continual learning scenarios:
@@ -154,9 +156,8 @@ class SupervisedMetaLearningTemplate(BatchObservation, SupervisedProblem,
                 train_dataset_adaptation
                 make_train_dataloader
                 train_epoch  # for each epoch
-                    # forward
-                    # backward
-                    # model update
+                    # inner_updates
+                    # outer_update
 
     **Evaluation loop**
     The evaluation loop is organized as follows::
@@ -168,8 +169,6 @@ class SupervisedMetaLearningTemplate(BatchObservation, SupervisedProblem,
                 make_eval_dataloader
                 eval_epoch  # for each epoch
                     # forward
-                    # backward
-                    # model update
 
     """
 
@@ -194,7 +193,10 @@ class SupervisedMetaLearningTemplate(BatchObservation, SupervisedProblem,
         :param model: PyTorch model.
         :param optimizer: PyTorch optimizer.
         :param criterion: loss function.
-        :param train_mb_size: mini-batch size for training.
+        :param train_mb_size: mini-batch size for training. The default
+            dataloader is a task-balanced dataloader that divides each
+            mini-batch evenly between samples from all existing tasks in
+            the dataset.
         :param train_epochs: number of training epochs.
         :param eval_mb_size: mini-batch size for eval.
         :param device: PyTorch device where the model will be allocated.
@@ -242,11 +244,11 @@ class OnlineSupervisedTemplate(OnlineObservation, SupervisedProblem, SGDUpdate,
                                BaseSGDTemplate):
     """Base class for continual learning strategies.
 
-    BaseTemplate is the super class of all task-based continual learning
-    strategies. It implements a basic training loop and callback system
-    that allows to execute code at each experience of the training loop.
-    Plugins can be used to implement callbacks to augment the training
-    loop with additional behavior (e.g. a memory buffer for replay).
+    OnlineSupervisedTemplate is the super class of all online supervised
+    task-based continual learning strategies. It implements a basic training
+    loop and callback system that allows to execute code at each experience of
+    the training loop. Plugins can be used to implement callbacks to augment the
+    training loop with additional behavior (e.g. a memory buffer for replay).
 
     **Scenarios**
     This strategy supports several continual learning scenarios:
@@ -281,8 +283,6 @@ class OnlineSupervisedTemplate(OnlineObservation, SupervisedProblem, SGDUpdate,
                 make_eval_dataloader
                 eval_epoch  # for each epoch
                     # forward
-                    # backward
-                    # model update
 
     """
 
@@ -307,7 +307,10 @@ class OnlineSupervisedTemplate(OnlineObservation, SupervisedProblem, SGDUpdate,
         :param model: PyTorch model.
         :param optimizer: PyTorch optimizer.
         :param criterion: loss function.
-        :param train_mb_size: mini-batch size for training.
+        :param train_mb_size: mini-batch size for training. The default
+            dataloader is a task-balanced dataloader that divides each
+            mini-batch evenly between samples from all existing tasks in
+            the dataset.
         :param train_passes: number of training passes.
         :param eval_mb_size: mini-batch size for eval.
         :param device: PyTorch device where the model will be allocated.
@@ -344,11 +347,12 @@ class OnlineSupervisedMetaLearningTemplate(OnlineObservation, SupervisedProblem,
                                            MetaUpdate, BaseSGDTemplate):
     """Base class for continual learning strategies.
 
-    BaseTemplate is the super class of all task-based continual learning
-    strategies. It implements a basic training loop and callback system
-    that allows to execute code at each experience of the training loop.
-    Plugins can be used to implement callbacks to augment the training
-    loop with additional behavior (e.g. a memory buffer for replay).
+    OnlineSupervisedMetaLearningTemplate is the super class of all online
+    supervised meta-learning task-based continual learning strategies.
+    It implements a basic training loop and callback system that allows
+    to execute code at each experience of the training loop. Plugins can be
+    used to implement callbacks to augment the training loop with additional
+    behavior (e.g. a memory buffer for replay).
 
     **Scenarios**
     This strategy supports several continual learning scenarios:
@@ -369,9 +373,8 @@ class OnlineSupervisedMetaLearningTemplate(OnlineObservation, SupervisedProblem,
                 train_dataset_adaptation
                 make_train_dataloader
                 train_epoch  # for each epoch
-                    # forward
-                    # backward
-                    # model update
+                    # inner_updates
+                    # outer_update
 
     **Evaluation loop**
     The evaluation loop is organized as follows::
@@ -383,8 +386,6 @@ class OnlineSupervisedMetaLearningTemplate(OnlineObservation, SupervisedProblem,
                 make_eval_dataloader
                 eval_epoch  # for each epoch
                     # forward
-                    # backward
-                    # model update
 
     """
 
@@ -409,7 +410,10 @@ class OnlineSupervisedMetaLearningTemplate(OnlineObservation, SupervisedProblem,
         :param model: PyTorch model.
         :param optimizer: PyTorch optimizer.
         :param criterion: loss function.
-        :param train_mb_size: mini-batch size for training.
+        :param train_mb_size: mini-batch size for training. The default
+            dataloader is a task-balanced dataloader that divides each
+            mini-batch evenly between samples from all existing tasks in
+            the dataset.
         :param train_passes: number of training passes.
         :param eval_mb_size: mini-batch size for eval.
         :param device: PyTorch device where the model will be allocated.

--- a/avalanche/training/templates/observation_type/online_observation.py
+++ b/avalanche/training/templates/observation_type/online_observation.py
@@ -12,19 +12,10 @@ class OnlineObservation:
 
         Called before each training experience to configure the optimizer.
         """
-        # We reset the optimizer's state after each experience if task
-        # boundaries are given, otherwise it updates the optimizer only if
-        # new parameters are added to the model after each adaptation step.
-
-        # We assume the current experience is an OnlineCLExperience:
-        if self.experience.access_task_boundaries:
-            reset_optimizer(self.optimizer, self.model)
-
-        else:
-            update_optimizer(self.optimizer,
-                             self.model_params_before_adaptation,
-                             self.model.parameters(),
-                             reset_state=False)
+        # We reset the optimizer's state after an experience only if task
+        # boundaries are given and the current experience is the first
+        # sub-experience or original experience.
+        reset_optimizer(self.optimizer, self.model)
 
     def model_adaptation(self, model=None):
         """Adapts the model to the current data.
@@ -37,13 +28,8 @@ class OnlineObservation:
         # For training:
         if isinstance(self.experience, OnlineCLExperience):
             # If the strategy has access to task boundaries, adapt the model
-            # for the whole origin experience to add the
-            if self.experience.access_task_boundaries:
-                avalanche_model_adaptation(model,
-                                           self.experience.origin_experience)
-            else:
-                self.model_params_before_adaptation = list(model.parameters())
-                avalanche_model_adaptation(model, self.experience)
+            # using the origin_experience.
+            avalanche_model_adaptation(model, self.experience.origin_experience)
 
         # For evaluation, the experience is not necessarily an online
         # experience:
@@ -54,13 +40,9 @@ class OnlineObservation:
 
     def check_model_and_optimizer(self):
         # If strategy has access to the task boundaries, and the current
-        # sub-experience is the first sub-experience in the online (sub-)stream,
+        # sub-experience is the first sub-experience in the online stream,
         # then adapt the model with the full origin experience:
         if self.experience.access_task_boundaries:
             if self.experience.is_first_subexp:
                 self.model = self.model_adaptation()
                 self.make_optimizer()
-        # Otherwise, adapt to the current sub-experience:
-        else:
-            self.model = self.model_adaptation()
-            self.make_optimizer()


### PR DESCRIPTION
This PR update template docstring and OnlineObservation. 

The changes in the OnlineObersvation class now enable training models with dynamic modules in online strategies. Model adaptation is removed for each sub-experience, and instead, model adaptation and optimizer reset happen only in the boundary sub-experiences. Related to issue #1197.