### PR TITLE
Added NewClassesCrossEntropy criterion and automatic criterion plugin

### DIFF
--- a/avalanche/training/losses.py
+++ b/avalanche/training/losses.py
@@ -168,16 +168,15 @@ class MaskedCrossEntropy(SupervisedPlugin):
     """
     Masked Cross Entropy
 
-    This criterion can be used for instance
-    in Class Incremental Learning Problems
-    when no examplars are used (i.e LwF in Class Incremental Learning 
-    would need to use mask="new").
+    This criterion can be used for instance in Class Incremental
+    Learning Problems when no examplars are used
+    (i.e LwF in Class Incremental Learning would need to use mask="new").
     """
 
     def __init__(self, classes=None, mask="all", reduction="mean"):
         """
         param: classes: Initial value for current classes
-        param: mask: "all" normal cross entropy, uses all the classes seen so far 
+        param: mask: "all" normal cross entropy, uses all the classes seen so far
                      "old" cross entropy only on the old classes
                      "new" cross entropy only on the new classes
         param: reduction: "mean" or "none", average or per-sample loss

--- a/avalanche/training/losses.py
+++ b/avalanche/training/losses.py
@@ -173,7 +173,7 @@ class MaskedCrossEntropy(SupervisedPlugin):
     (i.e LwF in Class Incremental Learning would need to use mask="new").
     """
 
