### PR TITLE
Fixed icarl by converting back TrainEvalModel to DynamicModule

### DIFF
--- a/avalanche/models/dynamic_modules.py
+++ b/avalanche/models/dynamic_modules.py
@@ -444,7 +444,7 @@ class MultiHeadClassifier(MultiTaskModule):
         return out
 
 
-class TrainEvalModel(DynamicModule):
+class TrainEvalModel(torch.nn.Module):
     """
     TrainEvalModel.
     This module allows to wrap together a common feature extractor and
@@ -465,23 +465,13 @@ class TrainEvalModel(DynamicModule):
         self.feature_extractor = feature_extractor
         self.train_classifier = train_classifier
         self.eval_classifier = eval_classifier
-        self.classifier = train_classifier
 
     def forward(self, x):
         x = self.feature_extractor(x)
-        return self.classifier(x)
-
-    def adaptation(self, experience: Optional[CLExperience] = None):
         if self.training:
-            self.train_adaptation(experience)
+            return self.train_classifier(x)
         else:
-            self.eval_adaptation(experience)
-
-    def train_adaptation(self, experience: Optional[CLExperience] = None):
-        self.classifier = self.train_classifier
-
-    def eval_adaptation(self, experience: Optional[CLExperience] = None):
-        self.classifier = self.eval_classifier
+            return self.eval_classifier(x)
 
 
 __all__ = [

--- a/avalanche/models/ncm_classifier.py
+++ b/avalanche/models/ncm_classifier.py
@@ -73,10 +73,10 @@ class NCMClassifier(nn.Module):
         with respect to each class.
         """
 
-        assert self.class_means is not None, "no class means available."
+        assert self.class_means_dict != {}, "no class means available."
         if self.normalize:
             # normalize across feature_size
-            x = (x.T / torch.norm(x, dim=1)).T
+            x = (x.T / torch.norm(x.T, dim=0)).T
 
         # (num_classes, batch_size)
         sqd = torch.cdist(self.class_means.to(x.device), x)

--- a/avalanche/training/losses.py
+++ b/avalanche/training/losses.py
@@ -52,7 +52,6 @@ class ICaRLLossPlugin(SupervisedPlugin):
     def after_training_exp(self, strategy, **kwargs):
         if self.old_model is None:
             old_model = copy.deepcopy(strategy.model)
-            old_model.eval()
             self.old_model = old_model.to(strategy.device)
 
         self.old_model.load_state_dict(strategy.model.state_dict())

--- a/avalanche/training/supervised/icarl.py
+++ b/avalanche/training/supervised/icarl.py
@@ -185,6 +185,7 @@ class _ICaRLPlugin(SupervisedPlugin):
         self.construct_exemplar_set(strategy)
         self.reduce_exemplar_set(strategy)
         self.compute_class_means(strategy)
+        strategy.model.train()
 
     def compute_class_means(self, strategy):
         if self.class_means == {}:

--- a/avalanche/training/supervised/icarl.py
+++ b/avalanche/training/supervised/icarl.py
@@ -201,7 +201,8 @@ class _ICaRLPlugin(SupervisedPlugin):
                 mapped_prototypes = strategy.model.feature_extractor(
                     class_samples
                 ).detach()
-            D = mapped_prototypes.T / torch.norm(mapped_prototypes, dim=1)
+            D = mapped_prototypes.T
+            D = D / torch.norm(D, dim=0)
 
             if len(class_samples.shape) == 4:
                 class_samples = torch.flip(class_samples, [3])
@@ -211,7 +212,8 @@ class _ICaRLPlugin(SupervisedPlugin):
                     class_samples
                 ).detach()
 
-            D2 = mapped_prototypes2.T / torch.norm(mapped_prototypes2, dim=1)
+            D2 = mapped_prototypes2.T
+            D2 = D2 / torch.norm(D2, dim=0)
 
             div = torch.ones(class_samples.shape[0], device=strategy.device)
             div = div / class_samples.shape[0]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -596,13 +596,19 @@ class TrainEvalModelTests(unittest.TestCase):
             eval_classifier=classifier2,
         )
 
-        model.train()
-        out = model(x)
-        assert out.shape[-1] == 10
-
         model.eval()
-        out = model(x)
-        assert out.shape[-1] == 7
+        model.adaptation()
+        assert model.classifier is classifier2
+
+        model.train()
+        model.adaptation()
+        assert model.classifier is classifier1
+
+        model.eval_adaptation()
+        assert model.classifier is classifier2
+
+        model.train_adaptation()
+        assert model.classifier is classifier1
 
 
 class NCMClassifierTest(unittest.TestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -596,19 +596,13 @@ class TrainEvalModelTests(unittest.TestCase):
             eval_classifier=classifier2,
         )
 
-        model.eval()
-        model.adaptation()
-        assert model.classifier is classifier2
-
         model.train()
-        model.adaptation()
-        assert model.classifier is classifier1
+        out = model(x)
+        assert out.shape[-1] == 10
 
-        model.eval_adaptation()
-        assert model.classifier is classifier2
-
-        model.train_adaptation()
-        assert model.classifier is classifier1
+        model.eval()
+        out = model(x)
+        assert out.shape[-1] == 7
 
 
 class NCMClassifierTest(unittest.TestCase):


### PR DESCRIPTION
The behavior of TrainEvalModel was not always consistent and the classifier sometimes failed to switch.
I brought back the DynamicModule version, this fixes iCarl performance.