### PR TITLE
Fix integration with IncrementalClassifier

### DIFF
--- a/avalanche/models/dynamic_modules.py
+++ b/avalanche/models/dynamic_modules.py
@@ -265,7 +265,8 @@ class IncrementalClassifier(DynamicModule):
         """
         out = self.classifier(x)
         if self.masking:
-            out[..., torch.logical_not(self.active_units)] = self.mask_value
+            mask = torch.logical_not(self.active_units)
+            out.masked_fill_(mask=mask, value=self.mask_value)
         return out
 
 

--- a/avalanche/models/dynamic_modules.py
+++ b/avalanche/models/dynamic_modules.py
@@ -266,7 +266,7 @@ class IncrementalClassifier(DynamicModule):
         out = self.classifier(x)
         if self.masking:
             mask = torch.logical_not(self.active_units)
-            out.masked_fill_(mask=mask, value=self.mask_value)
+            out = out.masked_fill(mask=mask, value=self.mask_value)
         return out
 
 

--- a/avalanche/training/plugins/rar.py
+++ b/avalanche/training/plugins/rar.py
@@ -174,13 +174,7 @@ class RARPlugin(SupervisedPlugin):
             copy_model, return_nodes=[self.name_ext_layer]
         )
 
-        params_list = []
-        for param_group in strategy.optimizer.state_dict()["param_groups"]:
-            for i, p in enumerate(copy_model.parameters()):
-                if i in param_group["params"]:
-                    params_list.append(p)
-
-        optimizer = SGD(params_list, lr=self.opt_lr)
+        optimizer = SGD(copy_model.parameters(), lr=self.opt_lr)
 
         optimizer.zero_grad()
         output = copy_model(strategy.mb_x)


### PR DESCRIPTION
When testing the RAR implementation using a model with `IncrementalClassifier` class, @AlbinSou found a new error.

The problem arises between an incompatibility between `IncremetnalClassifier` and the `feature_extraction` functions from pytorch. Because of this, I changed the mask function in the `IncrementalClassifier` class to be an in_place operation. This solves the first problem.

A second problem was a `KeyError` problem with `optimizer.state_dict()`. Because of this, I simplified the RAR implementation. This can help with the performance but sometimes take more time to run.