### PR TITLE
Add a variable to control whether to retain the graph or not in the backward pass

### DIFF
--- a/avalanche/training/templates/base_sgd.py
+++ b/avalanche/training/templates/base_sgd.py
@@ -114,6 +114,9 @@ class BaseSGDTemplate(
         )
         """ Eval mini-batch size. """
 
+        self.retain_graph: bool = False
+        """ Retain graph when calling loss.backward(). """
+
         if evaluator is None:
             evaluator = EvaluationPlugin()
         elif callable(evaluator):
@@ -220,7 +223,7 @@ class BaseSGDTemplate(
 
     def backward(self):
         """Run the backward pass."""
-        self.loss.backward()
+        self.loss.backward(retain_graph=self.retain_graph)
 
     def optimizer_step(self):
         """Execute the optimizer step (weights update)."""


### PR DESCRIPTION
With the addition of this variable, you can decide to keep the graph by setting `strategy.retain_graph = True` so that plugins can do their own backward pass after to the one triggered automatically without having to execute the forward pass again.

Unsatisfactory alternatives:
- subclass BaseSGDTemplate and change the implementation of its `backward()` method
- monkey patch the `backward()` method
- call `strategy.forward()` each time a second backward pass has to be made in the same iteration

Note that perhaps the name of this variable should be changed to something else.