### PR TITLE
FIX: Make optimizer now changes optimized_param_id in place

### DIFF
--- a/avalanche/training/supervised/expert_gate.py
+++ b/avalanche/training/supervised/expert_gate.py
@@ -179,7 +179,12 @@ class _ExpertGatePlugin(SupervisedPlugin):
         strategy.model.expert = new_expert
 
         # Reset the optimizer for the new expert model
-        reset_optimizer(strategy.optimizer, strategy.model.expert)
+        # reset_optimizer(strategy.optimizer, strategy.model.expert)
+        # make_optimizer should be called instead of reset_optimizer
+        # It puts all parameters from strategy.model in the optimizer
+        # To freeze parameters use param.requires_grad = False 
+        # and param.grad = None
+        strategy.make_optimizer()
 
         # Remove LwF plugin in case it is not needed
         if (self.lwf_plugin in strategy.plugins):

--- a/avalanche/training/templates/observation_type/batch_observation.py
+++ b/avalanche/training/templates/observation_type/batch_observation.py
@@ -59,16 +59,16 @@ class BatchObservation(SGDStrategyProtocol):
               initially put in the optimizer.
         """
         if self.optimized_param_id is None:
-            optimized_param_id = reset_optimizer(self.optimizer, self.model) 
+            self.optimized_param_id = \
+                    reset_optimizer(self.optimizer, self.model) 
         else:
-            optimized_param_id = \
+            self.optimized_param_id = \
                 update_optimizer(
                     self.optimizer, 
                     dict(self.model.named_parameters()),
                     self.optimized_param_id, 
                     reset_state=reset_optimizer_state
                     )
-        return optimized_param_id
 
     def check_model_and_optimizer(self):
         # If strategy has access to the task boundaries, and the current
@@ -77,19 +77,16 @@ class BatchObservation(SGDStrategyProtocol):
         assert self.experience is not None
 
         if self.optimized_param_id is None:
-            self.optimized_param_id = \
-                self.make_optimizer(reset_optimizer_state=True)
+            self.make_optimizer(reset_optimizer_state=True)
 
         if isinstance(self.experience, OnlineCLExperience):
             if self.experience.access_task_boundaries:
                 if self.experience.is_first_subexp:
                     self.model = self.model_adaptation()
-                    self.optimized_param_id = \
-                        self.make_optimizer(reset_optimizer_state=False)
+                    self.make_optimizer(reset_optimizer_state=False)
         else:
             self.model = self.model_adaptation()
-            self.optimized_param_id = \
-                self.make_optimizer(reset_optimizer_state=False)
+            self.make_optimizer(reset_optimizer_state=False)
 
 
 __all__ = ["BatchObservation"]


### PR DESCRIPTION
This clarifies the role of self.make_optimizer function that should be call whenever resetting the optimizer.

I now call it instead of reset_optimizer in expert gate

I also changed the make_optimizer function so that it changes the optimized_params_id in place so that the user does not have to care about them, and that the behaviour from check_model_and_optimizer is clearly separated from the one of make_optimizer (adaptation + make_optimizer but no more setting of optimized_param_id).