### PR TITLE
proper conversion of Tensor to list

### DIFF
--- a/avalanche/benchmarks/utils/utils.py
+++ b/avalanche/benchmarks/utils/utils.py
@@ -318,9 +318,11 @@ def _traverse_supported_dataset(
         result = []
         if indices is None:
             for c_dataset in dataset.datasets:
-                result += list(
-                    _traverse_supported_dataset(c_dataset, values_selector, indices)
-                )
+                result_data = _traverse_supported_dataset(c_dataset, values_selector)
+                if isinstance(result_data, Tensor):
+                    result += result_data.tolist()
+                else:
+                    result += list(result_data)
             return result
 
         datasets_to_indexes = defaultdict(list)

--- a/tests/benchmarks/utils/test_avalanche_classification_dataset.py
+++ b/tests/benchmarks/utils/test_avalanche_classification_dataset.py
@@ -328,6 +328,18 @@ class AvalancheDatasetTests(unittest.TestCase):
         self.assertEqual(5, z2)
         self.assertEqual(0, t2)
 
+    def test_avalanche_concat_dataset_targets_val_to_idx(self):
+        tensor_x = torch.rand(100, 3, 28, 28)
+        tensor_x2 = torch.rand(11, 3, 28, 28)
+        tensor_y = torch.randint(0, 10, (100,))
+        tensor_y2 = torch.randint(0, 10, (11,))
+        dataset1 = TensorDataset(tensor_x, tensor_y)
+        dataset2 = TensorDataset(tensor_x2, tensor_y2)
+        concat = dataset1 + dataset2
+        av_dataset = _make_taskaware_classification_dataset(concat)
+        self.assertIsInstance(av_dataset.targets.val_to_idx[0], list)
+        self.assertEqual(10, len(av_dataset.targets.val_to_idx))
+
     def test_avalanche_dataset_from_pytorch_subset(self):
         tensor_x = torch.rand(500, 3, 28, 28)
         tensor_y = torch.randint(0, 100, (500,))


### PR DESCRIPTION
`list(torch.Tensor) ` doesn't convert Tensor to list of scalars, but to list of Tensors.

I checked this is True for pytorch versions 1.12 and 2.0

```
[ins] In [6]: a = torch.Tensor([0,1])
[ins] In [7]: a.tolist()
Out[7]: [0.0, 1.0]
[ins] In [8]: list(a)
Out[8]: [tensor(0.), tensor(1.)]
```
 
That lead to the KeyError when I tried to used combined pytorch datsets, like this

```
    if args.reproduce_bugs:
        # substitute labels 0-9 with 10-19
        fmnist_test.targets += 10
        fmnist_train.targets += 10
        full_test = mnist_test + fmnist_test
        full_train = mnist_train + fmnist_train
        n_classes = 20
    else:
        full_test = mnist_test
        full_train = mnist_train
        n_classes = 10

    benchmark = nc_benchmark(
        full_train,
        full_test,
        n_experiences=n_classes // 2,
        task_labels=list(range(10)),
    )
```


I probably will open an issue, because the same probably will repeat at least for similar usage in 

> avalanche/benchmarks/utils/dataset_traversal_utils.py:191