### PR TITLE
fixed mir unused subsample argument

### DIFF
--- a/avalanche/training/plugins/mir.py
+++ b/avalanche/training/plugins/mir.py
@@ -128,9 +128,8 @@ class MIRPlugin(SupervisedPlugin):
             self.replay_loader = cycle(
                 torch.utils.data.DataLoader(
                     buffer,
-                    batch_size=self.batch_size_mem,
+                    batch_size=self.subsample,
                     shuffle=True,
-                    drop_last=True,
                 )
             )
         else:


### PR DESCRIPTION
Maybe wait before merging since this is linked to issue #1340 and @HamedHemati also reported a huge slowdown. If I find out where it comes from we might fix it also in this PR.