### PR TITLE
BugFix OnlineTemplate missing model adaptation call

### DIFF
--- a/avalanche/evaluation/metrics/cumulative_accuracies.py
+++ b/avalanche/evaluation/metrics/cumulative_accuracies.py
@@ -58,6 +58,10 @@ class CumulativeAccuracy(Metric[Dict[int, float]]):
             raise ValueError("Size mismatch for true_y " 
                              "and predicted_y tensors")
         for t, classes in classes_splits.items():
+            # This is to fix a weird bug 
+            # that was happening in some workflows
+            if t not in self._mean_accuracy:
+                self._mean_accuracy[t]
 
             # Only compute Accuracy for classes that are in classes set
             if len(set(true_y.cpu().numpy()).intersection(classes)) == 0:

--- a/avalanche/training/supervised/expert_gate.py
+++ b/avalanche/training/supervised/expert_gate.py
@@ -184,7 +184,7 @@ class _ExpertGatePlugin(SupervisedPlugin):
         # It puts all parameters from strategy.model in the optimizer
         # To freeze parameters use param.requires_grad = False 
         # and param.grad = None
-        strategy.make_optimizer()
+        strategy.make_optimizer(**kwargs)
 
         # Remove LwF plugin in case it is not needed
         if (self.lwf_plugin in strategy.plugins):

--- a/avalanche/training/templates/base_sgd.py
+++ b/avalanche/training/templates/base_sgd.py
@@ -244,7 +244,7 @@ class BaseSGDTemplate(
 
     # ==================================================================> NEW
 
-    def check_model_and_optimizer(self):
+    def check_model_and_optimizer(self, **kwargs):
         # Should be implemented in observation type
         raise NotImplementedError()
 
@@ -258,9 +258,7 @@ class BaseSGDTemplate(
         self.make_train_dataloader(**kwargs)
 
         # Model Adaptation (e.g. freeze/add new units)
-        # self.model = self.model_adaptation()
-        # self.make_optimizer()
-        self.check_model_and_optimizer()
+        self.check_model_and_optimizer(**kwargs)
 
         super()._before_training_exp(**kwargs)
 
@@ -393,6 +391,7 @@ class BaseSGDTemplate(
         shuffle=True,
         pin_memory=None,
         persistent_workers=False,
+        drop_last=False,
         **kwargs
     ):
         """Data loader initialization.
@@ -408,13 +407,15 @@ class BaseSGDTemplate(
 
         assert self.adapted_dataset is not None
 
+        torch.utils.data.DataLoader
+
         other_dataloader_args = self._obtain_common_dataloader_parameters(
             batch_size=self.train_mb_size,
             num_workers=num_workers,
             shuffle=shuffle,
             pin_memory=pin_memory,
             persistent_workers=persistent_workers,
-            **kwargs
+            drop_last=drop_last,
         )
 
         self.dataloader = TaskBalancedDataLoader(
@@ -452,7 +453,6 @@ class BaseSGDTemplate(
             pin_memory=pin_memory,
             persistent_workers=persistent_workers,
             drop_last=drop_last,
-            **kwargs
         )
 
         collate_from_data_or_kwargs(

--- a/avalanche/training/templates/observation_type/batch_observation.py
+++ b/avalanche/training/templates/observation_type/batch_observation.py
@@ -41,7 +41,7 @@ class BatchObservation(SGDStrategyProtocol):
 
         return model.to(self.device)
 
-    def make_optimizer(self, reset_optimizer_state=False):
+    def make_optimizer(self, reset_optimizer_state=False, **kwargs):
         """Optimizer initialization.
 
         Called before each training experience to configure the optimizer.
@@ -70,7 +70,7 @@ class BatchObservation(SGDStrategyProtocol):
                     reset_state=reset_optimizer_state
                     )
 
-    def check_model_and_optimizer(self):
+    def check_model_and_optimizer(self, reset_optimizer_state=False, **kwargs):
         # If strategy has access to the task boundaries, and the current
         # sub-experience is the first sub-experience in the online stream,
         # then adapt the model with the full origin experience:
@@ -83,13 +83,15 @@ class BatchObservation(SGDStrategyProtocol):
             if self.experience.access_task_boundaries:
                 if self.experience.is_first_subexp:
                     self.model = self.model_adaptation()
-                    self.make_optimizer(reset_optimizer_state=False)
+                    self.make_optimizer(
+                        reset_optimizer_state=reset_optimizer_state
+                    )
             else:
                 self.model = self.model_adaptation()
-                self.make_optimizer(reset_optimizer_state=False)
+                self.make_optimizer(reset_optimizer_state=reset_optimizer_state)
         else:
             self.model = self.model_adaptation()
-            self.make_optimizer(reset_optimizer_state=False)
+            self.make_optimizer(reset_optimizer_state=reset_optimizer_state)
 
 
 __all__ = ["BatchObservation"]

--- a/avalanche/training/templates/observation_type/batch_observation.py
+++ b/avalanche/training/templates/observation_type/batch_observation.py
@@ -84,6 +84,9 @@ class BatchObservation(SGDStrategyProtocol):
                 if self.experience.is_first_subexp:
                     self.model = self.model_adaptation()
                     self.make_optimizer(reset_optimizer_state=False)
+            else:
+                self.model = self.model_adaptation()
+                self.make_optimizer(reset_optimizer_state=False)
         else:
             self.model = self.model_adaptation()
             self.make_optimizer(reset_optimizer_state=False)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -594,26 +594,31 @@ class GeneralMetricTests(unittest.TestCase):
 
         # Test reset = 0
         metric.reset()
-        self.assertDictEqual(
-            metric.result(), {c: 0.0 for c in classes_splits}
-        )
+        expected_results = {c: 0.0 for c in classes_splits}
+        result = metric.result()
+        for id in expected_results:
+            self.assertEqual(result[id], expected_results[id])
+        metric.reset()
 
         # Test all wrong = 0
         out_wrong = torch.ones(self.batch_size, self.input_size)
         out_wrong[torch.arange(self.batch_size), self.y] = 0
         metric.update(classes_splits, out_wrong, self.y)
-        self.assertDictEqual(
-            metric.result(), {c: 0.0 for c in classes_splits}
-        )
+
+        expected_results = {c: 0.0 for c in classes_splits}
+        result = metric.result()
+        for id in expected_results:
+            self.assertEqual(result[id], expected_results[id])
         metric.reset()
 
         # Test all right = 1
         out_right = torch.zeros(self.batch_size, self.input_size)
         out_right[torch.arange(self.batch_size), self.y] = 1
         metric.update(classes_splits, out_right, self.y)
-        self.assertDictEqual(
-            metric.result(), {c: 1.0 for c in classes_splits}
-        )
+        expected_results = {c: 1.0 for c in classes_splits}
+        result = metric.result()
+        for id in expected_results:
+            self.assertEqual(result[id], expected_results[id])
         metric.reset()
         
     def test_labels_repartition(self):


### PR DESCRIPTION
When access_task_boundaries = False, the model adaptation was not called, I fixed it.

@AntonioCarta Another thing that I could fit there -> We had spoken about an option to reset the optimizer state or not. Right now by default it's False but their is no real way to change it apart when calling self.make_optimizer. Should I add this option to the SupervisedTemplate ?

Also I would like to fix the unit tests that don't pass sometimes but I'm not able to reproduce the bugs locally ...