### PR TITLE
NCM Classifier uses dictionary and can update means

### DIFF
--- a/avalanche/models/ncm_classifier.py
+++ b/avalanche/models/ncm_classifier.py
@@ -1,5 +1,6 @@
 import torch
-from torch import nn
+from torch import nn, Tensor
+from typing import Dict
 
 
 class NCMClassifier(nn.Module):
@@ -8,25 +9,39 @@ class NCMClassifier(nn.Module):
     NCMClassifier performs nearest class mean classification
     measuring the distance between the input tensor and the
     ones stored in 'self.class_means'.
+
+    Before being used for inference, NCMClassifier needs to
+    be updated with a mean vector per class, by calling
+    `update_class_means_dict`.
+
+    This class registers a `class_means` buffer that stores
+    the class means in a single tensor of shape
+    [max_class_id_seen, feature_size]. Classes with ID smaller
+    than `max_class_id_seen` are associated with a 0-vector.
     """
 
-    def __init__(self, class_means_dict={}, normalize=True):
+    def __init__(self,
+                 normalize: bool = True):
         """
-        :param class_means_dict: dictionary mapping class_id to mean vector.
-            classes must be zero-indexed.
         :param normalize: whether to normalize the input with
             2-norm = 1 before computing the distance.
         """
         super().__init__()
-        assert isinstance(class_means_dict, dict), \
-            "class_means_dict must be a dictionary mapping class_id " \
-            "to mean vector"
-        self.class_means_dict = class_means_dict
         # vectorized version of class means
-        self.class_means: torch.Tensor = None
+        self.register_buffer('class_means', None)
+        self.class_means_dict = {}
+
         self.normalize = normalize
 
-        self._vectorize_means_dict()
+    def load_state_dict(self, state_dict,
+                        strict: bool = True):
+        self.class_means = state_dict['class_means']
+        super().load_state_dict(state_dict, strict)
+        # fill dictionary
+        if self.class_means is not None:
+            for i in range(self.class_means.shape[0]):
+                if (self.class_means[i] != 0).any():
+                    self.class_means_dict[i] = self.class_means[i].clone()
 
     def _vectorize_means_dict(self):
         """
@@ -58,7 +73,7 @@ class NCMClassifier(nn.Module):
         with respect to each class.
         """
 
-        assert self.class_means_dict != {}, "empty dictionary of class means."
+        assert self.class_means is not None, "no class means available."
         if self.normalize:
             # normalize across feature_size
             x = (x.T / torch.norm(x, dim=1)).T
@@ -68,7 +83,8 @@ class NCMClassifier(nn.Module):
         # (batch_size, num_classes)
         return (-sqd).T
 
-    def update_class_means_dict(self, class_means_dict):
+    def update_class_means_dict(self,
+                                class_means_dict: Dict[int, Tensor]):
         """
         Update dictionary of class means.
         If class already exists, the average of the two mean vectors
@@ -77,6 +93,9 @@ class NCMClassifier(nn.Module):
         :param class_means_dict: a dictionary mapping class id
             to class mean tensor.
         """
+        assert isinstance(class_means_dict, dict), \
+            "class_means_dict must be a dictionary mapping class_id " \
+            "to mean vector"
         for k, v in class_means_dict.items():
             if k not in self.class_means_dict:
                 self.class_means_dict[k] = class_means_dict[k].clone()

--- a/avalanche/models/ncm_classifier.py
+++ b/avalanche/models/ncm_classifier.py
@@ -10,22 +10,82 @@ class NCMClassifier(nn.Module):
     ones stored in 'self.class_means'.
     """
 
-    def __init__(self, class_mean=None, normalize=True):
+    def __init__(self, class_means_dict={}, normalize=True):
         """
-        :param class_mean: tensor of dimension (num_classes x feature_size)
-            used to classify input patterns.
+        :param class_means_dict: dictionary mapping class_id to mean vector.
+            classes must be zero-indexed.
         :param normalize: whether to normalize the input with
             2-norm = 1 before computing the distance.
         """
         super().__init__()
-        self.class_means = class_mean
+        assert isinstance(class_means_dict, dict), \
+            "class_means_dict must be a dictionary mapping class_id " \
+            "to mean vector"
+        self.class_means_dict = class_means_dict
+        # vectorized version of class means
+        self.class_means: torch.Tensor = None
         self.normalize = normalize
 
