### PR TITLE
Shuffling dataset when updating GEM memory

### DIFF
--- a/avalanche/training/plugins/gem.py
+++ b/avalanche/training/plugins/gem.py
@@ -127,7 +127,8 @@ class GEMPlugin(SupervisedPlugin):
             dataset.collate_fn if hasattr(dataset, "collate_fn") else None
         )
         dataloader = DataLoader(
-            dataset, batch_size=batch_size, collate_fn=collate_fn
+            dataset, batch_size=batch_size, collate_fn=collate_fn,
+            shuffle=True
         )
         tot = 0
         for mbatch in dataloader:


### PR DESCRIPTION
Not shuffling the dataset has a large reduction in performance, since it may lead to an uneven distribution of samples per class within a task.
Using a class-balanced buffer would solve this. It is something we should consider for this kind of strategies. 
For balanced datasets, this PR should fix the issue.
