### PR TITLE
Forward class_id_from_zero_in_each_exp to nc_benchmark in classical benchmarks

### DIFF
--- a/avalanche/benchmarks/classic/ccifar10.py
+++ b/avalanche/benchmarks/classic/ccifar10.py
@@ -51,6 +51,7 @@ def SplitCIFAR10(
     fixed_class_order: Optional[Sequence[int]] = None,
     shuffle: bool = True,
     class_ids_from_zero_in_each_exp: bool = False,
+    class_ids_from_zero_from_first_exp: bool = False,
     train_transform: Optional[Any] = _default_cifar10_train_transform,
     eval_transform: Optional[Any] = _default_cifar10_eval_transform,
     dataset_root: Optional[Union[str, Path]] = None
@@ -104,6 +105,17 @@ def SplitCIFAR10(
         will be mapped to range [0, n_classes_in_exp) for each experience.
         Defaults to False. Mutually exclusive with the
         ``class_ids_from_zero_from_first_exp`` parameter.
+    :param class_ids_from_zero_from_first_exp: If True, original class IDs
+        will be remapped so that they will appear as having an ascending
+        order. For instance, if the resulting class order after shuffling
+        (or defined by fixed_class_order) is [23, 34, 11, 7, 6, ...] and
+        class_ids_from_zero_from_first_exp is True, then all the patterns
+        belonging to class 23 will appear as belonging to class "0",
+        class "34" will be mapped to "1", class "11" to "2" and so on.
+        This is very useful when drawing confusion matrices and when dealing
+        with algorithms with dynamic head expansion. Defaults to False.
+        Mutually exclusive with the ``class_ids_from_zero_in_each_exp``
+        parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -133,6 +145,7 @@ def SplitCIFAR10(
         shuffle=shuffle,
         per_exp_classes={0: 5} if first_exp_with_half_classes else None,
         class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/ccifar100.py
+++ b/avalanche/benchmarks/classic/ccifar100.py
@@ -56,6 +56,7 @@ def SplitCIFAR100(
     fixed_class_order: Optional[Sequence[int]] = None,
     shuffle: bool = True,
     class_ids_from_zero_in_each_exp: bool = False,
+    class_ids_from_zero_from_first_exp: bool = False,
     train_transform: Optional[Any] = _default_cifar100_train_transform,
     eval_transform: Optional[Any] = _default_cifar100_eval_transform,
     dataset_root: Optional[Union[str, Path]] = None
@@ -109,6 +110,17 @@ def SplitCIFAR100(
         will be mapped to range [0, n_classes_in_exp) for each experience.
         Defaults to False. Mutually exclusive with the
         ``class_ids_from_zero_from_first_exp`` parameter.
+    :param class_ids_from_zero_from_first_exp: If True, original class IDs
+        will be remapped so that they will appear as having an ascending
+        order. For instance, if the resulting class order after shuffling
+        (or defined by fixed_class_order) is [23, 34, 11, 7, 6, ...] and
+        class_ids_from_zero_from_first_exp is True, then all the patterns
+        belonging to class 23 will appear as belonging to class "0",
+        class "34" will be mapped to "1", class "11" to "2" and so on.
+        This is very useful when drawing confusion matrices and when dealing
+        with algorithms with dynamic head expansion. Defaults to False.
+        Mutually exclusive with the ``class_ids_from_zero_in_each_exp``
+        parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -138,6 +150,7 @@ def SplitCIFAR100(
         shuffle=shuffle,
         per_exp_classes={0: 50} if first_exp_with_half_classes else None,
         class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )
@@ -148,6 +161,7 @@ def SplitCIFAR110(
     *,
     seed: Optional[int] = None,
     fixed_class_order: Optional[Sequence[int]] = None,
+    class_ids_from_zero_from_first_exp: bool = False,
     train_transform: Optional[Any] = _default_cifar100_train_transform,
     eval_transform: Optional[Any] = _default_cifar100_eval_transform,
     dataset_root_cifar10: Optional[Union[str, Path]] = None,
@@ -192,6 +206,17 @@ def SplitCIFAR110(
         If None, value of ``seed`` will be used to define the class order for
         the incremental batches on cifar100. If non-None, ``seed`` parameter
         will be ignored. Defaults to None.
+    :param class_ids_from_zero_from_first_exp: If True, original class IDs
+        will be remapped so that they will appear as having an ascending
+        order. For instance, if the resulting class order after shuffling
+        (or defined by fixed_class_order) is [23, 34, 11, 7, 6, ...] and
+        class_ids_from_zero_from_first_exp is True, then all the patterns
+        belonging to class 23 will appear as belonging to class "0",
+        class "34" will be mapped to "1", class "11" to "2" and so on.
+        This is very useful when drawing confusion matrices and when dealing
+        with algorithms with dynamic head expansion. Defaults to False.
+        Mutually exclusive with the ``class_ids_from_zero_in_each_exp``
+        parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -242,6 +267,7 @@ def SplitCIFAR110(
         shuffle=False,
         seed=None,
         fixed_class_order=class_order,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         per_exp_classes={0: 10},
         train_transform=train_transform,
         eval_transform=eval_transform,

--- a/avalanche/benchmarks/classic/ccub200.py
+++ b/avalanche/benchmarks/classic/ccub200.py
@@ -51,6 +51,7 @@ def SplitCUB200(
     fixed_class_order=None,
     shuffle=False,
     class_ids_from_zero_in_each_exp: bool = False,
+    class_ids_from_zero_from_first_exp: bool = False,
     train_transform: Optional[Any] = _default_train_transform,
     eval_transform: Optional[Any] = _default_eval_transform,
     dataset_root: Optional[Union[str, Path]] = None
@@ -99,6 +100,17 @@ def SplitCUB200(
         will be mapped to range [0, n_classes_in_exp) for each experience.
         Defaults to False. Mutually exclusive with the
         ``class_ids_from_zero_from_first_exp`` parameter.
+    :param class_ids_from_zero_from_first_exp: If True, original class IDs
+        will be remapped so that they will appear as having an ascending
+        order. For instance, if the resulting class order after shuffling
+        (or defined by fixed_class_order) is [23, 34, 11, 7, 6, ...] and
+        class_ids_from_zero_from_first_exp is True, then all the patterns
+        belonging to class 23 will appear as belonging to class "0",
+        class "34" will be mapped to "1", class "11" to "2" and so on.
+        This is very useful when drawing confusion matrices and when dealing
+        with algorithms with dynamic head expansion. Defaults to False.
+        Mutually exclusive with the ``class_ids_from_zero_in_each_exp``
+        parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -136,6 +148,7 @@ def SplitCUB200(
         shuffle=shuffle,
         one_dataset_per_exp=True,
         class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/cfashion_mnist.py
+++ b/avalanche/benchmarks/classic/cfashion_mnist.py
@@ -40,6 +40,7 @@ def SplitFMNIST(
     fixed_class_order: Optional[Sequence[int]] = None,
     shuffle: bool = True,
     class_ids_from_zero_in_each_exp: bool = False,
+    class_ids_from_zero_from_first_exp: bool = False,
     train_transform: Optional[Any] = _default_fmnist_train_transform,
     eval_transform: Optional[Any] = _default_fmnist_eval_transform,
     dataset_root: Optional[Union[str, Path]] = None
@@ -96,6 +97,17 @@ def SplitFMNIST(
         will be mapped to range [0, n_classes_in_exp) for each experience.
         Defaults to False. Mutually exclusive with the
         ``class_ids_from_zero_from_first_exp`` parameter.
+    :param class_ids_from_zero_from_first_exp: If True, original class IDs
+        will be remapped so that they will appear as having an ascending
+        order. For instance, if the resulting class order after shuffling
+        (or defined by fixed_class_order) is [23, 34, 11, 7, 6, ...] and
+        class_ids_from_zero_from_first_exp is True, then all the patterns
+        belonging to class 23 will appear as belonging to class "0",
+        class "34" will be mapped to "1", class "11" to "2" and so on.
+        This is very useful when drawing confusion matrices and when dealing
+        with algorithms with dynamic head expansion. Defaults to False.
+        Mutually exclusive with the ``class_ids_from_zero_in_each_exp``
+        parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -126,6 +138,7 @@ def SplitFMNIST(
         shuffle=shuffle,
         per_exp_classes={0: 5} if first_batch_with_half_classes else None,
         class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/cimagenet.py
+++ b/avalanche/benchmarks/classic/cimagenet.py
@@ -52,6 +52,7 @@ def SplitImageNet(
     fixed_class_order=None,
     shuffle: bool = True,
     class_ids_from_zero_in_each_exp: bool = False,
+    class_ids_from_zero_from_first_exp: bool = False,
     train_transform: Optional[Any] = _default_train_transform,
     eval_transform: Optional[Any] = _default_eval_transform
 ):
@@ -108,6 +109,17 @@ def SplitImageNet(
         will be mapped to range [0, n_classes_in_exp) for each experience.
         Defaults to False. Mutually exclusive with the
         ``class_ids_from_zero_from_first_exp`` parameter.
+    :param class_ids_from_zero_from_first_exp: If True, original class IDs
+        will be remapped so that they will appear as having an ascending
+        order. For instance, if the resulting class order after shuffling
+        (or defined by fixed_class_order) is [23, 34, 11, 7, 6, ...] and
+        class_ids_from_zero_from_first_exp is True, then all the patterns
+        belonging to class 23 will appear as belonging to class "0",
+        class "34" will be mapped to "1", class "11" to "2" and so on.
+        This is very useful when drawing confusion matrices and when dealing
+        with algorithms with dynamic head expansion. Defaults to False.
+        Mutually exclusive with the ``class_ids_from_zero_in_each_exp``
+        parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -136,6 +148,7 @@ def SplitImageNet(
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
         class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/cinaturalist.py
+++ b/avalanche/benchmarks/classic/cinaturalist.py
@@ -52,6 +52,7 @@ def SplitInaturalist(
     download=False,
     seed=0,
     class_ids_from_zero_in_each_exp: bool = False,
+    class_ids_from_zero_from_first_exp: bool = False,
     train_transform: Optional[Any] = _default_train_transform,
     eval_transform: Optional[Any] = _default_eval_transform,
     dataset_root: Optional[Union[str, Path]] = None
@@ -110,6 +111,17 @@ def SplitInaturalist(
         will be mapped to range [0, n_classes_in_exp) for each experience.
         Defaults to False. Mutually exclusive with the
         ``class_ids_from_zero_from_first_exp`` parameter.
+    :param class_ids_from_zero_from_first_exp: If True, original class IDs
+        will be remapped so that they will appear as having an ascending
+        order. For instance, if the resulting class order after shuffling
+        (or defined by fixed_class_order) is [23, 34, 11, 7, 6, ...] and
+        class_ids_from_zero_from_first_exp is True, then all the patterns
+        belonging to class 23 will appear as belonging to class "0",
+        class "34" will be mapped to "1", class "11" to "2" and so on.
+        This is very useful when drawing confusion matrices and when dealing
+        with algorithms with dynamic head expansion. Defaults to False.
+        Mutually exclusive with the ``class_ids_from_zero_in_each_exp``
+        parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -158,6 +170,7 @@ def SplitInaturalist(
         task_labels=return_task_id,
         seed=seed,
         class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/cmnist.py
+++ b/avalanche/benchmarks/classic/cmnist.py
@@ -83,6 +83,7 @@ def SplitMNIST(
     fixed_class_order: Optional[Sequence[int]] = None,
     shuffle: bool = True,
     class_ids_from_zero_in_each_exp: bool = False,
+    class_ids_from_zero_from_first_exp: bool = False,
     train_transform: Optional[Any] = _default_mnist_train_transform,
     eval_transform: Optional[Any] = _default_mnist_eval_transform,
     dataset_root: Optional[Union[str, Path]] = None
@@ -159,6 +160,7 @@ def SplitMNIST(
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
         class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/comniglot.py
+++ b/avalanche/benchmarks/classic/comniglot.py
@@ -74,6 +74,7 @@ def SplitAlphabetOmniglot(
     return_task_id=False,
     seed: Optional[int] = None,
     fixed_class_order: Optional[Sequence[int]] = None,
+    class_ids_from_zero_from_first_exp: bool = False,
     shuffle: bool = True,
     train_transform: Optional[Any] = _default_omniglot_train_transform,
     eval_transform: Optional[Any] = _default_omniglot_eval_transform,
@@ -101,6 +102,17 @@ def SplitAlphabetOmniglot(
         order. If None, value of ``seed`` will be used to define the class
         order. If non-None, ``seed`` parameter will be ignored.
         Defaults to None.
+    :param class_ids_from_zero_from_first_exp: If True, original class IDs
+        will be remapped so that they will appear as having an ascending
+        order. For instance, if the resulting class order after shuffling
+        (or defined by fixed_class_order) is [23, 34, 11, 7, 6, ...] and
+        class_ids_from_zero_from_first_exp is True, then all the patterns
+        belonging to class 23 will appear as belonging to class "0",
+        class "34" will be mapped to "1", class "11" to "2" and so on.
+        This is very useful when drawing confusion matrices and when dealing
+        with algorithms with dynamic head expansion. Defaults to False.
+        Mutually exclusive with the ``class_ids_from_zero_in_each_exp``
+        parameter.
     :param shuffle: If true, the class order in the incremental experiences is
         randomly shuffled. Default to True.
     :param train_transform: The transformation to apply to the training data,
@@ -131,6 +143,7 @@ def SplitAlphabetOmniglot(
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
         class_ids_from_zero_in_each_exp=False,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )
@@ -144,6 +157,7 @@ def SplitOmniglot(
     fixed_class_order: Optional[Sequence[int]] = None,
     shuffle: bool = True,
     class_ids_from_zero_in_each_exp: bool = False,
+    class_ids_from_zero_from_first_exp: bool = False,
     train_transform: Optional[Any] = _default_omniglot_train_transform,
     eval_transform: Optional[Any] = _default_omniglot_eval_transform,
     dataset_root: Optional[Union[str, Path]] = None
@@ -193,6 +207,17 @@ def SplitOmniglot(
         will be mapped to range [0, n_classes_in_exp) for each experience.
         Defaults to False. Mutually exclusive with the
         ``class_ids_from_zero_from_first_exp`` parameter.
+    :param class_ids_from_zero_from_first_exp: If True, original class IDs
+        will be remapped so that they will appear as having an ascending
+        order. For instance, if the resulting class order after shuffling
+        (or defined by fixed_class_order) is [23, 34, 11, 7, 6, ...] and
+        class_ids_from_zero_from_first_exp is True, then all the patterns
+        belonging to class 23 will appear as belonging to class "0",
+        class "34" will be mapped to "1", class "11" to "2" and so on.
+        This is very useful when drawing confusion matrices and when dealing
+        with algorithms with dynamic head expansion. Defaults to False.
+        Mutually exclusive with the ``class_ids_from_zero_in_each_exp``
+        parameter.
     :param train_transform: The transformation to apply to the training data,
         e.g. a random crop, a normalization or a concatenation of different
         transformations (see torchvision.transform documentation for a
@@ -221,6 +246,7 @@ def SplitOmniglot(
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
         class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )

--- a/avalanche/benchmarks/classic/ctiny_imagenet.py
+++ b/avalanche/benchmarks/classic/ctiny_imagenet.py
@@ -48,6 +48,7 @@ def SplitTinyImageNet(
     fixed_class_order=None,
     shuffle: bool = True,
     class_ids_from_zero_in_each_exp: bool = False,
+    class_ids_from_zero_from_first_exp: bool = False,
     train_transform: Optional[Any] = _default_train_transform,
     eval_transform: Optional[Any] = _default_eval_transform,
     dataset_root: Optional[Union[str, Path]] = None
@@ -123,6 +124,7 @@ def SplitTinyImageNet(
         fixed_class_order=fixed_class_order,
         shuffle=shuffle,
         class_ids_from_zero_in_each_exp=class_ids_from_zero_in_each_exp,
+        class_ids_from_zero_from_first_exp=class_ids_from_zero_from_first_exp,
         train_transform=train_transform,
         eval_transform=eval_transform,
     )


### PR DESCRIPTION
A small fix so that we can forward this option to the benchmark creation. It was not the case yet.