### PR TITLE
Added NCM replace dictionary and used in icarl

### DIFF
--- a/avalanche/models/ncm_classifier.py
+++ b/avalanche/models/ncm_classifier.py
@@ -106,5 +106,18 @@ class NCMClassifier(nn.Module):
 
         self._vectorize_means_dict()
 
+    def replace_class_means_dict(self,
+                                 class_means_dict: Dict[int, Tensor]):
+        """
+        Replace existing dictionary of means with a given dictionary.
+        """
+        assert isinstance(class_means_dict, dict), \
+            "class_means_dict must be a dictionary mapping class_id " \
+            "to mean vector"
+        self.class_means_dict = {k: v.clone()
+                                 for k, v in class_means_dict.items()}
+
+        self._vectorize_means_dict()
+
 
 __all__ = ["NCMClassifier"]

--- a/avalanche/training/supervised/icarl.py
+++ b/avalanche/training/supervised/icarl.py
@@ -134,7 +134,6 @@ class _ICaRLPlugin(SupervisedPlugin):
         self.y_memory = []
         self.order = []
 
-        self.old_model = None
         self.observed_classes = []
         self.class_means = {}
         self.embedding_size = None
@@ -223,8 +222,8 @@ class _ICaRLPlugin(SupervisedPlugin):
             self.class_means[label] = (m1 + m2) / 2
             self.class_means[label] /= torch.norm(self.class_means[label])
 
-            strategy.model.eval_classifier.update_class_means_dict(
-                self.class_means)
+        strategy.model.eval_classifier.replace_class_means_dict(
+            self.class_means)
 
     def construct_exemplar_set(self, strategy: SupervisedTemplate):
         assert strategy.experience is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -642,6 +642,22 @@ class NCMClassifierTest(unittest.TestCase):
         assert torch.all(classifier.class_means[4] == torch.zeros(4,))
         assert torch.all(classifier.class_means[5] == new_mean)
 
+    def test_ncm_replace_means(self):
+        class_means = torch.tensor(
+            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]],
+            dtype=torch.float,
+        )
+        class_means_dict = {i: el for i, el in enumerate(class_means)}
+        classifier = NCMClassifier()
+        classifier.update_class_means_dict(class_means_dict)
+        class_means = torch.tensor(
+            [[2, 0, 0, 0], [2, 1, 0, 0], [2, 0, 1, 0]],
+            dtype=torch.float,
+        )
+        new_dict = {i: el for i, el in enumerate(class_means)}
+        classifier.replace_class_means_dict(new_dict)
+        assert (classifier.class_means[:, 0] == 2).all()
+
     def test_ncm_save_load(self):
         classifier = NCMClassifier()
         classifier.update_class_means_dict({1: torch.randn(5,),


### PR DESCRIPTION
Now NCM allows to replace all the means. This is useful in iCarl, where means are replaced after every experience.