-    def __init__(self, classes=None, mask="seen", reduction="batchmean"):
+    def __init__(self, classes=None, mask="seen", reduction="mean"):
         """
         param: classes: Initial value for current classes
         param: mask: "all" normal cross entropy, uses all the classes seen so far
@@ -198,11 +198,10 @@ class MaskedCrossEntropy(SupervisedPlugin):
         oh_targets = oh_targets[:, self.current_mask(logits.shape[1])]
         logits = logits[:, self.current_mask(logits.shape[1])]
 
-        return F.kl_div(
-            torch.log_softmax(logits, dim=1),
+        return cross_entropy_with_oh_targets(
+            logits,
             oh_targets.float(),
             reduction=self.reduction,
-            log_target=False,
         )
 
     def current_mask(self, logit_shape):

--- a/avalanche/training/regularization.py
+++ b/avalanche/training/regularization.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 from avalanche.models import MultiTaskModule, avalanche_forward
 
 
-def cross_entropy_with_oh_targets(outputs, targets, eps=1e-5, reduction="mean"):
+def cross_entropy_with_oh_targets(outputs, targets, reduction="mean"):
     """Calculates cross-entropy with temperature scaling,
     targets can also be soft targets but they must sum to 1"""
     outputs = torch.nn.functional.softmax(outputs, dim=1)

--- a/avalanche/training/regularization.py
+++ b/avalanche/training/regularization.py
@@ -8,11 +8,18 @@ import torch.nn.functional as F
 
 from avalanche.models import MultiTaskModule, avalanche_forward
 
+def stable_softmax(x):
+    z = x - torch.max(x, dim=1, keepdim=True)[0]
+    numerator = torch.exp(z)
+    denominator = torch.sum(numerator, dim=1, keepdim=True)
+    softmax = numerator / denominator
+    return softmax
+
 
 def cross_entropy_with_oh_targets(outputs, targets, reduction="mean"):
     """Calculates cross-entropy with temperature scaling,
     targets can also be soft targets but they must sum to 1"""
-    outputs = torch.nn.functional.softmax(outputs, dim=1)
+    outputs = stable_softmax(outputs)
     ce = -(targets * outputs.log()).sum(1)
     if reduction == "mean":
         ce = ce.mean()

--- a/avalanche/training/regularization.py
+++ b/avalanche/training/regularization.py
@@ -9,12 +9,17 @@ import torch.nn.functional as F
 from avalanche.models import MultiTaskModule, avalanche_forward
 
 
-def cross_entropy_with_oh_targets(outputs, targets, eps=1e-5):
+def cross_entropy_with_oh_targets(outputs, targets, eps=1e-5, reduction="mean"):
     """Calculates cross-entropy with temperature scaling,
     targets can also be soft targets but they must sum to 1"""
     outputs = torch.nn.functional.softmax(outputs, dim=1)
     ce = -(targets * outputs.log()).sum(1)
-    ce = ce.mean()
+    if reduction == "mean":
+        ce = ce.mean()
+    elif reduction == "none":
+        return ce
+    else:
+        raise NotImplementedError("reduction must be mean or none")
     return ce
 
 

--- a/avalanche/training/regularization.py
+++ b/avalanche/training/regularization.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 
 from avalanche.models import MultiTaskModule, avalanche_forward
 
+
 def stable_softmax(x):
     z = x - torch.max(x, dim=1, keepdim=True)[0]
     numerator = torch.exp(z)

--- a/avalanche/training/templates/base_sgd.py
+++ b/avalanche/training/templates/base_sgd.py
@@ -96,7 +96,7 @@ class BaseSGDTemplate(
         self._criterion = criterion
         """ Criterion. """
 
-        if criterion not in plugins and isinstance(criterion, BasePlugin):
+        if criterion not in self.plugins and isinstance(criterion, BasePlugin):
             self.plugins.append(criterion)
 
         self.train_epochs: int = train_epochs

--- a/avalanche/training/templates/base_sgd.py
+++ b/avalanche/training/templates/base_sgd.py
@@ -96,6 +96,9 @@ class BaseSGDTemplate(
         self._criterion = criterion
         """ Criterion. """
 
+        if criterion not in plugins and isinstance(criterion, BasePlugin):
+            self.plugins.append(criterion)
+
         self.train_epochs: int = train_epochs
         """ Number of training epochs. """
 

--- a/tests/training/test_losses.py
+++ b/tests/training/test_losses.py
@@ -1,7 +1,9 @@
 import unittest
 
 import torch
-from avalanche.training.losses import ICaRLLossPlugin
+import torch.nn as nn
+
+from avalanche.training.losses import ICaRLLossPlugin, NewClassesCrossEntropy
 
 
 class TestICaRLLossPlugin(unittest.TestCase):
@@ -32,6 +34,24 @@ class TestICaRLLossPlugin(unittest.TestCase):
         loss3 = criterion(new_pred, mb_y)
 
         assert loss3 == loss1
+
+
+class TestNewClassesCrossEntropy(unittest.TestCase):
+    def test_loss(self):
+        cross_entropy = nn.CrossEntropyLoss()
+
+        criterion = NewClassesCrossEntropy()
+        criterion.current_classes = [5, 6, 7]
+
+        mb_y = torch.tensor([5, 5, 6, 7, 6])
+
+        new_pred = torch.rand(5, 8)
+        new_pred_new = new_pred[:, criterion.current_classes]
+
+        loss1 = criterion(new_pred, mb_y)
+        loss2 = cross_entropy(new_pred_new, mb_y - 5)
+
+        assert float(loss1) == float(loss2)
 
 
 if __name__ == "__main__":

--- a/tests/training/test_losses.py
+++ b/tests/training/test_losses.py
@@ -1,4 +1,5 @@
 import unittest
+
 import torch
 import torch.nn as nn
 
@@ -46,12 +47,12 @@ class TestMaskedCrossEntropy(unittest.TestCase):
         mb_y = torch.tensor([5, 5, 6, 7, 6])
 
         new_pred = torch.rand(5, 8)
-        new_pred_new = new_pred[:, criterion.current_mask]
+        new_pred_new = new_pred[:, criterion.current_mask(new_pred.shape[1])]
 
         loss1 = criterion(new_pred, mb_y)
         loss2 = cross_entropy(new_pred_new, mb_y - 5)
 
-        criterion.mask = "all"
+        criterion.mask = "seen"
         loss3 = criterion(new_pred, mb_y)
 
         self.assertAlmostEqual(float(loss1), float(loss2), places=5)


### PR DESCRIPTION
I added a criterion that is very important when considering exemplar free scenarios, and only considers the learning of the new task. It's like a multitask learning criterion except this time we don't have task labels so the model outputs the full logits but when not using exemplars we want to update only the last head with the cross-entropy loss in order to avoid task-recency bias.

I personally needed this criterion to use LwF in the class incremental learning scenario but I think that in general it is useful whenever using functional regularization in CIL in the examplar free setting.

Another change that I introduced is more of a personal choice and I need your input on that. I noticed that many criterias were implemented as plugins because they need to access at some point some info about the training (i.e save a model, register current classes etc ...).

To reduce the burden of the user, I now automatically add the criterions that are also plugins to the list of plugins, by first checking that they are not already there to not have 2 times the same plugin. Let me know if you think this is a good idea otherwise I can get rid of it.

Another thing I noticed, is that the training criterion is used at evaluation.  I don't know if that could be interesting to use a training criterion and evaluation criterion or if this is too much. For instance when doing exemplar free learning, you want to learn only on the new task but you still want to have the full cross entropy as a criterion when evaluating on the previous experiences. The current behavior is that it gives 0 loss to all previous experiences and it gives some loss value to the new experience only.