### PR TITLE
Refactor CLEAR Benchmark based on the official webpage

### DIFF
--- a/avalanche/benchmarks/datasets/clear/clear.py
+++ b/avalanche/benchmarks/datasets/clear/clear.py
@@ -26,12 +26,14 @@ from avalanche.benchmarks.datasets import (
 from avalanche.benchmarks.utils import default_flist_reader
 from avalanche.benchmarks.datasets.clear import clear_data
 
-_CLEAR_DATA_SPLITS = {"clear10", "clear100", "clear10_neurips2021", "clear100_cvpr2022"}
+_CLEAR_DATA_SPLITS = {"clear10", "clear100", 
+        "clear10_neurips2021", "clear100_cvpr2022"}
 
 CLEAR_FEATURE_TYPES = {
     "clear10": ["moco_b0"],
     "clear100": ["moco_b0"],
-    "clear10_neurips2021": ["moco_b0", "moco_imagenet", "byol_imagenet", "imagenet"],
+    "clear10_neurips2021": ["moco_b0", 
+        "moco_imagenet", "byol_imagenet", "imagenet"],
     "clear100_cvpr2022": ["moco_b0"],
 }
 
@@ -92,7 +94,6 @@ class CLEARDataset(DownloadableDataset):
             filepath = self.root / name
             os.system(f"wget -P {str(self.root)} {url}")
             self._extract_archive(filepath, remove_archive=True)
-
 
     def _load_metadata(self) -> bool:
         print("LOAD")
@@ -175,7 +176,7 @@ class CLEARDataset(DownloadableDataset):
             for img_path, _ in self.samples:
                 path = self.root / img_path
                 if not os.path.exists(path):
-                    print(f"{path} does not exist. Files not properly extracted?")
+                    print(f"{path} does not exist.")
                     return False
             return True
 
@@ -499,7 +500,6 @@ class _CLEARFeature(CLEARDataset):
             print("CLEAR has not yet been downloaded")
             return False
         
-        
         self.tensors_and_targets = []
         splits = ["test", "train"] if self.split == "all" else [self.split]
         for split in splits:
@@ -569,7 +569,8 @@ if __name__ == "__main__":
             normalize,
         ]
     )
-    data_names = ["clear10_neurips2021", "clear100_cvpr2022", "clear10", "clear100"]
+    data_names = ["clear10_neurips2021", "clear100_cvpr2022", 
+            "clear10", "clear100"]
     for data_name in data_names:
         root = f"../avalanche_datasets/{data_name}"
         print(root)
@@ -611,7 +612,8 @@ if __name__ == "__main__":
             split="train",
             seed=0,
         )
-        print("clear10 size (train features): ", len(clear_dataset_train_feature))
+        print("clear10 size (train features): ", 
+                len(clear_dataset_train_feature))
         if '_' in data_name:
             clear_dataset_all_feature = _CLEARFeature(
                 root=root,
@@ -629,8 +631,10 @@ if __name__ == "__main__":
                 split="test",
                 seed=0,
             )
-            print(f"{data_name} size (test features): ", len(clear_dataset_test_feature))
-            print(f"{data_name} size (all features): ", len(clear_dataset_all_feature))
+            print(f"{data_name} size (test features): ", 
+                    len(clear_dataset_test_feature))
+            print(f"{data_name} size (all features): ", 
+                    len(clear_dataset_all_feature))
         print("Classes are: ")
         for i, name in enumerate(clear_dataset_test.class_names):
             print(f"{i} : {name}")

