### PR TITLE
Added DER strategy

### DIFF
--- a/avalanche/training/storage_policy.py
+++ b/avalanche/training/storage_policy.py
@@ -108,7 +108,7 @@ class ReservoirSamplingBuffer(ExemplarsBuffer):
         self.max_size = new_size
         if len(self.buffer) <= self.max_size:
             return
-        self.buffer.subset(torch.arange(self.max_size))
+        self.buffer = self.buffer.subset(torch.arange(self.max_size))
         self._buffer_weights = self._buffer_weights[: self.max_size]
 
 

--- a/avalanche/training/storage_policy.py
+++ b/avalanche/training/storage_policy.py
@@ -108,9 +108,7 @@ class ReservoirSamplingBuffer(ExemplarsBuffer):
         self.max_size = new_size
         if len(self.buffer) <= self.max_size:
             return
-        self.buffer = classification_subset(
-            self.buffer, torch.arange(self.max_size)
-        )
+        self.buffer.subset(torch.arange(self.max_size))
         self._buffer_weights = self._buffer_weights[: self.max_size]
 
 

--- a/avalanche/training/supervised/__init__.py
+++ b/avalanche/training/supervised/__init__.py
@@ -10,3 +10,4 @@ from .strategy_wrappers_online import *
 from .deep_slda import *
 from .icarl import ICaRL
 from .er_ace import ER_ACE, OnlineER_ACE
+from .der import DER

--- a/avalanche/training/supervised/der.py
+++ b/avalanche/training/supervised/der.py
@@ -232,12 +232,12 @@ class DER(SupervisedTemplate):
         if self.replay_loader is None:
             return None
 
-        batch_x, batch_y, batch_logits, batch_tid = next(self.replay_loader)
-        batch_x, batch_y, batch_logits, batch_tid = (
+        batch_x, batch_y, batch_tid, batch_logits = next(self.replay_loader)
+        batch_x, batch_y, batch_tid, batch_logits = (
             batch_x.to(self.device),
             batch_y.to(self.device),
-            batch_logits.to(self.device),
             batch_tid.to(self.device),
+            batch_logits.to(self.device),
         )
         self.mbatch[0] = torch.cat((batch_x, self.mbatch[0]))
         self.mbatch[1] = torch.cat((batch_y, self.mbatch[1]))
@@ -278,7 +278,6 @@ class DER(SupervisedTemplate):
                     self.mb_output[: self.batch_size_mem],
                     self.mb_y[: self.batch_size_mem],
                 )
-                self.loss = self.loss / 2
             else:
                 self.loss += self.criterion()
 

--- a/avalanche/training/supervised/der.py
+++ b/avalanche/training/supervised/der.py
@@ -167,6 +167,33 @@ class DER(SupervisedTemplate):
         eval_every=-1,
         peval_mode="epoch",
     ):
