### PR TITLE
Some minor fixes in batch_observation and utils

### DIFF
--- a/avalanche/training/templates/observation_type/batch_observation.py
+++ b/avalanche/training/templates/observation_type/batch_observation.py
@@ -76,9 +76,6 @@ class BatchObservation(SGDStrategyProtocol):
         if at_task_boundary(self.experience):
             self.model = self.model_adaptation()
             self.make_optimizer(reset_optimizer_state=reset_optimizer_state, **kwargs)
-        else:
-            self.model = self.model_adaptation()
-            self.make_optimizer(reset_optimizer_state=reset_optimizer_state, **kwargs)
 
 
 __all__ = ["BatchObservation"]

--- a/avalanche/training/templates/observation_type/batch_observation.py
+++ b/avalanche/training/templates/observation_type/batch_observation.py
@@ -8,7 +8,7 @@ from avalanche.benchmarks import OnlineCLExperience
 from avalanche.models.utils import avalanche_model_adaptation
 from avalanche.training.templates.strategy_mixin_protocol import SGDStrategyProtocol
 from avalanche.models.dynamic_optimizers import reset_optimizer, update_optimizer
-from avalanche.training.utils import at_task_boundary
+from avalanche.training.utils import _at_task_boundary
 
 
 class BatchObservation(SGDStrategyProtocol):
@@ -73,7 +73,7 @@ class BatchObservation(SGDStrategyProtocol):
         if self.optimized_param_id is None:
             self.make_optimizer(reset_optimizer_state=True, **kwargs)
 
-        if at_task_boundary(self.experience):
+        if _at_task_boundary(self.experience, before=True):
             self.model = self.model_adaptation()
             self.make_optimizer(reset_optimizer_state=reset_optimizer_state, **kwargs)
 

--- a/avalanche/training/utils.py
+++ b/avalanche/training/utils.py
@@ -15,15 +15,15 @@ General utility functions for pytorch.
 
 """
 from collections import defaultdict
-from typing import Dict, NamedTuple, List, Optional, Tuple, Callable, Union
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
-from torch.nn import Module, Linear
-from torch.utils.data import Dataset, DataLoader
+from torch.nn import Linear, Module
+from torch.utils.data import DataLoader, Dataset
 
-from avalanche.models.batch_renorm import BatchRenorm2D
 from avalanche.benchmarks import OnlineCLExperience
+from avalanche.models.batch_renorm import BatchRenorm2D
 
 
 def at_task_boundary(training_experience) -> bool:
@@ -45,7 +45,10 @@ def at_task_boundary(training_experience) -> bool:
 
     if isinstance(training_experience, OnlineCLExperience):
         if training_experience.access_task_boundaries:
-            if training_experience.is_first_subexp:
+            if (
+                training_experience.is_first_subexp
+                or training_experience.is_last_subexp
+            ):
                 return True
         else:
             return True
@@ -222,7 +225,7 @@ def replace_bn_with_brn(
 ):
     for attr_str in dir(m):
         target_attr = getattr(m, attr_str)
-        if type(target_attr) == torch.nn.BatchNorm2d:
+        if isinstance(target_attr, torch.nn.BatchNorm2d):
             # print('replaced: ', name, attr_str)
             setattr(
                 m,
@@ -253,7 +256,7 @@ def change_brn_pars(
 ):
     for attr_str in dir(m):
         target_attr = getattr(m, attr_str)
-        if type(target_attr) == BatchRenorm2D:
+        if isinstance(target_attr, BatchRenorm2D):
             target_attr.momentum = torch.tensor((momentum), requires_grad=False)
             target_attr.r_max = torch.tensor(r_max, requires_grad=False)
             target_attr.d_max = torch.tensor(d_max, requires_grad=False)

--- a/avalanche/training/utils.py
+++ b/avalanche/training/utils.py
@@ -26,7 +26,7 @@ from avalanche.benchmarks import OnlineCLExperience
 from avalanche.models.batch_renorm import BatchRenorm2D
 
 
-def at_task_boundary(training_experience) -> bool:
+def _at_task_boundary(training_experience, before=True) -> bool:
     """
     Given a training experience,
     returns true if the experience is at the task boundary
@@ -41,14 +41,17 @@ def at_task_boundary(training_experience) -> bool:
 
     - If the experience is not an online experience, returns True
 
+    :param before: If used in before_training_exp, 
+                   set to True, otherwise set 
+                   to False
+
     """
 
     if isinstance(training_experience, OnlineCLExperience):
         if training_experience.access_task_boundaries:
-            if (
-                training_experience.is_first_subexp
-                or training_experience.is_last_subexp
-            ):
+            if before and training_experience.is_first_subexp:
+                return True
+            elif (not before) and training_experience.is_last_subexp:
                 return True
         else:
             return True
@@ -484,5 +487,4 @@ __all__ = [
     "examples_per_class",
     "ParamData",
     "cycle",
-    "at_task_boundary",
 ]

--- a/avalanche/training/utils.py
+++ b/avalanche/training/utils.py
@@ -41,8 +41,8 @@ def _at_task_boundary(training_experience, before=True) -> bool:
 
     - If the experience is not an online experience, returns True
 
-    :param before: If used in before_training_exp, 
-                   set to True, otherwise set 
+    :param before: If used in before_training_exp,
+                   set to True, otherwise set
                    to False
 
     """


### PR DESCRIPTION
Two fixes,

One is some useless code that was left in the batch_observation. This code was slowing down a bit in the case of using an online setting with access to task boundaries. I had mistakenly left this part of code when switching to using util function at_task_boundary.

Another is about some formatting and changing one feature in the at_task_boundary function. So far the function was only using is_first_subexp attribute which was leading to some problems when using it in after_training_task, it was not detecting the boundary if the experience was the last experience of the task. Now it is detecting the boundary both right before the shift and right after the shift.