+        self._vectorize_means_dict()
+
+    def _vectorize_means_dict(self):
+        """
+        Transform the dictionary of {class_id: mean vector}
+        into a tensor of shape (num_classes, feature_size), where
+        `feature_size` is the size of the mean vector.
+        The `num_classes` parameter is the maximum class_id found
+        in the dictionary. Missing class means are treated as zero vectors.
+        """
+        if self.class_means_dict == {}:
+            return
+
+        max_class = max(self.class_means_dict.keys()) + 1
+        first_mean = list(self.class_means_dict.values())[0]
+        feature_size = first_mean.size(0)
+        device = first_mean.device
+        self.class_means = torch.zeros(max_class, feature_size).to(device)
+
+        for k, v in self.class_means_dict.items():
+            self.class_means[k] = self.class_means_dict[k].clone()
+
+    @torch.no_grad()
     def forward(self, x):
+        """
+        :param x: (batch_size, feature_size)
+
+        Returns a tensor of size (batch_size, num_classes) with
+        negative distance of each element in the mini-batch
+        with respect to each class.
+        """
+
+        assert self.class_means_dict != {}, "empty dictionary of class means."
         if self.normalize:
-            x = (x.T / torch.norm(x.T, dim=0)).T
-        sqd = torch.cdist(self.class_means[:, :].T, x)
+            # normalize across feature_size
+            x = (x.T / torch.norm(x, dim=1)).T
+
+        # (num_classes, batch_size)
+        sqd = torch.cdist(self.class_means.to(x.device), x)
+        # (batch_size, num_classes)
         return (-sqd).T
+
+    def update_class_means_dict(self, class_means_dict):
+        """
+        Update dictionary of class means.
+        If class already exists, the average of the two mean vectors
+        will be computed.
+
+        :param class_means_dict: a dictionary mapping class id
+            to class mean tensor.
+        """
+        for k, v in class_means_dict.items():
+            if k not in self.class_means_dict:
+                self.class_means_dict[k] = class_means_dict[k].clone()
+            else:
+                device = self.class_means_dict[k].device
+                self.class_means_dict[k] += class_means_dict[k].to(device)
+                self.class_means_dict[k] /= 2
+
+        self._vectorize_means_dict()
 
 
 __all__ = ["NCMClassifier"]

--- a/avalanche/models/scr_model.py
+++ b/avalanche/models/scr_model.py
@@ -21,7 +21,7 @@ class SCRModel(nn.Module):
             of the feature extractor
         """
         super().__init__()
-        self.ncm = NCMClassifier()
+        self.ncm = NCMClassifier(normalize=False)
         self.feature_extractor = feature_extractor
         self.train_classifier = projection
         self.eval_classifier = self.ncm

--- a/avalanche/training/supervised/supervised_contrastive_replay.py
+++ b/avalanche/training/supervised/supervised_contrastive_replay.py
@@ -178,27 +178,4 @@ class SCR(SupervisedTemplate):
             class_means[label] /= float(num_els)
             class_means[label] /= class_means[label].norm()
 
-        # add new means to the eval classifier
-        # in case there are new classes, extend the eval classifier means
-        num_classes = max(class_means.keys()) + 1
-        hidden_size = class_means[num_classes-1].size(0)
-        if self.model.eval_classifier.class_means is None:
-            # first time adding means
-            means = torch.zeros(num_classes, hidden_size)
-        elif num_classes > self.model.eval_classifier.class_means.size(1):
-            # new classes discovered
-            means = torch.zeros(num_classes, hidden_size)
-            means[:self.model.eval_classifier.class_means.size(1), :] = \
-                self.model.eval_classifier.class_means.clone().cpu().T
-        else:
-            # no new classes
-            means = self.model.eval_classifier.class_means.cpu().T
-
-        for k, v in sorted(class_means.items()):
-            if (means[k] == 0).all():
-                means[k] = v.clone()
-            else:
-                means[k] = (means[k] + v) / 2.
-
-        # (H, n classes)
-        self.model.eval_classifier.class_means = means.to(self.device).T
+        self.model.eval_classifier.update_class_means_dict(class_means)

--- a/avalanche/training/templates/base_sgd.py
+++ b/avalanche/training/templates/base_sgd.py
@@ -219,7 +219,7 @@ class BaseSGDTemplate(
 
     def training_epoch(self, **kwargs):
         # Should be implemented in Update Type
-        raise NotADirectoryError()
+        raise NotImplementedError()
 
     def backward(self):
         """Run the backward pass."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -620,8 +620,8 @@ class NCMClassifierTest(unittest.TestCase):
 
         mb_y = torch.tensor([0, 2], dtype=torch.float)
 
