### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ csvlogs/
 docs/generated/
 .fleet
 pip-wheel-metadata
+**/.DS_Store


### PR DESCRIPTION
Minor update: adds .DS_Store metafiles on macOS to `.gitignore`. You have them inside every folder. Adding them to the ignore list makes tracking changes easier. 