+        """
+        :param model: PyTorch model.
+        :param optimizer: PyTorch optimizer.
+        :param criterion: loss function.
+        :param mem_size: int       : Fixed memory size
+        :param batch_size_mem: int : Size of the batch sampled from the buffer
+        :param derpp: bool : When True, uses DER++ 
+                            (add CE loss to the buffer 
+                             samples on top of MSE loss)
+        :param alpha: float : Hyperparameter weighting the MSE loss
+        :param beta: float : Hyperparameter weighting the CE loss (DER++)
+        :param train_mb_size: mini-batch size for training.
+        :param train_passes: number of training passes.
+        :param eval_mb_size: mini-batch size for eval.
+        :param device: PyTorch device where the model will be allocated.
+        :param plugins: (optional) list of StrategyPlugins.
+        :param evaluator: (optional) instance of EvaluationPlugin for logging
+            and metric computations. None to remove logging.
+        :param eval_every: the frequency of the calls to `eval` inside the
+            training loop. -1 disables the evaluation. 0 means `eval` is called
+            only at the end of the learning experience. Values >0 mean that
+            `eval` is called every `eval_every` experiences and at the end of
+            the learning experience.
+        :param peval_mode: one of {'experience', 'iteration'}. Decides whether
+            the periodic evaluation during training should execute every
+            `eval_every` experience or iterations (Default='experience').
+        """
         super().__init__(
             model=model,
             optimizer=optimizer,

--- a/avalanche/training/supervised/der.py
+++ b/avalanche/training/supervised/der.py
@@ -1,0 +1,236 @@
+import copy
+from typing import List, Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.nn import CrossEntropyLoss, Module
+from torch.optim import Optimizer
+from torch.utils.data import Dataset
+from torchvision.transforms import Compose, RandomCrop, RandomHorizontalFlip
+
+from avalanche.benchmarks.utils import (classification_subset,
+                                        make_tensor_classification_dataset)
+from avalanche.core import SupervisedPlugin
+from avalanche.models.utils import avalanche_forward
+from avalanche.training.plugins.evaluation import default_evaluator
+from avalanche.training.storage_policy import (BalancedExemplarsBuffer,
+                                               ReservoirSamplingBuffer)
+from avalanche.training.templates import SupervisedTemplate
+
+
+def cycle(loader):
+    while True:
+        for batch in loader:
+            yield batch
+
+
+@torch.no_grad()
+def dataset_with_logits(dataset, model, batch_size, device, _max_size=300):
+    model = copy.deepcopy(model)
+    model.train()
+    logits = []
+    data = []
+    loader = torch.utils.data.DataLoader(
+        dataset, 
+        batch_size=batch_size, 
+        shuffle=False)
+
+    for x, _, _ in loader:
+        x = x.to(device)
+        out = model(x)
+        logits.append(out)
+        data.append(x)
+
+    logits = torch.cat(logits)
+    data = torch.cat(data)
+
+    logits = F.pad(logits, (0, _max_size - logits.shape[1]), value=0)
+
+    if len(data.shape) == 4:
+        transform = Compose(
+            [RandomCrop(data[0].shape[2], padding=4), RandomHorizontalFlip()]
+        )
+    else:
+        transform = None
+
+    dataset = make_tensor_classification_dataset(
+        data,
+        torch.tensor(dataset.targets),
+        torch.tensor(dataset.targets_task_labels),
+        logits,
+        transform=transform,
+    )
+    return dataset
+
+
+class ClassBalancedBufferWithLogits(BalancedExemplarsBuffer):
+    """
+    ClassBalancedBuffer that also stores the logits
+    """
+
+    def __init__(
+        self,
+        max_size: int,
+        adaptive_size: bool = True,
+        total_num_classes: int = None,
+    ):
+        """Init.
+
+        :param max_size: The max capacity of the replay memory.
+        :param adaptive_size: True if mem_size is divided equally over all
+                            observed experiences (keys in replay_mem).
+        :param total_num_classes: If adaptive size is False, the fixed number
+                                  of classes to divide capacity over.
+        """
+        if not adaptive_size:
+            assert (
+                total_num_classes > 0
+            ), """When fixed exp mem size, total_num_classes should be > 0."""
+
+        super().__init__(max_size, adaptive_size, total_num_classes)
+        self.adaptive_size = adaptive_size
+        self.total_num_classes = total_num_classes
+        self.seen_classes = set()
+
+    def update(self, strategy: "SupervisedTemplate", **kwargs):
+        new_data = strategy.experience.dataset.eval()
+
+        new_data_with_logits = dataset_with_logits(
+            new_data, strategy.model, strategy.train_mb_size, strategy.device,
+        )
+
+        # Get sample idxs per class
+        cl_idxs = {}
+        for idx, target in enumerate(new_data.targets):
+            if target not in cl_idxs:
+                cl_idxs[target] = []
+            cl_idxs[target].append(idx)
+
+        # Make AvalancheSubset per class
+        cl_datasets = {}
+        for c, c_idxs in cl_idxs.items():
+            subset = classification_subset(new_data_with_logits, indices=c_idxs)
+            cl_datasets[c] = subset
+        # Update seen classes
+        self.seen_classes.update(cl_datasets.keys())
+
+        # associate lengths to classes
+        lens = self.get_group_lengths(len(self.seen_classes))
+        class_to_len = {}
+        for class_id, ll in zip(self.seen_classes, lens):
+            class_to_len[class_id] = ll
+
+        # update buffers with new data
+        for class_id, new_data_c in cl_datasets.items():
+            ll = class_to_len[class_id]
+            if class_id in self.buffer_groups:
+                old_buffer_c = self.buffer_groups[class_id]
+                # Here it uses underlying dataset
+                old_buffer_c.update_from_dataset(new_data_c)
+                old_buffer_c.resize(strategy, ll)
+            else:
+                new_buffer = ReservoirSamplingBuffer(ll)
+                new_buffer.update_from_dataset(new_data_c)
+                self.buffer_groups[class_id] = new_buffer
+
+        # resize buffers
+        for class_id, class_buf in self.buffer_groups.items():
+            self.buffer_groups[class_id].resize(
+                strategy, 
+                class_to_len[class_id])
+
+
+class DER(SupervisedTemplate):
+    """ 
+    Implements the DER and the DER++ Strategy, 
+    from the "Dark Experience For General Continual Learning" 
+    paper, Buzzega et. al, https://arxiv.org/abs/2004.07211 
+    """
+
+    def __init__(
+        self,
+        model: Module,
+        optimizer: Optimizer,
+        criterion=CrossEntropyLoss(),
+        mem_size: int = 200,
+        batch_size_mem: int = None,
+        derpp: bool = False,
+        alpha: float = 0.1,
+        beta: float = 0.5,
+        train_mb_size: int = 1,
+        train_epochs: int = 1,
+        eval_mb_size: Optional[int] = 1,
+        device="cpu",
+        plugins: Optional[List[SupervisedPlugin]] = None,
+        evaluator=default_evaluator(),
+        eval_every=-1,
+        peval_mode="epoch",
+    ):
+        super().__init__(
+            model=model,
+            optimizer=optimizer,
+            criterion=criterion,
+            train_mb_size=train_mb_size,
+            train_epochs=train_epochs,
+            eval_mb_size=eval_mb_size,
+            device=device,
+            plugins=plugins,
+            evaluator=evaluator,
+            eval_every=eval_every,
+            peval_mode=peval_mode,
+        )
+        if batch_size_mem is None:
+            self.batch_size_mem = train_mb_size
+        else:
+            self.batch_size_mem = batch_size_mem
+        self.mem_size = mem_size
+        self.storage_policy = ClassBalancedBufferWithLogits(
+            self.mem_size, adaptive_size=True
+        )
+        self.replay_loader = None
+        self.derpp = derpp
+        self.alpha = alpha
+        self.beta = beta
+
+    def _before_training_exp(self, **kwargs):
+        buffer = self.storage_policy.buffer
+        if len(buffer) >= self.batch_size_mem:
+            self.replay_loader = cycle(
+                torch.utils.data.DataLoader(
+                    buffer,
+                    batch_size=self.batch_size_mem,
+                    shuffle=True,
+                    drop_last=True,
+                )
+            )
+        else:
+            self.replay_loader = None
+
+        super()._before_training_exp(**kwargs)
+
+    def _after_training_exp(self, **kwargs):
+        self.storage_policy.update(self, **kwargs)
+        super()._after_training_exp(**kwargs)
+
+    def _before_backward(self, **kwargs):
+        super()._before_backward(**kwargs)
+        if self.replay_loader is None:
+            return None
+
+        batch_x, batch_y, batch_tid, batch_logits, _ = next(self.replay_loader)
+        batch_x, batch_y, batch_tid, batch_logits = (
+            batch_x.to(self.device),
+            batch_y.to(self.device),
+            batch_tid.to(self.device),
+            batch_logits.to(self.device),
+        )
+
+        out_buffer = avalanche_forward(self.model, batch_x, batch_tid)
+
+        self.loss += self.alpha * F.mse_loss(
+            out_buffer, batch_logits[:, : out_buffer.shape[1]]
+        )
+
+        if self.derpp:
+            self.loss += self.beta * F.cross_entropy(out_buffer, batch_y)

--- a/avalanche/training/supervised/der.py
+++ b/avalanche/training/supervised/der.py
@@ -6,18 +6,11 @@ import torch
 import torch.nn.functional as F
 from torch.nn import CrossEntropyLoss, Module
 from torch.optim import Optimizer
-from torch.utils.data import Dataset
-from torchvision.transforms import Compose, RandomCrop, RandomHorizontalFlip
 
-from avalanche.benchmarks.utils import (classification_subset,
-                                        make_avalanche_dataset,
-                                        make_tensor_classification_dataset)
+from avalanche.benchmarks.utils import make_avalanche_dataset
 from avalanche.benchmarks.utils.data import AvalancheDataset
 from avalanche.benchmarks.utils.data_attribute import TensorDataAttribute
-from avalanche.benchmarks.utils.transform_groups import (EmptyTransformGroups,
-                                                         TransformGroups)
 from avalanche.core import SupervisedPlugin
-from avalanche.models.utils import avalanche_forward
 from avalanche.training.plugins.evaluation import default_evaluator
 from avalanche.training.storage_policy import (BalancedExemplarsBuffer,
                                                ReservoirSamplingBuffer)

--- a/avalanche/training/supervised/der.py
+++ b/avalanche/training/supervised/der.py
@@ -268,6 +268,9 @@ class DER(SupervisedTemplate):
             self._after_forward(**kwargs)
 
             if self.replay_loader is not None:
+
+                # DER Loss computation
+
                 self.loss += F.cross_entropy(
                     self.mb_output[self.batch_size_mem:],
                     self.mb_y[self.batch_size_mem:],
@@ -281,6 +284,13 @@ class DER(SupervisedTemplate):
                     self.mb_output[:self.batch_size_mem],
                     self.mb_y[:self.batch_size_mem],
                 )
+
+                # They are a few difference compared to the autors impl:
+                # - Joint forward pass vs. 3 forward passes
+                # - One replay batch vs two replay batches
+                # - Logits are stored from the non-transformed sample
+                #   after training on task vs instantly on transformed sample
+
             else:
                 self.loss += self.criterion()
 

--- a/tests/benchmarks/test_data_attribute.py
+++ b/tests/benchmarks/test_data_attribute.py
@@ -1,8 +1,12 @@
 import unittest
 
+import numpy as np
 import torch
 
-from avalanche.benchmarks.utils.data_attribute import DataAttribute
+from avalanche.benchmarks.utils import (classification_subset,
+                                        make_avalanche_dataset)
+from avalanche.benchmarks.utils.data_attribute import (DataAttribute,
+                                                       TensorDataAttribute)
 
 
 class DataAttributeTests(unittest.TestCase):
@@ -24,9 +28,8 @@ class DataAttributeTests(unittest.TestCase):
         t0 = torch.zeros(10, dtype=torch.int)
         t1 = torch.ones(10, dtype=torch.int)
         da = DataAttribute(torch.cat([t0, t1]), "task_labels")
-        self.assertEqual(
-            da.val_to_idx, {0: list(range(10)), 1: list(range(10, 20))}
-        )
+        self.assertEqual(da.val_to_idx, {0: list(range(10)), 
+                                         1: list(range(10, 20))})
 
     def test_subset(self):
         """Test that subset is correctly computed."""
@@ -41,6 +44,54 @@ class DataAttributeTests(unittest.TestCase):
         t0 = torch.zeros(10, dtype=torch.int)
         t1 = torch.ones(10, dtype=torch.int)
         da = DataAttribute(torch.cat([t0, t1]), "task_labels")
-        self.assertEqual(
-            list(da.concat(da).data), list(torch.cat([t0, t1, t0, t1]))
+        self.assertEqual(list(da.concat(da).data), 
+                         list(torch.cat([t0, t1, t0, t1])))
+
+
+class TensorDataAttributeTests(unittest.TestCase):
+    def test_subset(self):
+        """Test that subset is correctly computed."""
+        t0 = torch.zeros(10)
+        t1 = torch.ones(10)
+        da = TensorDataAttribute(torch.cat([t0, t1]), "logit")
+        self.assertEqual(list(da.subset(range(10)).data), list(t0))
+        self.assertEqual(list(da.subset(range(10, 20)).data), list(t1))
+
+    def test_concat(self):
+        """Test that concat is correctly computed."""
+        t0 = torch.zeros(10)
+        t1 = torch.ones(10)
+        da = DataAttribute(torch.cat([t0, t1]), "logits")
+        self.assertEqual(list(da.concat(da).data), 
+                         list(torch.cat([t0, t1, t0, t1])))
+
+    def test_swap(self):
+        """Test that data attributes are
+        always returned in the same order"""
+        # Fake x, y
+        t1 = list(zip(np.arange(10), np.arange(10)))
+        t2 = torch.ones(10).tolist()
+        t3 = (torch.ones(10) * 2).tolist()
+        t4 = (torch.ones(10) * 3).tolist()
+
+        dataset = make_avalanche_dataset(
+            t1,
+            data_attributes=[
+                TensorDataAttribute(t2, name="logits", use_in_getitem=True),
+                TensorDataAttribute(t3, name="logits2", use_in_getitem=True),
+            ],
         )
+
+        # Now add another attribute
+        dataset = make_avalanche_dataset(
+            dataset,
+            data_attributes=[
+                TensorDataAttribute(t4, name="logits0", use_in_getitem=True),
+            ],
+        )
+
+        print(dataset[0])
+        # This outputs 0 0 3 1 2
+        # Correct behavior should be to have 
+        # the last added in the end ?
+        # So in that case 0 0 1 2 3

--- a/tests/benchmarks/test_data_attribute.py
+++ b/tests/benchmarks/test_data_attribute.py
@@ -90,8 +90,4 @@ class TensorDataAttributeTests(unittest.TestCase):
             ],
         )
 
