### PR TITLE
Major BiC fix/reimplementation

### DIFF
--- a/avalanche/models/bic_model.py
+++ b/avalanche/models/bic_model.py
@@ -1,3 +1,4 @@
+from typing import Iterable, SupportsInt
 import torch
 
 
@@ -10,25 +11,28 @@ class BiasLayer(torch.nn.Module):
     Recognition. 2019"
     """
 
-    def __init__(self, device, clss):
+    def __init__(self, clss: Iterable[SupportsInt]):
         """
-        :param device: device used by the main model. 'cpu' or 'cuda'
         :param clss: list of classes of the current layer. This are use
             to identify the columns which are multiplied by the Bias
             correction Layer.
         """
         super().__init__()
-        self.alpha = torch.nn.Parameter(torch.ones(1, device=device))
-        self.beta = torch.nn.Parameter(torch.zeros(1, device=device))
+        self.alpha = torch.nn.Parameter(torch.ones(1))
+        self.beta = torch.nn.Parameter(torch.zeros(1))
 
-        self.clss = torch.Tensor(list(clss)).long().to(device)
-        self.not_clss = None
+        unique_classes = list(sorted(set(int(x) for x in clss)))
+
+        self.register_buffer("clss", torch.tensor(unique_classes, dtype=torch.long))
 
     def forward(self, x):
         alpha = torch.ones_like(x)
-        beta = torch.ones_like(x)
+        beta = torch.zeros_like(x)
 
         alpha[:, self.clss] = self.alpha
         beta[:, self.clss] = self.beta
 
         return alpha * x + beta
+
+
+__all__ = ["BiasLayer"]

--- a/avalanche/training/plugins/bic.py
+++ b/avalanche/training/plugins/bic.py
@@ -255,6 +255,7 @@ class BiCPlugin(SupervisedPlugin):
         # Make sure that the old_model is frozen (including batch norm layers)
         # requires_grad=False is not sufficient to freeze BN layers,
         # we also need eval()
+        self.model_old = None
         self.model_old = deepcopy(strategy.model)
         self.model_old.eval()
         for param in self.model_old.parameters():
@@ -381,7 +382,7 @@ class BiCPlugin(SupervisedPlugin):
             batch_size=strategy.train_mb_size,
             shuffle=True,
             num_workers=self.num_workers,
-            persistent_workers=persistent_workers,
+            persistent_workers=persistent_workers if self.num_workers > 0 else False,
         )
 
         # Loop epochs

--- a/avalanche/training/storage_policy.py
+++ b/avalanche/training/storage_policy.py
@@ -461,7 +461,10 @@ class _ParametricSingleBuffer(ExemplarsBuffer):
         self.update_from_dataset(strategy, new_data)
 
     def update_from_dataset(self, strategy, new_data):
-        self.buffer = self.buffer.concat(new_data)
+        if len(self.buffer) == 0:
+            self.buffer = new_data
+        else:
+            self.buffer = self.buffer.concat(new_data)
         self.resize(strategy, self.max_size)
 
     def resize(self, strategy, new_size: int):

--- a/tests/benchmarks/scenarios/test_task_aware.py
+++ b/tests/benchmarks/scenarios/test_task_aware.py
@@ -16,7 +16,8 @@ class TestsTaskAware(unittest.TestCase):
     def test_taskaware(self):
         """Common use case: add tas labels to class-incremental benchmark."""
         n_classes, n_samples_per_class, n_features = 10, 3, 7
-        while True:
+
+        for _ in range(10000):
             dataset = make_classification(
                 n_samples=n_classes * n_samples_per_class,
                 n_classes=n_classes,
@@ -25,6 +26,9 @@ class TestsTaskAware(unittest.TestCase):
                 n_redundant=0,
             )
 
+            # The following check is required to ensure that at least 2 exemplars
+            # per class are generated. Otherwise, the train_test_split function will
+            # fail.
             _, unique_count = np.unique(dataset[1], return_counts=True)
             if np.min(unique_count) > 1:
                 break

--- a/tests/benchmarks/scenarios/test_task_aware.py
+++ b/tests/benchmarks/scenarios/test_task_aware.py
@@ -9,19 +9,26 @@ from avalanche.benchmarks.scenarios.task_aware import task_incremental_benchmark
 from avalanche.benchmarks.utils.classification_dataset import ClassificationDataset
 from avalanche.benchmarks.utils.data_attribute import DataAttribute
 from torch.utils.data import TensorDataset
+import numpy as np
 
 
 class TestsTaskAware(unittest.TestCase):
     def test_taskaware(self):
         """Common use case: add tas labels to class-incremental benchmark."""
         n_classes, n_samples_per_class, n_features = 10, 3, 7
-        dataset = make_classification(
-            n_samples=n_classes * n_samples_per_class,
-            n_classes=n_classes,
-            n_features=n_features,
-            n_informative=6,
-            n_redundant=0,
-        )
+        while True:
+            dataset = make_classification(
+                n_samples=n_classes * n_samples_per_class,
+                n_classes=n_classes,
+                n_features=n_features,
+                n_informative=6,
+                n_redundant=0,
+            )
+
+            _, unique_count = np.unique(dataset[1], return_counts=True)
+            if np.min(unique_count) > 1:
+                break
+
         X = torch.from_numpy(dataset[0]).float()
         y = torch.from_numpy(dataset[1]).long()
         train_X, test_X, train_y, test_y = train_test_split(


### PR DESCRIPTION
This PR is a major re-implementation/global fix for [BiC (paper)](https://openaccess.thecvf.com/content_CVPR_2019/papers/Wu_Large_Scale_Incremental_Learning_CVPR_2019_paper.pdf)

The implementation found in Avalanche (and in other CL libraries as well) has various issues, mainly connected to the understanding of how the algorithm works. It's an honest mistake that I made too when reading the paper.

The official implementation of BiC can be found here (TF 1.x :/ ): https://github.com/wuyuebupt/LargeScaleIncrementalLearning/tree/master

BiC works like that:
1. Distillation phase: classic training loop with distillation loss (on logits of old classes) + classification loss (logits of old and new classes)
2. Bias correction phase: learn alpha and beta correction parameters for new classes

The main issue in Avalanche implementation is that BiC does not actually keep a separate bias correction layer for each experience, it only keeps single alpha and beta parameters (a single bias correction layer) which is then applied only to the "last" experience.

In practice:

1. Distillation phase: distill on logits (after the FC layer) by applying the bias correction on the activations of the old model (used for distillation) for the classes found in experience `current_experience-1`. Bias correction is not applied to other classes (such as the ones in `current_experience-t` t>=2, nor `current_experience`. Bias correction is not applied to the activations from the current model. The usual classification loss is applied on the logits of the current model without bias correction.
2. Discard the previous bias correction layer and learn new alpha and beta values for the classes in `current_experience`
3. (eval) During the test phase, apply the bias correction only to the logits of classes from `current_experience`

What Avalanche was doing (and I suspect FACIL too) is to keep a separate (permanent) bias correction layer for each experience. Those were then used in all phases (computing the distillation loss, classification loss, bias correction for new classes, test phase).

I noticed these problems when fixing other accidental bugs related to the freezing of the old model and bias layers, which are of course fixed in this version :).

To recap:

- Fix the distillation loss computation procedure (proper freezing of the old model, bias correction only on classes of `current_experience-1`, ...)
- Fix the loss function (see: https://colab.research.google.com/drive/1eLQbfxe6i0V7tu5spMxLSopebuP7Wc9l?usp=sharing)
- Fix the bias correction procedure (freezing of the current model, post-training bias layer freezing, ...)
- Fix the BiasLayer implementation (the forward function was bugged as the beta-derived tensor was initialized to 1s instead of 0s)
