### PR TITLE
Remove setuptools version constraint

### DIFF
--- a/avalanche/training/supervised/lamaml_v2.py
+++ b/avalanche/training/supervised/lamaml_v2.py
@@ -1,11 +1,8 @@
 from typing import Callable, List, Sequence, Optional, Union
+from packaging.version import parse
+import torch
 
-import pkg_resources
-from pkg_resources import DistributionNotFound, VersionConflict
-
-try:
-    pkg_resources.require("torch>=2.0.0")
-except (DistributionNotFound, VersionConflict) as e:
+if parse(torch.__version__) < parse("2.0.0"):
     raise RuntimeError(f"LaMAML requires torch >= 2.0.0.")
 
 import torch
@@ -20,7 +17,6 @@ from copy import deepcopy
 from avalanche.training.plugins import SupervisedPlugin, EvaluationPlugin
 from avalanche.training.plugins.evaluation import default_evaluator
 from avalanche.training.templates import SupervisedMetaLearningTemplate
-from avalanche.models.utils import avalanche_forward
 from avalanche.training.storage_policy import ReservoirSamplingBuffer
 
 

--- a/avalanche/training/templates/base_sgd.py
+++ b/avalanche/training/templates/base_sgd.py
@@ -1,5 +1,5 @@
 from typing import Any, Callable, Iterable, Sequence, Optional, TypeVar, Union
-from pkg_resources import parse_version
+from packaging.version import parse
 
 import torch
 from torch.nn import Module, CrossEntropyLoss
@@ -358,7 +358,7 @@ class BaseSGDTemplate(
         other_dataloader_args = {}
 
         if "persistent_workers" in kwargs:
-            if parse_version(torch.__version__) >= parse_version("1.7.0"):
+            if parse(torch.__version__) >= parse("1.7.0"):
                 other_dataloader_args["persistent_workers"] = kwargs[
                     "persistent_workers"
                 ]

--- a/examples/detection.py
+++ b/examples/detection.py
@@ -16,7 +16,7 @@ the stream of experiences is obtained by splitting the dataset in equal parts.
 """
 
 import argparse
-from pkg_resources import parse_version
+from packaging.version import parse
 import torch
 import torchvision
 import logging
@@ -152,9 +152,7 @@ def main(args):
 
 
 def obtain_base_model(segmentation: bool):
-    torchvision_is_old_version = parse_version(torch.__version__) < parse_version(
-        "0.13"
-    )
+    torchvision_is_old_version = parse(torch.__version__) < parse("0.13")
 
     pretrain_argument = dict()
 

--- a/examples/detection_lvis.py
+++ b/examples/detection_lvis.py
@@ -19,7 +19,7 @@ import logging
 from pathlib import Path
 from typing import Union
 
-from pkg_resources import parse_version
+from packaging.version import parse
 
 from avalanche.benchmarks.datasets.lvis_dataset import LvisDataset
 from avalanche.evaluation.metrics.detection import make_lvis_metrics
@@ -134,9 +134,7 @@ def main(args):
 
 
 def obtain_base_model(segmentation: bool):
-    torchvision_is_old_version = parse_version(torch.__version__) < parse_version(
-        "0.13"
-    )
+    torchvision_is_old_version = parse(torch.__version__) < parse("0.13")
 
     pretrain_argument = dict()
 

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setuptools.setup(
         "gdown",
         "quadprog",
         "dill",
-        "setuptools<=59.5.0",
+        "setuptools",
     ],
     extras_require=get_extra_requires("extra_dependencies.txt", add_all=True),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setuptools.setup(
         "gdown",
         "quadprog",
         "dill",
-        "setuptools",
+        "packaging",
     ],
     extras_require=get_extra_requires("extra_dependencies.txt", add_all=True),
     include_package_data=True,

--- a/tests/benchmarks/scenarios/test_rl_scenario.py
+++ b/tests/benchmarks/scenarios/test_rl_scenario.py
@@ -11,7 +11,6 @@ try:
     skip = False
 except ImportError:
     skip = True
-skip = False
 
 
 class RLScenarioTests(unittest.TestCase):


### PR DESCRIPTION
After some testing, it seems that we can remove the runtime dependency on setuptools.

This switches the runtime version checks (previously done using setuptools `pkg_resources`) to `packaging`, as `pkg_resources` is deprecated.

Minor fix for `rl` unit tests, that raised an error if an optional dependency could not be found.