--- a/avalanche/benchmarks/datasets/clear/clear.py
+++ b/avalanche/benchmarks/datasets/clear/clear.py
@@ -26,11 +26,11 @@ from avalanche.benchmarks.datasets import (
 from avalanche.benchmarks.utils import default_flist_reader
 from avalanche.benchmarks.datasets.clear import clear_data
 
-_CLEAR_DATA_SPLITS = {"clear10", "clear100_cvpr2022"}
+_CLEAR_DATA_SPLITS = {"clear10", "clear100"}
 
 CLEAR_FEATURE_TYPES = {
-    "clear10": ["moco_b0", "moco_imagenet", "byol_imagenet", "imagenet"],
-    "clear100_cvpr2022": ["moco_b0"],
+    "clear10": ["moco_b0"],
+    "clear100": ["moco_b0"],
 }
 
 SPLIT_OPTIONS = ["all", "train", "test"]
@@ -322,9 +322,6 @@ class _CLEARFeature(CLEARDataset):
         :param feature_type: The type of features.
             For CLEAR10, choose from [
                 'moco_b0', # Moco V2 ResNet50 pretrained on bucket 0
-                'moco_imagenet', # Moco V2 ResNet50 pretrained on Imagenet
-                'byol_imagenet', # BYOL ResNet50 pretrained on Imagenet
-                'imagenet', # ResNet50 pretrained on Imagenet
             ]
         :param target_transform: The transformations to apply to the Y values.
         """

--- a/avalanche/benchmarks/datasets/clear/clear.py
+++ b/avalanche/benchmarks/datasets/clear/clear.py
@@ -96,7 +96,6 @@ class CLEARDataset(DownloadableDataset):
             self._extract_archive(filepath, remove_archive=True)
 
     def _load_metadata(self) -> bool:
-        print("LOAD")
         if '_' in self.data_name:
             return self._load_metadata_old()
         else:

--- a/avalanche/benchmarks/datasets/clear/clear.py
+++ b/avalanche/benchmarks/datasets/clear/clear.py
@@ -27,13 +27,13 @@ from avalanche.benchmarks.utils import default_flist_reader
 from avalanche.benchmarks.datasets.clear import clear_data
 
 _CLEAR_DATA_SPLITS = {"clear10", "clear100", 
-        "clear10_neurips2021", "clear100_cvpr2022"}
+                      "clear10_neurips2021", "clear100_cvpr2022"}
 
 CLEAR_FEATURE_TYPES = {
     "clear10": ["moco_b0"],
     "clear100": ["moco_b0"],
     "clear10_neurips2021": ["moco_b0", 
-        "moco_imagenet", "byol_imagenet", "imagenet"],
+                            "moco_imagenet", "byol_imagenet", "imagenet"],
     "clear100_cvpr2022": ["moco_b0"],
 }
 
@@ -570,7 +570,7 @@ if __name__ == "__main__":
         ]
     )
     data_names = ["clear10_neurips2021", "clear100_cvpr2022", 
-            "clear10", "clear100"]
+                  "clear10", "clear100"]
     for data_name in data_names:
         root = f"../avalanche_datasets/{data_name}"
         print(root)
@@ -613,7 +613,7 @@ if __name__ == "__main__":
             seed=0,
         )
         print("clear10 size (train features): ", 
-                len(clear_dataset_train_feature))
+              len(clear_dataset_train_feature))
         if '_' in data_name:
             clear_dataset_all_feature = _CLEARFeature(
                 root=root,
@@ -632,9 +632,9 @@ if __name__ == "__main__":
                 seed=0,
             )
             print(f"{data_name} size (test features): ", 
-                    len(clear_dataset_test_feature))
+                  len(clear_dataset_test_feature))
             print(f"{data_name} size (all features): ", 
-                    len(clear_dataset_all_feature))
+                  len(clear_dataset_all_feature))
         print("Classes are: ")
         for i, name in enumerate(clear_dataset_test.class_names):
             print(f"{i} : {name}")

--- a/avalanche/benchmarks/datasets/clear/clear_data.py
+++ b/avalanche/benchmarks/datasets/clear/clear_data.py
@@ -30,5 +30,18 @@ clear100 = [
         "https://clear-challenge.s3.us-east-2.amazonaws.com",
     )
 ]
+clear10_neurips2021= [
+    (
+        "clear10-public.zip",  # name
+        "https://clear-challenge.s3.us-east-2.amazonaws.com",
+    )
+]
+clear100_cvpr2022 = [
+    (
+        "clear100-workshop-avalanche.zip",  # name
+        "https://clear-challenge.s3.us-east-2.amazonaws.com",
+    )
+]
 
-__all__ = ["clear10", "clear100"]
+
+__all__ = ["clear10", "clear100", "clear10_neurips2021", "clear100_cvpr2022"]

--- a/avalanche/benchmarks/datasets/clear/clear_data.py
+++ b/avalanche/benchmarks/datasets/clear/clear_data.py
@@ -30,7 +30,7 @@ clear100 = [
         "https://clear-challenge.s3.us-east-2.amazonaws.com",
     )
 ]
-clear10_neurips2021= [
+clear10_neurips2021 = [
     (
         "clear10-public.zip",  # name
         "https://clear-challenge.s3.us-east-2.amazonaws.com",

--- a/avalanche/benchmarks/datasets/clear/clear_data.py
+++ b/avalanche/benchmarks/datasets/clear/clear_data.py
@@ -20,7 +20,7 @@ clear10 = [
         "https://clear-challenge.s3.us-east-2.amazonaws.com",
     )
 ]
-clear100_cvpr2022 = [
+clear100 = [
     (
         "clear100-train.zip",  # name
         "https://clear-challenge.s3.us-east-2.amazonaws.com",
@@ -31,4 +31,4 @@ clear100_cvpr2022 = [
     )
 ]
 
-__all__ = ["clear10", "clear100_cvpr2022"]
+__all__ = ["clear10", "clear100"]

--- a/avalanche/benchmarks/datasets/clear/clear_data.py
+++ b/avalanche/benchmarks/datasets/clear/clear_data.py
@@ -12,13 +12,21 @@
 """ CLEAR data """
 clear10 = [
     (
-        "clear10-public.zip",  # name
+        "clear10-train.zip",  # name
+        "https://clear-challenge.s3.us-east-2.amazonaws.com",
+    ),
+    (
+        "clear10-test.zip",  # name
         "https://clear-challenge.s3.us-east-2.amazonaws.com",
     )
 ]
 clear100_cvpr2022 = [
     (
-        "clear100-workshop-avalanche.zip",  # name
+        "clear100-train.zip",  # name
+        "https://clear-challenge.s3.us-east-2.amazonaws.com",
+    ),
+    (
+        "clear100-test.zip",  # name
         "https://clear-challenge.s3.us-east-2.amazonaws.com",
     )
 ]

--- a/examples/clear.py
+++ b/examples/clear.py
@@ -188,7 +188,7 @@ def main():
     for train_idx in range(num_timestamp):
         for test_idx in range(num_timestamp):
             accuracy_matrix[train_idx][test_idx] = results[train_idx][
-                f"Top1_Acc_Stream/eval_phase/test_stream/Task00{test_idx}"
+                f"Top1_Acc_Stream/eval_phase/test_stream/Task00{test_idx}/Exp00{test_idx}"
             ]
     print("Accuracy_matrix : ")
     print(accuracy_matrix)

--- a/examples/clear.py
+++ b/examples/clear.py
@@ -188,7 +188,7 @@ def main():
     for train_idx in range(num_timestamp):
         for test_idx in range(num_timestamp):
             accuracy_matrix[train_idx][test_idx] = results[train_idx][
-                f"Top1_Acc_Stream/eval_phase/test_stream/Task00{test_idx}/Exp00{test_idx}"
+             f"Top1_Acc_Stream/eval_phase/test_stream/Task00{test_idx}/Exp00{test_idx}"
             ]
     print("Accuracy_matrix : ")
     print(accuracy_matrix)

--- a/examples/clear.py
+++ b/examples/clear.py
@@ -188,7 +188,7 @@ def main():
     for train_idx in range(num_timestamp):
         for test_idx in range(num_timestamp):
             accuracy_matrix[train_idx][test_idx] = results[train_idx][
-                f"Top1_Acc_Stream/eval_phase/test_stream" \
+                f"Top1_Acc_Stream/eval_phase/test_stream"
                 f"/Task00{test_idx}/Exp00{test_idx}"
             ]
     print("Accuracy_matrix : ")

--- a/examples/clear.py
+++ b/examples/clear.py
@@ -38,7 +38,8 @@ from avalanche.benchmarks.classic.clear import CLEAR, CLEARMetric
 
 # For CLEAR dataset setup
 DATASET_NAME = "clear100_cvpr2022"
-NUM_CLASSES = {"clear10": 11, "clear100_cvpr2022": 100}
+NUM_CLASSES = {"clear10_neurips_2021": 11, "clear100_cvpr2022": 100,
+               "clear10": 11, "clear100": 100}
 assert DATASET_NAME in NUM_CLASSES.keys()
 
 # please refer to paper for discussion on streaming v.s. iid protocol

--- a/examples/clear.py
+++ b/examples/clear.py
@@ -188,8 +188,8 @@ def main():
     for train_idx in range(num_timestamp):
         for test_idx in range(num_timestamp):
             accuracy_matrix[train_idx][test_idx] = results[train_idx][
-             f"Top1_Acc_Stream/eval_phase/test_stream/" \
-                f"Task00{test_idx}/Exp00{test_idx}"
+                f"Top1_Acc_Stream/eval_phase/test_stream" \
+                f"/Task00{test_idx}/Exp00{test_idx}"
             ]
     print("Accuracy_matrix : ")
     print(accuracy_matrix)

--- a/examples/clear.py
+++ b/examples/clear.py
@@ -188,7 +188,8 @@ def main():
     for train_idx in range(num_timestamp):
         for test_idx in range(num_timestamp):
             accuracy_matrix[train_idx][test_idx] = results[train_idx][
-             f"Top1_Acc_Stream/eval_phase/test_stream/Task00{test_idx}/Exp00{test_idx}"
+             f"Top1_Acc_Stream/eval_phase/test_stream/" \
+                f"Task00{test_idx}/Exp00{test_idx}"
             ]
     print("Accuracy_matrix : ")
     print(accuracy_matrix)

--- a/examples/clear_linear.py
+++ b/examples/clear_linear.py
@@ -166,7 +166,8 @@ def main():
     accuracy_matrix = np.zeros((num_timestamp, num_timestamp))
     for train_idx in range(num_timestamp):
         for test_idx in range(num_timestamp):
-            mname = f'Top1_Acc_Exp/eval_phase/test_stream/Task00{test_idx}/Exp00{test_idx}'
+            mname = f'Top1_Acc_Exp/eval_phase/test_stream' \
+                    f'/Task00{test_idx}/Exp00{test_idx}'
             accuracy_matrix[train_idx][test_idx] = results[train_idx][mname]
     print("Accuracy_matrix : ")
     print(accuracy_matrix)

--- a/examples/clear_linear.py
+++ b/examples/clear_linear.py
@@ -109,6 +109,7 @@ def main():
         seed = 0
 
     benchmark = CLEAR(
+        data_name=DATASET_NAME,
         evaluation_protocol=EVALUATION_PROTOCOL,
         feature_type=CLEAR_FEATURE_TYPE,
         seed=seed,

--- a/examples/clear_linear.py
+++ b/examples/clear_linear.py
@@ -166,8 +166,8 @@ def main():
     accuracy_matrix = np.zeros((num_timestamp, num_timestamp))
     for train_idx in range(num_timestamp):
         for test_idx in range(num_timestamp):
-            mname = f'Top1_Acc_Exp/eval_phase/test_stream' \
-                    f'/Task00{test_idx}/Exp00{test_idx}'
+            mname = f"Top1_Acc_Exp/eval_phase/test_stream" \
+                    f"/Task00{test_idx}/Exp00{test_idx}"
             accuracy_matrix[train_idx][test_idx] = results[train_idx][mname]
     print("Accuracy_matrix : ")
     print(accuracy_matrix)

--- a/examples/clear_linear.py
+++ b/examples/clear_linear.py
@@ -166,7 +166,7 @@ def main():
     accuracy_matrix = np.zeros((num_timestamp, num_timestamp))
     for train_idx in range(num_timestamp):
         for test_idx in range(num_timestamp):
-            mname = f'Top1_Acc_Exp/eval_phase/test_stream/Exp00{test_idx}'
+            mname = f'Top1_Acc_Exp/eval_phase/test_stream/Task00{test_idx}/Exp00{test_idx}'
             accuracy_matrix[train_idx][test_idx] = results[train_idx][mname]
     print("Accuracy_matrix : ")
     print(accuracy_matrix)

--- a/examples/clear_linear.py
+++ b/examples/clear_linear.py
@@ -36,8 +36,9 @@ from avalanche.training.supervised import Naive
 from avalanche.benchmarks.classic.clear import CLEAR, CLEARMetric
 
 # For CLEAR dataset setup
-DATASET_NAME = "clear10"
-NUM_CLASSES = {"clear10": 11}
+DATASET_NAME = "clear10_neurips2021"
+NUM_CLASSES = {"clear10_neurips_2021": 11, "clear100_cvpr2022": 100,
+               "clear10": 11, "clear100": 100}
 CLEAR_FEATURE_TYPE = "moco_b0"  # MoCo V2 pretrained on bucket 0
 # CLEAR_FEATURE_TYPE = "moco_imagenet"  # MoCo V2 pretrained on imagenet
 # CLEAR_FEATURE_TYPE = "byol_imagenet"  # BYOL pretrained on imagenet


### PR DESCRIPTION
According to the [CLEAR official wiki](https://linzhiqiu.gitbook.io/the-clear-benchmark/documentation/download-clear-10-clear-100), the download path is slightly changed although the previous one is still working now. Moreover, they removed other features except moco_b0. I changed it accordingly.