### PR TITLE
Streamline data loaders

### DIFF
--- a/avalanche/benchmarks/utils/classification_dataset.py
+++ b/avalanche/benchmarks/utils/classification_dataset.py
@@ -87,7 +87,7 @@ def lookup(indexable, idx):
 class ClassificationDataset(AvalancheDataset[T_co]):
 
     @property
-    def task_pattern_indices(self):
+    def task_pattern_indices(self) -> Dict[int, Sequence[int]]:
         """A dictionary mapping task ids to their sample indices."""
         return self.targets_task_labels.val_to_idx  # type: ignore
 

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -19,7 +19,6 @@ from typing import (
     Dict,
     Iterator,
     List,
-    Mapping,
     Optional,
     Sequence,
     Sized,
@@ -27,31 +26,14 @@ from typing import (
 )
 import numpy as np
 
-import torch
-from torch.utils.data import RandomSampler, DistributedSampler, Dataset
+from torch.utils.data import DistributedSampler, Dataset
 from torch.utils.data.dataloader import DataLoader
 
-from avalanche.benchmarks.utils.collate_functions import (
-    classification_collate_mbatches_fn,
-)
-from avalanche.benchmarks.utils.collate_functions import (
-    detection_collate_fn as _detection_collate_fn,
-)
-from avalanche.benchmarks.utils.collate_functions import (
-    detection_collate_mbatches_fn as _detection_collate_mbatches_fn,
-)
 from avalanche.benchmarks.utils.data import AvalancheDataset
 from avalanche.benchmarks.utils.data_attribute import DataAttribute
 from avalanche.distributed.distributed_helper import DistributedHelper
 
-_default_collate_mbatches_fn = classification_collate_mbatches_fn
-
-detection_collate_fn = _detection_collate_fn
-
-detection_collate_mbatches_fn = _detection_collate_mbatches_fn
-
-import torch
-from torch.utils.data.sampler import RandomSampler, BatchSampler
+from torch.utils.data.sampler import BatchSampler
 from torch.utils.data import ConcatDataset
 from torch.utils.data.sampler import Sampler
 
@@ -72,31 +54,53 @@ def collate_from_data_or_kwargs(data, kwargs):
         kwargs["collate_fn"] = data.collate_fn
 
 
-class TaskBalancedDataLoader:
-    """Task-balanced data loader for Avalanche's datasets."""
+class MultiDatasetDataLoader:
+    """Custom data loader for multiple datasets."""
 
     def __init__(
         self,
-        data: AvalancheDataset,
-        oversample_small_tasks: bool = False,
+        datasets: Sequence[AvalancheDataset],
+        batch_sizes: Sequence[int],
+        termination_dataset: int = -1,
+        oversample_small_datasets: bool = False,
+        distributed_sampling: bool = True,
+        never_ending: bool = False,
         **kwargs
     ):
-        """Task-balanced data loader for Avalanche's datasets.
+        """Custom data loader for loading batches from multiple datasets.
 
-        The iterator returns a mini-batch balanced across each task, which
-        makes it useful when training in multi-task scenarios whenever data is
-        highly unbalanced.
+        This dataloader iterates in parallel multiple datasets which are used
+        to create mini-batches by concatenating their data together. 
+        The number of examples from each dataset in each mini-batch 
+        is defined by the `batch_sizes` parameter.
 
-        If `oversample_small_tasks == True` smaller tasks are
-        oversampled to match the largest task. Otherwise, once the data for a
-        specific task is terminated, that task will not be present in the
-        subsequent mini-batches.
+        The length of the loader (that is, the number of iterations in an 
+        epoch) is determined by the `termination_dataset`.
 
-        :param data: an instance of `AvalancheDataset`.
-        :param oversample_small_tasks: whether smaller tasks should be
-            oversampled to match the largest one.
+        The `oversample_small_datasets` paramter can be used to control what to
+        do when smaller datasets are consumed and the epoch is not ended yet.
+
+        :param datasets: A list of :class:`AvalancheDataset`.
+        :param batch_sizes: A list of int, describing the number of examples
+            per minibatch to take from each dataset.
+        :param termination_dataset: The index of the dataset used to determine
+            the number of iterations per epoch. Defaults to -1, which means
+            that the highest number of iterations among all datasets will be
+            used.
+        :param oversample_small_datasets: If `True`, smaller datasets will be
+            cycled again until the epoch is ended. If it is `False`, smaller
+            datasets will not be cycled again, which means that some datasets
+            will not contribute to the minibatch composition near the end of
+            the epoch.
+        :param distributed_sampling: If True, apply the PyTorch 
+            :class:`DistributedSampler`. Defaults to False.
+        :param never_ending: If True, this data loader will cycle indefinitely
+            by iterating over all datasets again and again and the epoch will
+            never end. In this case, the `termination_dataset` and
+            `oversample_small_datasets` parameters are ignored. Defaults to
+            False.
         :param kwargs: data loader arguments used to instantiate the loader for
-            each task separately. See pytorch :class:`DataLoader`.
+            each dataset. See PyTorch :class:`DataLoader`.
         """
         if "collate_mbatches" in kwargs:
             raise ValueError(
@@ -105,41 +109,138 @@ class TaskBalancedDataLoader:
                 "`data.collate_fn`."
             )
 
-        self.data = data
-        self.dataloaders: Dict[int, DataLoader] = dict()
-        self.oversample_small_tasks = oversample_small_tasks
+        if termination_dataset >= len(datasets):
+            raise ValueError(
+                'termination_dataset must be the index of the '
+                'dataset used to determine the termination of an epoch'
+            )
+        
+        distributed_sampling = distributed_sampling and \
+            DistributedHelper.is_distributed
 
-        # split data by task.
-        task_datasets = []
-        task_labels_field = getattr(self.data, 'targets_task_labels')
-        assert isinstance(task_labels_field, DataAttribute)
-        for task_label in task_labels_field.uniques:
+        self.datasets = list(datasets)
+        self.oversample_small_datasets: bool = oversample_small_datasets
+        self.batch_sizes: List[int] = list(batch_sizes)
+        self.distributed_sampling: bool = distributed_sampling
+        self.loader_kwargs: Dict[str, Any] = kwargs
+        self.termination_dataset: int = termination_dataset
+        self.never_ending: bool = never_ending
 
-            tidxs = task_labels_field.val_to_idx[task_label]
-            tdata = self.data.subset(tidxs)
-            task_datasets.append(tdata)
+        # Only used if persistent_workers == True in loader kwargs
+        self._persistent_loader = None
 
-        # the iteration logic is implemented by GroupBalancedDataLoader.
-        # we use kwargs to pass the arguments to avoid passing the same
-        # arguments multiple times.
-        if "data" in kwargs:
-            del kwargs["data"]
-        # needed if they are passed as positional arguments
-        kwargs["oversample_small_groups"] = oversample_small_tasks
-        self._dl = GroupBalancedDataLoader(datasets=task_datasets, **kwargs)
+        if "collate_fn" not in self.loader_kwargs:
+            self.loader_kwargs["collate_fn"] = self.datasets[0].collate_fn
+
+        if self.never_ending:
+            # Infinite data loader
+            self.termination_dataset = -1
+            self.n_iterations = 10 ** 10
+            self.oversample_small_datasets = True
+        else:
+            # Estimate number of iterations per epoch
+            loaders_len = np.full((len(self.datasets,)), -1)
+
+            if self.termination_dataset < 0:
+                for i, (data_subset, subset_mb_size) in \
+                        enumerate(zip(self.datasets, self.batch_sizes)):
+                    loaders_len[i] = len(
+                        _make_data_loader(
+                            data_subset,
+                            distributed_sampling,
+                            kwargs,
+                            subset_mb_size,
+                            force_no_workers=True,
+                        )[0]
+                    )
+            else:
+                loaders_len[self.termination_dataset] = len(
+                    _make_data_loader(
+                        self.datasets[self.termination_dataset],
+                        distributed_sampling,
+                        kwargs,
+                        self.batch_sizes[self.termination_dataset],
+                        force_no_workers=True
+                    )[0]
+                )
+
+            self.termination_dataset = loaders_len.argmax().item()
+            self.n_iterations = loaders_len.max().item()
 
     def __iter__(self):
-        for el in self._dl.__iter__():
-            yield el
+        # Adapted from the __iter__ of PyTorch DataLoader:
+        # https://pytorch.org/docs/stable/_modules/torch/utils/data/dataloader.html#DataLoader
+        # Needed to support 'persistent_workers'
+
+        use_persistent_workers = self.loader_kwargs.get(
+            'persistent_workers', False)
+        num_workers = self.loader_kwargs.get(
+            'num_workers', 0)
+
+        if use_persistent_workers and num_workers > 0:
+            if self._persistent_loader is None:
+                self._persistent_loader = self._get_loader()
+
+            yield from self._persistent_loader
+        else:
+            yield from self._get_loader()
+        
+    def _get_loader(self):
+        samplers = self._create_samplers(
+            self.datasets,
+            self.batch_sizes,
+            self.distributed_sampling,
+            self.loader_kwargs
+        )
+
+        overall_dataset = ConcatDataset(self.datasets)
+
+        multi_dataset_batch_sampler = MultiDatasetSampler(
+            overall_dataset.datasets,
+            samplers,
+            termination_dataset_idx=self.termination_dataset,
+            oversample_small_datasets=self.oversample_small_datasets,
+            never_ending=self.never_ending
+        )
+
+        loader = _make_data_loader_with_batched_sampler(
+            overall_dataset,
+            batch_sampler=multi_dataset_batch_sampler,
+            data_loader_args=self.loader_kwargs
+        )
+
+        return loader
 
     def __len__(self):
-        return self._dl.__len__()
+        return self.n_iterations
+    
+    @staticmethod
+    def _create_samplers(
+        datasets: List[AvalancheDataset], 
+        batch_sizes: List[int],
+        distributed_sampling: bool,
+        loader_kwargs: Dict[str, Any]
+    ):
+        samplers = []
 
+        for dataset, dataset_mb_size in zip(datasets, batch_sizes):
+            sampler = _make_sampler(
+                dataset,
+                distributed_sampling,
+                loader_kwargs,
+                dataset_mb_size
+            )
 
-class GroupBalancedDataLoader:
+            samplers.append(sampler)
+        
+        return samplers
+    
+
+class GroupBalancedDataLoader(MultiDatasetDataLoader):
     """Data loader that balances data from multiple datasets."""
 
     def __init__(
+            
         self,
         datasets: Sequence[AvalancheDataset],
         oversample_small_groups: bool = False,
@@ -162,29 +263,11 @@ class GroupBalancedDataLoader:
             oversampled to match the largest one.
         :param batch_size: the size of the batch. It must be greater than or
             equal to the number of groups.
+        :param distributed_sampling: If True, apply the PyTorch 
+            :class:`DistributedSampler`. Defaults to False.
         :param kwargs: data loader arguments used to instantiate the loader for
             each group separately. See pytorch :class:`DataLoader`.
         """
-        if "collate_mbatches" in kwargs:
-            raise ValueError(
-                "collate_mbatches is not needed anymore and it has been "
-                "deprecated. Data loaders will use the collate function"
-                "`data.collate_fn`."
-            )
-
-        self.datasets = datasets
-        self.batch_sizes = []
-        self.oversample_small_groups = oversample_small_groups
-        self.distributed_sampling = distributed_sampling
-        self.loader_kwargs = kwargs
-        if "collate_fn" in kwargs:
-            self.collate_fn = kwargs["collate_fn"]
-        else:
-            self.collate_fn = self.datasets[0].collate_fn
-
-        # collate is done after we have all batches
-        # so we set an empty collate for the internal dataloaders
-        self.loader_kwargs["collate_fn"] = return_identity
 
         # check if batch_size is larger than or equal to the number of datasets
         assert batch_size >= len(datasets)
@@ -193,154 +276,122 @@ class GroupBalancedDataLoader:
         ds_batch_size = batch_size // len(datasets)
         remaining = batch_size % len(datasets)
 
-        for _ in self.datasets:
+        batch_sizes = []
+        for _ in datasets:
             bs = ds_batch_size
             if remaining > 0:
                 bs += 1
                 remaining -= 1
-            self.batch_sizes.append(bs)
+            batch_sizes.append(bs)
 
-        loaders_for_len_estimation = [
-            _make_data_loader(
-                dataset,
-                distributed_sampling,
-                kwargs,
-                mb_size,
-                force_no_workers=True,
-            )[0]
-            for dataset, mb_size in zip(self.datasets, self.batch_sizes)
-        ]
+        super().__init__(
+            datasets,
+            batch_sizes,
+            oversample_small_datasets=oversample_small_groups,
+            distributed_sampling=distributed_sampling,
+            **kwargs
+        )
 
-        self.max_len = max([len(d) for d in loaders_for_len_estimation])
 
-    def __iter__(self):
-        dataloaders = []
-        samplers = []
-        for dataset, mb_size in zip(self.datasets, self.batch_sizes):
-            data_l, data_l_sampler = _make_data_loader(
-                dataset,
-                self.distributed_sampling,
-                self.loader_kwargs,
-                mb_size,
+class TaskBalancedDataLoader(GroupBalancedDataLoader):
+    """Task-balanced data loader for Avalanche's datasets."""
+
+    def __init__(
+        self,
+        data: AvalancheDataset,
+        batch_size: int = 32,
+        oversample_small_groups: bool = False,
+        distributed_sampling: bool = True,  # TODO: doc fix
+        **kwargs
+    ):
+        """Task-balanced data loader for Avalanche's datasets.
+
+        The iterator returns a mini-batch balanced across each task, which
+        makes it useful when training in multi-task scenarios whenever data is
+        highly unbalanced.
+
+        If `oversample_small_tasks == True` smaller tasks are
+        oversampled to match the largest task. Otherwise, once the data for a
+        specific task is terminated, that task will not be present in the
+        subsequent mini-batches.
+
+        :param data: an instance of `AvalancheDataset`.
+        :param oversample_small_groups: whether smaller tasks should be
+            oversampled to match the largest one.
+        :param distributed_sampling: If True, apply the PyTorch 
+            :class:`DistributedSampler`. Defaults to False.
+        :param kwargs: data loader arguments used to instantiate the loader for
+            each task separately. See pytorch :class:`DataLoader`.
+        """
+
+        if 'oversample_small_tasks' in kwargs:
+            raise ValueError(
+                "oversample_small_tasks is deprecated in favor of "
+                "oversample_small_groups"
             )
+            
+        # Split data by task
+        task_datasets = []
+        task_labels_field = getattr(data, 'targets_task_labels')
+        assert isinstance(task_labels_field, DataAttribute)
+        for task_label in task_labels_field.uniques:
+            tidxs = task_labels_field.val_to_idx[task_label]
+            tdata = data.subset(tidxs)
+            task_datasets.append(tdata)
 
-            dataloaders.append(data_l)
-            samplers.append(data_l_sampler)
-
-        iter_dataloaders = []
-        for dl in dataloaders:
-            iter_dataloaders.append(iter(dl))
-
-        max_num_mbatches = max([len(d) for d in dataloaders])
-        for it in range(max_num_mbatches):
-            mb_curr = []
-            removed_dataloaders_idxs = []
-            # copy() is necessary because we may remove keys from the
-            # dictionary. This would break the generator.
-            for tid, (t_loader, t_loader_sampler) in enumerate(
-                zip(iter_dataloaders, samplers)
-            ):
-                try:
-                    batch = next(t_loader)
-                except StopIteration:
-                    # StopIteration is thrown if dataset ends.
-                    if self.oversample_small_groups:
-                        # reinitialize data loader
-                        if isinstance(t_loader_sampler, DistributedSampler):
-                            # Manage shuffling in DistributedSampler
-                            t_loader_sampler.set_epoch(
-                                t_loader_sampler.epoch + 1
-                            )
-
-                        iter_dataloaders[tid] = iter(dataloaders[tid])
-                        batch = next(iter_dataloaders[tid])
-                    else:
-                        # We iteratated over all the data from this group
-                        # and we don't need the iterator anymore.
-                        iter_dataloaders[tid] = None
-                        samplers[tid] = None
-                        removed_dataloaders_idxs.append(tid)
-                        continue
-                mb_curr.extend(batch)
-            yield self.collate_fn(mb_curr)
-
-            # clear empty data-loaders
-            for tid in reversed(removed_dataloaders_idxs):
-                del iter_dataloaders[tid]
-                del samplers[tid]
-
-    def __len__(self):
-        return self.max_len
+        super().__init__(
+            task_datasets,
+            oversample_small_groups=oversample_small_groups,
+            batch_size=batch_size,
+            distributed_sampling=distributed_sampling,
+            **kwargs
+        )
 
 
-class GroupBalancedInfiniteDataLoader:
+class GroupBalancedInfiniteDataLoader(MultiDatasetDataLoader):
     """Data loader that balances data from multiple datasets emitting an
     infinite stream."""
 
     def __init__(
         self,
         datasets: Sequence[AvalancheDataset],
-        collate_mbatches=_default_collate_mbatches_fn,
+        batch_size=32,
         distributed_sampling: bool = True,
         **kwargs
     ):
         """Data loader that balances data from multiple datasets emitting an
         infinite stream.
+
         Mini-batches emitted by this dataloader are created by collating
         together mini-batches from each group. It may be used to balance data
         among classes, experiences, tasks, and so on.
+
         :param datasets: an instance of `AvalancheDataset`.
-        :param collate_mbatches: function that given a sequence of mini-batches
-            (one for each task) combines them into a single mini-batch. Used to
-            combine the mini-batches obtained separately from each task.
+        :param batch_size: the size of the batch to take from each dataset.
+            Please note that, differently from other Avalanche multi dataset 
+            loaders, this value is the per-dataset contribution to the
+            final mini-batch, NOT the final mini-batch size. The final
+            mini-batches will be of size `len(datasets) * batch_size`.
+        :param distributed_sampling: If True, apply the PyTorch 
+            :class:`DistributedSampler`. Defaults to False.
         :param kwargs: data loader arguments used to instantiate the loader for
             each group separately. See pytorch :class:`DataLoader`.
         """
-        self.datasets = datasets
-        self.dataloaders = []
-        self.collate_mbatches = collate_mbatches
 
-        for data in self.datasets:
-            if DistributedHelper.is_distributed and distributed_sampling:
-                seed = torch.randint(
-                    0,
-                    2 ** 32 - 1 - DistributedHelper.world_size,
-                    (1,),
-                    dtype=torch.int64,
-                )
-                seed += DistributedHelper.rank
-                generator = torch.Generator()
-                generator.manual_seed(int(seed))
-            else:
-                generator = None  # Default
-            infinite_sampler = RandomSampler(
-                data,
-                replacement=True,
-                num_samples=10 ** 10,
-                generator=generator,
-            )
-            collate_from_data_or_kwargs(data, kwargs)
-            dl = DataLoader(data, sampler=infinite_sampler, **kwargs)
-            self.dataloaders.append(dl)
-        self.max_len = 10 ** 10
+        batch_sizes = [batch_size] * len(datasets)
 
-    def __iter__(self):
-        iter_dataloaders = []
-        for dl in self.dataloaders:
-            iter_dataloaders.append(iter(dl))
-
-        while True:
-            mb_curr = []
-            for tid, t_loader in enumerate(iter_dataloaders):
-                batch = next(t_loader)
-                mb_curr.append(batch)
-            yield self.collate_mbatches(mb_curr)
-
-    def __len__(self):
-        return self.max_len
+        super().__init__(
+            datasets,
+            batch_sizes,
+            termination_dataset=-1,
+            oversample_small_datasets=True,
+            distributed_sampling=distributed_sampling,
+            never_ending=True,
+            **kwargs
+        )
 
 
-class ReplayDataLoader:
+class ReplayDataLoader(MultiDatasetDataLoader):
     """Custom data loader for rehearsal/replay strategies."""
 
     def __init__(
@@ -381,38 +432,18 @@ class ReplayDataLoader:
         :param task_balanced_dataloader: if true, buffer data loaders will be
             task-balanced, otherwise it creates a single data loader for the
             buffer samples.
+        :param distributed_sampling: If True, apply the PyTorch 
+            :class:`DistributedSampler`. Defaults to False.
         :param kwargs: data loader arguments used to instantiate the loader for
             each task separately. See pytorch :class:`DataLoader`.
         """
-        if "collate_mbatches" in kwargs:
-            raise ValueError(
-                "collate_mbatches is not needed anymore and it has been "
-                "deprecated. Data loaders will use the collate function"
-                "`data.collate_fn`."
-            )
 
-        self.data = data
-        self.memory = memory
-        self.oversample_small_tasks = oversample_small_tasks
-        self.task_balanced_dataloader = task_balanced_dataloader
-        self.data_batch_sizes: Union[int, Dict[int, int]] = dict()
-        self.memory_batch_sizes: Union[int, Dict[int, int]] = dict()
-        self.distributed_sampling = distributed_sampling
-        self.loader_kwargs = kwargs
-
-        # Only used if persistent_workers == True in loader kwargs
-        self._persistent_loader = None
-
-        if "collate_fn" not in self.loader_kwargs:
-            self.loader_kwargs["collate_fn"] = self.data.collate_fn
-            
-        self.data_batch_sizes, _ = self._get_batch_sizes(
-            data, batch_size, 0, False
-        )
+        if "collate_fn" not in kwargs:
+            kwargs["collate_fn"] = data.collate_fn
 
         # Create dataloader for memory items
         if task_balanced_dataloader:
-            memory_task_labels = getattr(self.memory, 'targets_task_labels')
+            memory_task_labels = getattr(memory, 'targets_task_labels')
             assert isinstance(memory_task_labels, DataAttribute)
             num_keys = len(memory_task_labels.uniques)
 
@@ -423,428 +454,97 @@ class ReplayDataLoader:
                 "and current data."
             )
 
+            # Make the batch size balanced between tasks
+            # The remainder (remaining_example) will be distributed
+            # across tasks by "self._get_datasets_and_batch_sizes(...)"
             single_group_batch_size = batch_size_mem // num_keys
             remaining_example = batch_size_mem % num_keys
         else:
             single_group_batch_size = batch_size_mem
             remaining_example = 0
 
-        self.memory_batch_sizes, _ = self._get_batch_sizes(
+        # For current data, use the batch_size from the input "batch_size".
+        # batch_size can be an int (do not split by task)
+        # or a dictionary task_id -> mb_size
+        # In both cases, remaining_examples=0
+        data_batch_sizes, data_subsets = self._get_datasets_and_batch_sizes(
+            data,
+            batch_size,
+            0,
+            False
+        )
+
+        memory_batch_sizes, memory_subsets = self._get_datasets_and_batch_sizes(
             memory,
             single_group_batch_size,
             remaining_example,
             task_balanced_dataloader,
         )
 
+        # Obtain the subset with the highest number of iterations
+        # This is the one that defines when an epoch ends
+        # Note: this is aligned with the behavior of the legacy
+        # multi-loader version of ReplayDataLoader
         loaders_for_len_estimation = []
 
-        if isinstance(self.data_batch_sizes, int):
+        for data_subset, subset_mb_size in zip(data_subsets, data_batch_sizes):
             loaders_for_len_estimation.append(
                 _make_data_loader(
-                    data,
+                    data_subset,
                     distributed_sampling,
                     kwargs,
-                    self.data_batch_sizes,
+                    subset_mb_size,
                     force_no_workers=True,
                 )[0]
             )
-        else:
-            # Task balanced
-            data_task_set: Mapping[int, AvalancheDataset] = \
-                getattr(data, 'task_set')
-            for task_id in data_task_set:
-                dataset = data_task_set[task_id]
-                mb_sz = self.data_batch_sizes[task_id]
-
-                loaders_for_len_estimation.append(
-                    _make_data_loader(
-                        dataset,
-                        distributed_sampling,
-                        kwargs,
-                        mb_sz,
-                        force_no_workers=True,
-                    )[0]
-                )
-
-        self.max_len = max([len(d) for d in loaders_for_len_estimation])
-
-    def __iter__(self):
-        # Adapted from the __iter__ of PyTorch DataLoader:
-        # https://pytorch.org/docs/stable/_modules/torch/utils/data/dataloader.html#DataLoader
-        # Needed to support 'persistent_workers'
-
-        use_persistent_workers = self.loader_kwargs.get(
-            'persistent_workers', False)
-        num_workers = self.loader_kwargs.get(
-            'num_workers', 0)
-
-        if use_persistent_workers and num_workers > 0:
-            if self._persistent_loader is None:
-                self._persistent_loader = self._get_loader()
-
-            yield from self._persistent_loader
-        else:
-            yield from self._get_loader()
         
-    def _get_loader(self):
-        data_datasets, data_samplers = self._create_samplers(
-            self.data,
-            self.data_batch_sizes,
-            self.distributed_sampling,
-            self.loader_kwargs
-        )
-
-        memory_datasets, memory_samplers = self._create_samplers(
-            self.memory,
-            self.memory_batch_sizes,
-            self.distributed_sampling,
-            self.loader_kwargs
-        )
-
-        overall_dataset = ConcatDataset(data_datasets + memory_datasets)
-        overall_samplers = data_samplers + memory_samplers
-
-        # The longest sampler is the one that defines when an epoch ends
-        # Note: this is aligned with the behavior of LegacyReplayDataLoader
-        longest_data_sampler = np.array(
-            len(d) for d in data_samplers
+        longest_data_subset_idx = np.array(
+            len(d) for d in loaders_for_len_estimation
         ).argmax().item()
 
-        multi_dataset_batch_sampler = MultiDatasetSampler(
-            overall_dataset.datasets,
-            overall_samplers,
-            termination_dataset_idx=longest_data_sampler,
-            oversample_small_tasks=self.oversample_small_tasks
+        super().__init__(
+            data_subsets + memory_subsets,
+            data_batch_sizes + memory_batch_sizes,
+            termination_dataset=longest_data_subset_idx,
+            oversample_small_datasets=oversample_small_tasks,
+            distributed_sampling=distributed_sampling,
+            **kwargs
         )
 
-        loader = _make_data_loader_with_batched_sampler(
-            overall_dataset,
-            batch_sampler=multi_dataset_batch_sampler,
-            data_loader_args=self.loader_kwargs
-        )
-
-        return loader
-
-    def __len__(self):
-        return self.max_len
-    
     @staticmethod
-    def _create_samplers(
-        data: AvalancheDataset, 
-        batch_sizes: Union[int, List[int], Dict[int, int]],
-        distributed_sampling: bool,
-        loader_kwargs: Dict[str, Any]
-    ):
-        datasets = []
-        samplers = []
-
-        if isinstance(batch_sizes, int):
-            sampler = _make_sampler(
-                data,
-                distributed_sampling,
-                loader_kwargs,
-                batch_sizes
-            )
-            datasets.append(data)
-            samplers.append(sampler)
-        else:
-            for task_id in data.task_set:  # TODO: sorted (deterministic) loop
-                dataset = data.task_set[task_id]
-                mb_sz = batch_sizes[task_id]
-
-                sampler = _make_sampler(
-                    dataset,
-                    distributed_sampling,
-                    loader_kwargs,
-                    mb_sz
-                )
-
-                datasets.append(dataset)
-                samplers.append(sampler)
-        return datasets, samplers
-
-    @staticmethod
-    def _get_batch_sizes(
-        data_dict,
-        single_exp_batch_size,
-        remaining_example,
-        task_balanced_dataloader,
-    ):
-        batch_sizes = dict()
-        if task_balanced_dataloader:
-            for task_id in data_dict.task_set:
-                current_batch_size = single_exp_batch_size
-                if remaining_example > 0:
-                    current_batch_size += 1
-                    remaining_example -= 1
-                batch_sizes[task_id] = current_batch_size
-        else:
-            # Current data is loaded without task balancing
-            batch_sizes = single_exp_batch_size
-        return batch_sizes, remaining_example
-    
-
-class LegacyReplayDataLoader:
-    """Custom data loader for rehearsal/replay strategies."""
-
-    def __init__(
-        self,
+    def _get_datasets_and_batch_sizes(
         data: AvalancheDataset,
-        memory: Optional[AvalancheDataset] = None,
-        oversample_small_tasks: bool = False,
-        batch_size: int = 32,
-        batch_size_mem: int = 32,
-        task_balanced_dataloader: bool = False,
-        distributed_sampling: bool = True,
-        **kwargs
+        batch_sizes_def: Union[int, Dict[int, int]],
+        remaining_examples: int,
+        task_balanced_dataloader: bool
     ):
-        """Custom data loader for rehearsal strategies.
+        datasets: List[AvalancheDataset] = []
+        batch_sizes: List[int] = []
+        batch_size_per_task = not isinstance(batch_sizes_def, int)
 
-        This dataloader iterates in parallel two datasets, the current `data`
-        and the rehearsal `memory`, which are used to create mini-batches by
-        concatenating their data together. Mini-batches from both of them are
-        balanced using the task label (i.e. each mini-batch contains a balanced
-        number of examples from all the tasks in the `data` and `memory`).
-
-        The length of the loader is determined only by the current 
-        task data and is the same than what it would be when creating a 
-        data loader for this dataset.
-
-        If `oversample_small_tasks == True` smaller tasks are oversampled to
-        match the largest task.
-
-        :param data: AvalancheDataset.
-        :param memory: AvalancheDataset.
-        :param oversample_small_tasks: whether smaller tasks should be
-            oversampled to match the largest one.
-        :param batch_size: the size of the data batch. It must be greater
-            than or equal to the number of tasks.
-        :param batch_size_mem: the size of the memory batch. If
-            `task_balanced_dataloader` is set to True, it must be greater than
-            or equal to the number of tasks.
-        :param task_balanced_dataloader: if true, buffer data loaders will be
-            task-balanced, otherwise it creates a single data loader for the
-            buffer samples.
-        :param kwargs: data loader arguments used to instantiate the loader for
-            each task separately. See pytorch :class:`DataLoader`.
-        """
-        if "collate_mbatches" in kwargs:
-            raise ValueError(
-                "collate_mbatches is not needed anymore and it has been "
-                "deprecated. Data loaders will use the collate function"
-                "`data.collate_fn`."
-            )
-
-        self.data = data
-        self.memory = memory
-        self.oversample_small_tasks = oversample_small_tasks
-        self.task_balanced_dataloader = task_balanced_dataloader
-        self.data_batch_sizes: Union[int, Dict[int, int]] = dict()
-        self.memory_batch_sizes: Union[int, Dict[int, int]] = dict()
-        self.distributed_sampling = distributed_sampling
-        self.loader_kwargs = kwargs
-
-        if "collate_fn" in kwargs:
-            self.collate_fn = kwargs["collate_fn"]
-        else:
-            self.collate_fn = self.data.collate_fn
-
-        # collate is done after we have all batches
-        # so we set an empty collate for the internal dataloaders
-        self.loader_kwargs["collate_fn"] = lambda x: x
-
-        if task_balanced_dataloader:
-            memory_task_labels = getattr(self.memory, 'targets_task_labels')
-            assert isinstance(memory_task_labels, DataAttribute)
-            num_keys = len(memory_task_labels.uniques)
-            assert batch_size_mem >= num_keys, (
-                "Batch size must be greator or equal "
-                "to the number of tasks in the memory "
-                "and current data."
-            )
-
-        self.data_batch_sizes, _ = self._get_batch_sizes(
-            data, batch_size, 0, False
-        )
-
-        # Create dataloader for memory items
-        if task_balanced_dataloader:
-            memory_task_labels = getattr(self.memory, 'targets_task_labels')
-            assert isinstance(memory_task_labels, DataAttribute)
-            num_keys = len(memory_task_labels.uniques)
-            single_group_batch_size = batch_size_mem // num_keys
-            remaining_example = batch_size_mem % num_keys
-        else:
-            single_group_batch_size = batch_size_mem
-            remaining_example = 0
-
-        self.memory_batch_sizes, _ = self._get_batch_sizes(
-            memory,
-            single_group_batch_size,
-            remaining_example,
-            task_balanced_dataloader,
-        )
-
-        loaders_for_len_estimation = []
-
-        if isinstance(self.data_batch_sizes, int):
-            loaders_for_len_estimation.append(
-                _make_data_loader(
-                    data,
-                    distributed_sampling,
-                    kwargs,
-                    self.data_batch_sizes,
-                    force_no_workers=True,
-                )[0]
-            )
-        else:
-            # Task balanced
-            data_task_set: Mapping[int, AvalancheDataset] = \
-                getattr(data, 'task_set')
-            for task_id in data_task_set:
-                dataset = data_task_set[task_id]
-                mb_sz = self.data_batch_sizes[task_id]
-
-                loaders_for_len_estimation.append(
-                    _make_data_loader(
-                        dataset,
-                        distributed_sampling,
-                        kwargs,
-                        mb_sz,
-                        force_no_workers=True,
-                    )[0]
-                )
-
-        self.max_len = max([len(d) for d in loaders_for_len_estimation])
-
-    def __iter__(self):
-        loader_data, sampler_data = self._create_loaders_and_samplers(
-            self.data, self.data_batch_sizes
-        )
-
-        loader_memory, sampler_memory = self._create_loaders_and_samplers(
-            self.memory, self.memory_batch_sizes
-        )
-
-        iter_data_dataloaders = {}
-        iter_buffer_dataloaders = {}
-
-        for t in loader_data.keys():
-            iter_data_dataloaders[t] = iter(loader_data[t])
-        for t in loader_memory.keys():
-            iter_buffer_dataloaders[t] = iter(loader_memory[t])
-
-        max_len = max([len(d) for d in loader_data.values()])
-
-        try:
-            for it in range(max_len):
-                mb_curr: List[Any] = []
-                ReplayDataLoader._get_mini_batch_from_data_dict(
-                    iter_data_dataloaders,
-                    sampler_data,
-                    loader_data,
-                    self.oversample_small_tasks,
-                    mb_curr,
-                )
-
-                ReplayDataLoader._get_mini_batch_from_data_dict(
-                    iter_buffer_dataloaders,
-                    sampler_memory,
-                    loader_memory,
-                    self.oversample_small_tasks,
-                    mb_curr,
-                )
-
-                yield self.collate_fn(mb_curr)
-        except StopIteration:
-            return
-
-    def __len__(self):
-        return self.max_len
-
-    @staticmethod
-    def _get_mini_batch_from_data_dict(
-        iter_dataloaders,
-        iter_samplers,
-        loaders_dict,
-        oversample_small_tasks,
-        mb_curr,
-    ):
-        # list() is necessary because we may remove keys from the
-        # dictionary. This would break the generator.
-        for t in list(iter_dataloaders.keys()):
-            t_loader = iter_dataloaders[t]
-            t_sampler = iter_samplers[t]
-            try:
-                tbatch = next(t_loader)
-            except StopIteration:
-                # StopIteration is thrown if dataset ends.
-                # reinitialize data loader
-                if oversample_small_tasks:
-                    # reinitialize data loader
-                    if isinstance(t_sampler, DistributedSampler):
-                        # Manage shuffling in DistributedSampler
-                        t_sampler.set_epoch(t_sampler.epoch + 1)
-
-                    iter_dataloaders[t] = iter(loaders_dict[t])
-                    tbatch = next(iter_dataloaders[t])
-                else:
-                    del iter_dataloaders[t]
-                    del iter_samplers[t]
-                    continue
-            mb_curr.extend(tbatch)
-
-    def _create_loaders_and_samplers(self, data, batch_sizes):
-        loaders = dict()
-        samplers = dict()
-
-        if isinstance(batch_sizes, int):
-            loader, sampler = _make_data_loader(
-                data,
-                self.distributed_sampling,
-                self.loader_kwargs,
-                batch_sizes,
-            )
-            loaders[0] = loader
-            samplers[0] = sampler
-        else:
+        if task_balanced_dataloader or batch_size_per_task:
             for task_id in data.task_set:
                 dataset = data.task_set[task_id]
-                mb_sz = batch_sizes[task_id]
 
-                loader, sampler = _make_data_loader(
-                    dataset,
-                    self.distributed_sampling,
-                    self.loader_kwargs,
-                    mb_sz,
-                )
+                if batch_size_per_task:
+                    current_batch_size = batch_sizes_def[task_id]
+                else:
+                    current_batch_size = batch_sizes_def
 
-                loaders[task_id] = loader
-                samplers[task_id] = sampler
-        return loaders, samplers
-
-    @staticmethod
-    def _get_batch_sizes(
-        data_dict,
-        single_exp_batch_size,
-        remaining_example,
-        task_balanced_dataloader,
-    ):
-        batch_sizes = dict()
-        if task_balanced_dataloader:
-            for task_id in data_dict.task_set:
-                current_batch_size = single_exp_batch_size
-                if remaining_example > 0:
+                if remaining_examples > 0:
                     current_batch_size += 1
-                    remaining_example -= 1
-                batch_sizes[task_id] = current_batch_size
+                    remaining_examples -= 1
+
+                datasets.append(dataset)
+                batch_sizes.append(current_batch_size)
         else:
             # Current data is loaded without task balancing
-            batch_sizes = single_exp_batch_size
-        return batch_sizes, remaining_example
+            datasets.append(data)
+            batch_sizes.append(batch_sizes_def)
+        return batch_sizes, datasets
 
 
-class MultiDatasetSampler(Sampler):
+class MultiDatasetSampler(Sampler[List[int]]):
     """
     Iterate over datasets and provide a batch per dataset in each mini-batch.
     """
@@ -853,21 +553,30 @@ class MultiDatasetSampler(Sampler):
             datasets: Sequence[Sized],
             samplers: Sequence[BatchSampler],
             termination_dataset_idx: int = 0,
-            oversample_small_tasks: bool = False):
+            oversample_small_datasets: bool = False,
+            never_ending: bool = False):
         assert len(datasets) == len(samplers)
-        assert termination_dataset_idx >= 0 and \
+        assert never_ending or (
+            termination_dataset_idx >= 0 and
             termination_dataset_idx < len(datasets)
+        )
 
         self.datasets = list(datasets)
         self.samplers = list(samplers)
         self.cumulative_sizes = ConcatDataset.cumsum(self.datasets)
+        self.never_ending = never_ending
 
-        # termination_dataset_idx == dataset used to determine the epoch end
-        self.termination_dataset_idx = termination_dataset_idx
-        self.termination_dataset_iterations = \
-            len(self.samplers[self.termination_dataset_idx])
+        if self.never_ending:
+            self.termination_dataset_idx = -1
+            self.termination_dataset_iterations = 10 ** 10
+            self.oversample_small_datasets = True
+        else:
+            # termination_dataset_idx => dataset used to determine the epoch end
+            self.termination_dataset_idx = termination_dataset_idx
+            self.termination_dataset_iterations = \
+                len(self.samplers[self.termination_dataset_idx])
 
-        self.oversample_small_tasks = oversample_small_tasks
+            self.oversample_small_datasets = oversample_small_datasets
        
     def __len__(self):
         return self.termination_dataset_iterations
@@ -889,13 +598,17 @@ class MultiDatasetSampler(Sampler):
             per_dataset_indices: List[Optional[np.ndarray]] = \
                 [None] * number_of_datasets
 
-            # Obtain the indices for the "main" dataset first
-            sampling_dataset_order = [self.termination_dataset_idx] + list(
-                x for x in range(number_of_datasets)
-                if x != self.termination_dataset_idx
-            )
-            is_termination_dataset = \
-                [True] + ([False] * (number_of_datasets - 1))
+            if self.never_ending:
+                sampling_dataset_order = list(range(number_of_datasets))
+                is_termination_dataset = [False] * number_of_datasets
+            else:
+                # Obtain the indices for the "main" dataset first
+                sampling_dataset_order = [self.termination_dataset_idx] + list(
+                    x for x in range(number_of_datasets)
+                    if x != self.termination_dataset_idx
+                )
+                is_termination_dataset = \
+                    [True] + ([False] * (number_of_datasets - 1))
 
             for dataset_idx, is_term_dataset in zip(
                     sampling_dataset_order, 
@@ -907,8 +620,10 @@ class MultiDatasetSampler(Sampler):
                 if sampler is None:
                     continue
 
-                should_stop_if_ended = is_term_dataset or not \
-                    self.oversample_small_tasks
+                should_stop_if_ended = (
+                    is_term_dataset or
+                    not self.oversample_small_datasets
+                ) and (not self.never_ending)
 
                 continue_epoch, updated_iterator, next_batch_indices = \
                     self._next_batch(
@@ -1057,8 +772,6 @@ def _make_sampler(
 
 
 __all__ = [
-    "detection_collate_fn",
-    "detection_collate_mbatches_fn",
     "collate_from_data_or_kwargs",
     "TaskBalancedDataLoader",
     "GroupBalancedDataLoader",

--- a/avalanche/benchmarks/utils/data_loader.py
+++ b/avalanche/benchmarks/utils/data_loader.py
@@ -77,8 +77,9 @@ class MultiDatasetDataLoader:
         The length of the loader (that is, the number of iterations in an 
         epoch) is determined by the `termination_dataset`.
 
-        The `oversample_small_datasets` paramter can be used to control what to
-        do when smaller datasets are consumed and the epoch is not ended yet.
+        The `oversample_small_datasets` parameter can be used to control what
+        to do when smaller datasets are consumed and the epoch is not ended
+        yet.
 
         :param datasets: A list of :class:`AvalancheDataset`.
         :param batch_sizes: A list of int, describing the number of examples

--- a/avalanche/benchmarks/utils/detection_dataset.py
+++ b/avalanche/benchmarks/utils/detection_dataset.py
@@ -76,23 +76,27 @@ class DetectionDataset(AvalancheDataset[T_co]):
     @property
     def task_pattern_indices(self) -> Dict[int, Sequence[int]]:
         """A dictionary mapping task ids to their sample indices."""
-        # Assumes that targets_task_labels exists
-        t_labels: DataAttribute[int] = self.targets_task_labels  # type: ignore
-        return t_labels.val_to_idx
+        return self.targets_task_labels.val_to_idx  # type: ignore
 
     @property
-    def task_set(self: TDetectionDataset) -> TaskSet[TDetectionDataset]:
+    def task_set(self: TDetectionDataset) -> \
+            TaskSet[TDetectionDataset]:
         """Returns the dataset's ``TaskSet``, which is a mapping <task-id,
         task-dataset>."""
         return TaskSet(self)
 
     def subset(self, indices):
         data = super().subset(indices)
-        return data.with_transforms(self._transform_groups.current_group)
+        return data.with_transforms(
+            self._flat_data._transform_groups.current_group)
 
     def concat(self, other):
         data = super().concat(other)
-        return data.with_transforms(self._transform_groups.current_group)
+        return data.with_transforms(
+            self._flat_data._transform_groups.current_group)
+
+    def __hash__(self):
+        return id(self)
 
 
 class SupervisedDetectionDataset(DetectionDataset[T_co]):

--- a/avalanche/training/supervised/naive_object_detection.py
+++ b/avalanche/training/supervised/naive_object_detection.py
@@ -11,16 +11,17 @@
 from typing import Callable, Optional, Sequence, Union
 
 import torch
-from pkg_resources import parse_version
 from torch.nn import Module
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 
 from avalanche.benchmarks.utils.data_loader import (
     collate_from_data_or_kwargs,
-    detection_collate_fn,
     TaskBalancedDataLoader,
-    detection_collate_mbatches_fn,
+)
+
+from avalanche.benchmarks.utils import (
+    detection_collate_fn,
 )
 from avalanche.core import SupervisedPlugin
 from avalanche.training.plugins import EvaluationPlugin

--- a/avalanche/training/templates/update_type/sgd_update.py
+++ b/avalanche/training/templates/update_type/sgd_update.py
@@ -1,4 +1,3 @@
-
 from avalanche.training.templates.strategy_mixin_protocol \
     import SGDStrategyProtocol
 

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -29,6 +29,7 @@ from avalanche.benchmarks.utils.data_loader import (
     ReplayDataLoader,
     TaskBalancedDataLoader,
     GroupBalancedDataLoader,
+    GroupBalancedInfiniteDataLoader
 )
 
 
@@ -78,6 +79,12 @@ class DataLoaderTests(unittest.TestCase):
         dl = ReplayDataLoader(data, data)
         for el in dl:
             pass
+
+        dl = GroupBalancedInfiniteDataLoader(ds)
+        max_iters = 10**3
+        for i, el in enumerate(dl):
+            if i == max_iters:
+                break
 
     def test_dataload_reinit(self):
         benchmark = get_fast_benchmark()


### PR DESCRIPTION
As part of the effort to add support for FFCV data loading, this PR brings an overall change in the way data loaders are created.

Avalanche data loaders are used to return batches which are the concatenation of smaller mini-batches from multiple datasets. 

Up to now, this was accomplished by:
- Creating a data loader for each dataset (each with the same parameters!)
- Manually looping over all loaders, fetching the sub-mini-batches  
- Collate the sub-mini-batches before returning them (in the main thread!)

This led to issues regarding `num_workers` (which were spawned for each sub-dataset thus leading to spawning `N * num_workers`), bottlenecks related to the collate on the main thread, etc, not to mention that the code of each loader replicated operations already implemented in other loaders.

With the improvements found in this PR, a single PyTorch DataLoader is created based on a newly implemented Sampler that is used to return the indices in the desired order. The new mechanism supports distributed sampling, ensures that the correct number of workers is created, and that flags like `persistent_workers` and `pin_memory` have appreciable results. In addition, minibatch collate is done at the DataLoader level, thus removing a problematic bottleneck.

Note: experiment results may slightly change w.r.t. the previous implementation. This is not a bug and is related to the way random number generators are consumed, which may lead to a different choice of replay examples in the ReplayPlugin. Setting `shuffle=False` or setting a manual seed in the ReplayPlugin update method leads to the same results as the previous loader implementations.