-        print(dataset[0])
-        # This outputs 0 0 3 1 2
-        # Correct behavior should be to have 
-        # the last added in the end ?
-        # So in that case 0 0 1 2 3
+        assert dataset[0] == [0.0, 0.0, 1.0, 2.0, 3.0]

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -45,6 +45,7 @@ from avalanche.training.supervised import (
     BiC,
     MIR,
     ER_ACE,
+    DER,
 )
 from avalanche.training.supervised.cumulative import Cumulative
 from avalanche.training.supervised.icarl import ICaRL
@@ -980,6 +981,24 @@ class StrategyTest(unittest.TestCase):
             multi_task=False
         )
         strategy = ER_ACE(
+            model,
+            optimizer,
+            criterion,
+            mem_size=1000,
+            batch_size_mem=10,
+            train_mb_size=10,
+            device=self.device,
+            eval_mb_size=50,
+            train_epochs=2,
+        )
+        self.run_strategy(benchmark, strategy)
+
+    def test_der(self):
+        # SIT scenario
+        model, optimizer, criterion, benchmark = self.init_scenario(
+            multi_task=False
+        )
+        strategy = DER(
             model,
             optimizer,
             criterion,

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -1004,6 +1004,7 @@ class StrategyTest(unittest.TestCase):
             criterion,
             mem_size=1000,
             batch_size_mem=10,
+            transforms=None,
             train_mb_size=10,
             device=self.device,
             eval_mb_size=50,

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -1004,7 +1004,6 @@ class StrategyTest(unittest.TestCase):
             criterion,
             mem_size=1000,
             batch_size_mem=10,
-            transforms=None,
             train_mb_size=10,
             device=self.device,
             eval_mb_size=50,


### PR DESCRIPTION
I added the DER strategy here. Below I list some implementations details and choices that we can change potentially.

- About the use of transformations: For now, I do not use transformations by default on the current data, because in avalanche this is not suppose to be a choice from the strategy but rather one from the benchmark. However, the use of input transformations is a part of the DER method, so it should be either triggered when using it in what case the actual DER will happen, or used without input transformations in what case transformations will be applied only on the buffer data.
- To store the data, I use a derived version of ClassBalancedBuffer which additionally stores the logits of the memory samples so that they can later be replayed. To do this, I use a classification tensor dataset that I create by iterating over the experience dataset, and I collect both the input data and the logits that I pad to a maximum dimension (set to 300 for now), I will explain below why. I also take care of using experience.dataset.eval() so that stored data is not already augmented data, I think this should be sufficient precaution but let me know if you think there might be a problem there.
- Another point that I am not sure how to handle is the logits size. I think the classical behavior that you would expect for the model used inside an avalanche strategy would be to have potentially varying number of logits, which could make the classification tensor dataset fail to be built since it cannot store tensors of different size in the same dataset. This is why I pad the logits to a given shape.
- Again, about the logits size, the classical DER strategy do not use varying logits size and thus store the value of the full (untrained included) logits from the beginning of training. This behavior I think was not initially desired by the authors but they later said in a follow up paper that they realized it was beneficial for the performance to do it like that. In avalanche, the strategy is not suppose to chose the architecture of the model, so the implementation I provide deals with both cases, when using a model with growing logits and also when using a models with fixed number of logits.

TLDR; While this strategy is implementing the DER and DER++ strategy, they are two details from the paper that are classically handled by avalanche (use of input transformations and model head size) that can significantly change the behavior of the method. Setting them correctly will lead to use the actual DER, otherwise it will be a modified version that tries to stick as close as possible to the original one.