### PR TITLE
Fix for NCM forward pass when no class mean is present yet

### DIFF
--- a/avalanche/models/ncm_classifier.py
+++ b/avalanche/models/ncm_classifier.py
@@ -62,7 +62,8 @@ class NCMClassifier(DynamicModule):
         first_mean = list(self.class_means_dict.values())[0]
         feature_size = first_mean.size(0)
         device = first_mean.device
-        self.class_means = torch.zeros(self.max_class+1, feature_size).to(device)
+        self.class_means = torch.zeros(self.max_class+1,
+                                       feature_size).to(device)
 
         for k, v in self.class_means_dict.items():
             self.class_means[k] = self.class_means_dict[k].clone()
@@ -107,10 +108,12 @@ class NCMClassifier(DynamicModule):
         """
         assert momentum <= 1 and momentum >= 0
         assert isinstance(class_means_dict, dict), (
-            "class_means_dict must be a dictionary mapping class_id " "to mean vector"
+            "class_means_dict must be a dictionary mapping class_id "
+            "to mean vector"
         )
         for k, v in class_means_dict.items():
-            if k not in self.class_means_dict:
+            if (k not in self.class_means_dict or
+                    (self.class_means_dict[k] == 0).all()):
                 self.class_means_dict[k] = class_means_dict[k].clone()
             else:
                 device = self.class_means_dict[k].device
@@ -126,10 +129,11 @@ class NCMClassifier(DynamicModule):
         Replace existing dictionary of means with a given dictionary.
         """
         assert isinstance(class_means_dict, dict), (
-            "class_means_dict must be a dictionary mapping class_id " "to mean vector"
+            "class_means_dict must be a dictionary mapping class_id "
+            "to mean vector"
         )
-        self.class_means_dict = {k: v.clone() for k, v in class_means_dict.items()}
-
+        self.class_means_dict = {k: v.clone()
+                                 for k, v in class_means_dict.items()}
         self._vectorize_means_dict()
 
     def init_missing_classes(self, classes, class_size, device):

--- a/avalanche/models/ncm_classifier.py
+++ b/avalanche/models/ncm_classifier.py
@@ -62,8 +62,7 @@ class NCMClassifier(DynamicModule):
         first_mean = list(self.class_means_dict.values())[0]
         feature_size = first_mean.size(0)
         device = first_mean.device
-        self.class_means = torch.zeros(self.max_class+1,
-                                       feature_size).to(device)
+        self.class_means = torch.zeros(self.max_class + 1, feature_size).to(device)
 
         for k, v in self.class_means_dict.items():
             self.class_means[k] = self.class_means_dict[k].clone()
@@ -78,10 +77,7 @@ class NCMClassifier(DynamicModule):
         with respect to each class.
         """
         if self.class_means_dict == {}:
-            self.init_missing_classes(
-                range(self.max_class+1),
-                x.shape[1],
-                x.device)
+            self.init_missing_classes(range(self.max_class + 1), x.shape[1], x.device)
 
         assert self.class_means_dict != {}, "no class means available."
         if self.normalize:
@@ -108,12 +104,10 @@ class NCMClassifier(DynamicModule):
         """
         assert momentum <= 1 and momentum >= 0
         assert isinstance(class_means_dict, dict), (
-            "class_means_dict must be a dictionary mapping class_id "
-            "to mean vector"
+            "class_means_dict must be a dictionary mapping class_id " "to mean vector"
         )
         for k, v in class_means_dict.items():
-            if (k not in self.class_means_dict or
-                    (self.class_means_dict[k] == 0).all()):
+            if k not in self.class_means_dict or (self.class_means_dict[k] == 0).all():
                 self.class_means_dict[k] = class_means_dict[k].clone()
             else:
                 device = self.class_means_dict[k].device
@@ -129,19 +123,15 @@ class NCMClassifier(DynamicModule):
         Replace existing dictionary of means with a given dictionary.
         """
         assert isinstance(class_means_dict, dict), (
-            "class_means_dict must be a dictionary mapping class_id "
-            "to mean vector"
+            "class_means_dict must be a dictionary mapping class_id " "to mean vector"
         )
-        self.class_means_dict = {k: v.clone()
-                                 for k, v in class_means_dict.items()}
+        self.class_means_dict = {k: v.clone() for k, v in class_means_dict.items()}
         self._vectorize_means_dict()
 
     def init_missing_classes(self, classes, class_size, device):
         for k in classes:
             if k not in self.class_means_dict:
-                self.class_means_dict[k] = torch.zeros(class_size).to(
-                    device
-                )
+                self.class_means_dict[k] = torch.zeros(class_size).to(device)
         self._vectorize_means_dict()
 
     def eval_adaptation(self, experience):
@@ -149,9 +139,9 @@ class NCMClassifier(DynamicModule):
         for k in classes:
             self.max_class = max(k, self.max_class)
         if self.class_means is not None:
-            self.init_missing_classes(classes,
-                                      self.class_means.shape[1],
-                                      self.class_means.device)
+            self.init_missing_classes(
+                classes, self.class_means.shape[1], self.class_means.device
+            )
 
 
 __all__ = ["NCMClassifier"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -639,6 +639,13 @@ class NCMClassifierTest(unittest.TestCase):
         classifier.replace_class_means_dict(new_dict)
         assert (classifier.class_means[:, 0] == 2).all()
 
+    def test_ncm_forward_without_class_means(self):
+        classifier = NCMClassifier()
+        classifier.init_missing_classes(list(range(10)),
+                                        7, 'cpu')
+        logits = classifier(torch.randn(2, 7))
+        assert logits.shape == (2, 10)
+
     def test_ncm_save_load(self):
         classifier = NCMClassifier()
         classifier.update_class_means_dict(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -641,8 +641,7 @@ class NCMClassifierTest(unittest.TestCase):
 
     def test_ncm_forward_without_class_means(self):
         classifier = NCMClassifier()
-        classifier.init_missing_classes(list(range(10)),
-                                        7, 'cpu')
+        classifier.init_missing_classes(list(range(10)), 7, "cpu")
         logits = classifier(torch.randn(2, 7))
         assert logits.shape == (2, 10)
 

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -862,6 +862,7 @@ class StrategyTest(unittest.TestCase):
             train_epochs=2,
             eval_mb_size=50,
             device=self.device,
+            eval_every=1
         )
 
         run_strategy(benchmark, strategy)

--- a/tests/training/test_strategies.py
+++ b/tests/training/test_strategies.py
@@ -862,7 +862,7 @@ class StrategyTest(unittest.TestCase):
             train_epochs=2,
             eval_mb_size=50,
             device=self.device,
-            eval_every=1
+            eval_every=1,
         )
 
         run_strategy(benchmark, strategy)


### PR DESCRIPTION
NCM now supports forward pass even when no class mean is provided. NCM automatically initializes class means to zero based on the largest class found in the eval dataset during eval adaptation.