### PR TITLE
replace lambda functions with pickle compatible equivalent.

### DIFF
--- a/avalanche/benchmarks/utils/classification_dataset.py
+++ b/avalanche/benchmarks/utils/classification_dataset.py
@@ -476,8 +476,7 @@ def classification_subset(
 
     if class_mapping is not None:
         frozen_transform_groups = DefaultTransformGroups(
-            # (None, lambda x: class_mapping[x])
-            (None, partial(lookup, class_mapping))  # replace lambda function to allow pickle to do it's thing for multiprocessing
+            (None, partial(lookup, class_mapping))
         )
     else:
         frozen_transform_groups = None

--- a/avalanche/benchmarks/utils/classification_dataset.py
+++ b/avalanche/benchmarks/utils/classification_dataset.py
@@ -56,11 +56,13 @@ T_co = TypeVar("T_co", covariant=True)
 TAvalancheDataset = TypeVar("TAvalancheDataset", bound="AvalancheDataset")
 TTargetType = Union[int]
 
+
 def lookup(indexable, idx):
-    '''
+    """
     A simple function that implements indexing into an indexable object.
-    Together with 'partial' this allows us to circumvent lambda functions that cannot be pickled.
-    '''
+    Together with 'partial' this allows us to circumvent lambda functions
+    that cannot be pickled.
+    """
     return indexable[idx]
 
 

--- a/avalanche/benchmarks/utils/classification_dataset.py
+++ b/avalanche/benchmarks/utils/classification_dataset.py
@@ -18,6 +18,7 @@ to be used frequently, as is common in replay strategies.
 """
 import warnings
 from collections import defaultdict, deque
+from functools import partial
 
 import torch
 from torch.utils.data import Dataset
@@ -54,6 +55,13 @@ from typing_extensions import Protocol
 T_co = TypeVar("T_co", covariant=True)
 TAvalancheDataset = TypeVar("TAvalancheDataset", bound="AvalancheDataset")
 TTargetType = Union[int]
+
+def lookup(indexable, idx):
+    '''
+    A simple function that implements indexing into an indexable object.
+    Together with 'partial' this allows us to circumvent lambda functions that cannot be pickled.
+    '''
+    return indexable[idx]
 
 
 # Info: https://mypy.readthedocs.io/en/stable/protocols.html#callback-protocols
@@ -468,7 +476,8 @@ def classification_subset(
 
     if class_mapping is not None:
         frozen_transform_groups = DefaultTransformGroups(
-            (None, lambda x: class_mapping[x])
+            # (None, lambda x: class_mapping[x])
+            (None, partial(lookup, class_mapping))  # replace lambda function to allow pickle to do it's thing for multiprocessing
         )
     else:
         frozen_transform_groups = None

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -163,7 +163,7 @@ class GroupBalancedDataLoader:
 
         # collate is done after we have all batches
         # so we set an empty collate for the internal dataloaders
-        self.loader_kwargs["collate_fn"] = return_identity  # this used to be a lambda function but that breaks pickling for multiple dataloader processes
+        self.loader_kwargs["collate_fn"] = return_identity
 
         # check if batch_size is larger than or equal to the number of datasets
         assert batch_size >= len(datasets)

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -42,7 +42,8 @@ detection_collate_mbatches_fn = _detection_collate_mbatches_fn
 
 def return_identity(x):
     """
-    The identity function. Can be wrapped in 'partial' to act as a getter function.
+    The identity function. Can be wrapped in 'partial'
+    to act as a getter function.
     Used to avoid lambda functions that cannot be pickled.
     """
     return x

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -40,6 +40,13 @@ detection_collate_fn = _detection_collate_fn
 detection_collate_mbatches_fn = _detection_collate_mbatches_fn
 
 
+def return_identity(x):
+    '''
+    The identity function. Can be wrapped in 'partial' to act as a getter function.
+    Used to avoid lambda functions that cannot be pickled.
+    '''
+    return x
+
 def collate_from_data_or_kwargs(data, kwargs):
     if "collate_fn" in kwargs:
         return
@@ -156,7 +163,7 @@ class GroupBalancedDataLoader:
 
         # collate is done after we have all batches
         # so we set an empty collate for the internal dataloaders
-        self.loader_kwargs["collate_fn"] = lambda x: x
+        self.loader_kwargs["collate_fn"] = return_identity  # this used to be a lambda function but that breaks pickling for multiple dataloader processes
 
         # check if batch_size is larger than or equal to the number of datasets
         assert batch_size >= len(datasets)

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -41,11 +41,12 @@ detection_collate_mbatches_fn = _detection_collate_mbatches_fn
 
 
 def return_identity(x):
-    '''
+    """
     The identity function. Can be wrapped in 'partial' to act as a getter function.
     Used to avoid lambda functions that cannot be pickled.
-    '''
+    """
     return x
+
 
 def collate_from_data_or_kwargs(data, kwargs):
     if "collate_fn" in kwargs:

--- a/avalanche/benchmarks/utils/transform_groups.py
+++ b/avalanche/benchmarks/utils/transform_groups.py
@@ -27,6 +27,10 @@ from avalanche.benchmarks.utils.transforms import (
 )
 
 def identity(x):
+    '''
+    this is used together with partial to replace a lambda function
+    that causes pickle to fail
+    '''
     return x
 
 class TransformGroups:
@@ -131,8 +135,6 @@ class DefaultTransformGroups(TransformGroups):
     def __init__(self, transform):
         super().__init__({})
         transform = _normalize_transform(transform)
-        # this used to be a lambda function, which cannot be pickled
-        # self.transform_groups = defaultdict(make_getter(transform))
         self.transform_groups = defaultdict(partial(identity, transform))
 
     def with_transform(self, group_name):
@@ -142,8 +144,6 @@ class DefaultTransformGroups(TransformGroups):
 class EmptyTransformGroups(DefaultTransformGroups):
     def __init__(self):
         super().__init__({})
-        # this was a lambda function before that may bring us into a pickle when using multiple dataloader workers
-        # use identity function with partial in an attempt to circumvent the lambda
         self.transform_groups = defaultdict(partial(identity, None))
 
     def __call__(self, elem, group_name=None):

--- a/avalanche/benchmarks/utils/transform_groups.py
+++ b/avalanche/benchmarks/utils/transform_groups.py
@@ -26,12 +26,14 @@ from avalanche.benchmarks.utils.transforms import (
     MultiParamTransform,
 )
 
+
 def identity(x):
-    '''
+    """
     this is used together with partial to replace a lambda function
     that causes pickle to fail
-    '''
+    """
     return x
+
 
 class TransformGroups:
     """Transformation groups for Avalanche datasets.

--- a/avalanche/training/plugins/evaluation.py
+++ b/avalanche/training/plugins/evaluation.py
@@ -178,8 +178,6 @@ class EvaluationPlugin:
         except AttributeError as e:
             if item.startswith("before_") or item.startswith("after_"):
                 # method is a callback. Forward to metrics.
-
-                # this was a lambda function before, which causes pickle to fail.
                 def fun(strat, **kwargs):
                     return self._update_metrics_and_loggers(strat, item)
                 return fun

--- a/avalanche/training/plugins/evaluation.py
+++ b/avalanche/training/plugins/evaluation.py
@@ -178,9 +178,11 @@ class EvaluationPlugin:
         except AttributeError as e:
             if item.startswith("before_") or item.startswith("after_"):
                 # method is a callback. Forward to metrics.
-                return lambda strat, **kwargs: self._update_metrics_and_loggers(
-                    strat, item
-                )
+
+                # this was a lambda function before, which causes pickle to fail.
+                def fun(strat, **kwargs):
+                    return self._update_metrics_and_loggers(strat, item)
+                return fun
             raise
 
     def before_eval(self, strategy: "SupervisedTemplate", **kwargs):

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -157,7 +157,8 @@ class DataLoaderTests(unittest.TestCase):
 
         # test training for one experience
         train_exp = train_stream[0]
-        cl_strategy.train(train_exp, num_workers=4)  # setting num_workers > 0 should not fail
+        # setting num_workers > 0 should not fail
+        cl_strategy.train(train_exp, num_workers=4)
 
 
 if __name__ == "__main__":

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -137,6 +137,28 @@ class DataLoaderTests(unittest.TestCase):
                 self.assertLessEqual(sum(lengths), batch_size)
             cl_strategy.train(step)
 
+    def test_dataloader_with_multiple_workers(self):
+        device = torch.device("cpu")
+        # initialize a simple model
+        model = SimpleMLP(num_classes=10, input_size=6)
+
+        # initialize a benchmark
+        benchmark = get_fast_benchmark()
+        train_stream = benchmark.train_stream
+
+        # Prepare for training & testing
+        optimizer = SGD(model.parameters(), lr=0.001, momentum=0.9)
+        criterion = CrossEntropyLoss()
+
+        # Continual learning strategy
+        cl_strategy = Naive(
+            model, optimizer, criterion, train_mb_size=32, train_epochs=1,
+            eval_mb_size=32, device=device)
+
+        # test training for one experience
+        train_exp = train_stream[0]
+        cl_strategy.train(train_exp, num_workers=4)  # setting num_workers > 0 should not fail
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hello, In the current version of avalanche (0.3.1) setting num_workers > 0 in the train function of a strategy causes a crash.
In my case the reason for this was a number of lambda functions in dataset definitions, which cannot be pickled. Since PyTorch relies on pickle for multiprocessing this prohibits parallelisation in data loading.

This pull request includes a simple fix, although admittedly not a very beautiful one. Unfortunately I do not know the library well enough yet to propose a better solution. Nonetheless I hope that this is helpful to you.

Thank you for all the work you do!

Best wishes,
Daniel