### PR TITLE
Allow setting prefetch_factor for multiprocessing

### DIFF
--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -590,6 +590,8 @@ def _make_data_loader(
         data_loader_args['num_workers'] = 0
         if 'persistent_workers' in data_loader_args:
             data_loader_args['persistent_workers'] = False
+        if 'prefetch_factor' in data_loader_args:
+            data_loader_args['prefetch_factor'] = 2
 
     if _DistributedHelper.is_distributed and distributed_sampling:
         sampler = DistributedSampler(


### PR DESCRIPTION
Hello,
setting prefetch_factor to anything else than 2 caused the program to crash during length estimation of the dataset.