### PR TITLE
removed drop_last forwarding from make_eval_dataloader

### DIFF
--- a/avalanche/training/templates/base_sgd.py
+++ b/avalanche/training/templates/base_sgd.py
@@ -430,7 +430,6 @@ class BaseSGDTemplate(
         shuffle=False,
         pin_memory=None,
         persistent_workers=False,
-        drop_last=False,
         **kwargs
     ):
         """
@@ -452,7 +451,6 @@ class BaseSGDTemplate(
             shuffle=shuffle,
             pin_memory=pin_memory,
             persistent_workers=persistent_workers,
-            drop_last=drop_last,
         )
 
         collate_from_data_or_kwargs(


### PR DESCRIPTION
Before that, when calling

strategy.train(experience, eval_streams=[scenario.val_stream], drop_last=True)

The drop_last argument was used both in the training and in the evaluation dataloader. This is a quickfix to fix this behavior, it would be nice to find a better way of distinguishing kwargs that are forwarded to eval/train loaders, or even to functions outside of loaders.