-        classifier = NCMClassifier(class_means_dict=class_means_dict,
-                                   normalize=False)
+        classifier = NCMClassifier(normalize=False)
+        classifier.update_class_means_dict(class_means_dict)
 
         pred = classifier(mb_x)
         assert torch.all(torch.max(pred, 1)[1] == mb_y)
@@ -632,7 +632,8 @@ class NCMClassifierTest(unittest.TestCase):
             dtype=torch.float,
         )
         class_means_dict = {i: el for i, el in enumerate(class_means)}
-        classifier = NCMClassifier(class_means_dict=class_means_dict)
+        classifier = NCMClassifier()
+        classifier.update_class_means_dict(class_means_dict)
         assert classifier.class_means.shape == (3, 4)
         new_mean = torch.randn(4,)
         classifier.update_class_means_dict({5: new_mean.clone()})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -608,21 +608,38 @@ class TrainEvalModelTests(unittest.TestCase):
 class NCMClassifierTest(unittest.TestCase):
     def test_ncm_classification(self):
         class_means = torch.tensor(
-            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]],
             dtype=torch.float,
         )
+        class_means_dict = {i: el for i, el in enumerate(class_means)}
 
         mb_x = torch.tensor(
-            [[4, 3, 2, 1], [3, 4, 2, 1], [3, 2, 4, 1], [3, 2, 1, 4]],
+            [[4, 3, 2, 1], [3, 2, 4, 1]],
             dtype=torch.float,
         )
 
-        mb_y = torch.tensor([0, 1, 2, 3], dtype=torch.float)
+        mb_y = torch.tensor([0, 2], dtype=torch.float)
 
-        classifier = NCMClassifier(class_means)
+        classifier = NCMClassifier(class_means_dict=class_means_dict,
+                                   normalize=False)
 
         pred = classifier(mb_x)
         assert torch.all(torch.max(pred, 1)[1] == mb_y)
+
+    def test_ncm_class_expansion(self):
+        class_means = torch.tensor(
+            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]],
+            dtype=torch.float,
+        )
+        class_means_dict = {i: el for i, el in enumerate(class_means)}
+        classifier = NCMClassifier(class_means_dict=class_means_dict)
+        assert classifier.class_means.shape == (3, 4)
+        new_mean = torch.randn(4,)
+        classifier.update_class_means_dict({5: new_mean.clone()})
+        assert classifier.class_means.shape == (6, 4)
+        assert torch.all(classifier.class_means[3] == torch.zeros(4,))
+        assert torch.all(classifier.class_means[4] == torch.zeros(4,))
+        assert torch.all(classifier.class_means[5] == new_mean)
 
 
 class PNNTest(unittest.TestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -642,6 +642,19 @@ class NCMClassifierTest(unittest.TestCase):
         assert torch.all(classifier.class_means[4] == torch.zeros(4,))
         assert torch.all(classifier.class_means[5] == new_mean)
 
+    def test_ncm_save_load(self):
+        classifier = NCMClassifier()
+        classifier.update_class_means_dict({1: torch.randn(5,),
+                                            2: torch.randn(5,)})
+        torch.save(classifier.state_dict(), 'ncm.pt')
+        del classifier
+        classifier = NCMClassifier()
+        check = torch.load('ncm.pt')
+        classifier.load_state_dict(check)
+        assert classifier.class_means.shape == (3, 5)
+        assert (classifier.class_means[0] == 0).all()
+        assert len(classifier.class_means_dict) == 2
+
 
 class PNNTest(unittest.TestCase):
     def test_pnn_on_multiple_tasks(self):


### PR DESCRIPTION
The NCM Classifier was quite cumbersome to use. Now it explicitly keeps a dictionary of means for each class and has a method to update the means. 
The means are vectorized in a tensor after each update.

Tests and strategies using NCM have been updated.