### PR TITLE
Speedup for long benchmarks iteration

### DIFF
--- a/avalanche/benchmarks/scenarios/lazy_dataset_sequence.py
+++ b/avalanche/benchmarks/scenarios/lazy_dataset_sequence.py
@@ -244,9 +244,11 @@ class LazyDatasetSequence(Sequence[TCLDataset]):
                 )
 
             self._loaded_experiences[exp_id] = generated_exp
-            self.targets_field_sequence[exp_id] = getattr(generated_exp, "targets")
-            self.task_labels_field_sequence[exp_id] = getattr(
-                generated_exp, "targets_task_labels"
+            self.targets_field_sequence[exp_id] = list(
+                getattr(generated_exp, "targets")
+            )
+            self.task_labels_field_sequence[exp_id] = list(
+                getattr(generated_exp, "targets_task_labels")
             )
             self._next_exp_id += 1
 


### PR DESCRIPTION
A simple fix to speedup benchmark creation and stream iteration.

The impact is greatly noticeable in long benchmarks (such as SplitImagenet, n_experiences=1000), where the iteration time on the training stream drops from 1h to 1m. I also tried other optimizations regarding FlatData, but this seems to be the most straightforward solution.