### PR TITLE
Fix issue #1371

### DIFF
--- a/tests/test_high_level_generators.py
+++ b/tests/test_high_level_generators.py
@@ -500,6 +500,12 @@ class HighLevelGeneratorTests(unittest.TestCase):
         self.assertTrue(torch.equal(test_x, mb[0]))
         self.assertTrue(torch.equal(test_y, mb[1]))
 
+        # Regression test for #1371
+        self.assertEquals(
+            [0],
+            valid_benchmark.train_stream[0].classes_in_this_experience
+        )
+
     def test_lazy_benchmark_with_validation_stream_fixed_size(self):
         lazy_options = [None, True, False]
         for lazy_option in lazy_options:


### PR DESCRIPTION
The recent typing fixes switched the factory validation and data incremental generators to a generic DatasetScenario, which is problem-agnostic. With this PR, we try to return a benchmark of the same class of the input benchmark, allowing experiences to be created with the correct fields.

Fixes #1371 