### PR TITLE
Improve support for PyTorch 2.* and Python>=3.8

### DIFF
--- a/avalanche/benchmarks/classic/openloris.py
+++ b/avalanche/benchmarks/classic/openloris.py
@@ -14,8 +14,7 @@ It basically returns a iterable benchmark object ``GenericCLScenario`` given
 a number of configuration parameters."""
 
 from pathlib import Path
-from typing import Union, Any, Optional
-from typing_extensions import Literal
+from typing import Union, Any, Optional, Literal
 
 from avalanche.benchmarks.classic.classic_benchmarks_utils import (
     check_vision_benchmark,

--- a/avalanche/benchmarks/classic/stream51.py
+++ b/avalanche/benchmarks/classic/stream51.py
@@ -9,9 +9,7 @@
 # Website: www.continualai.org                                                 #
 ################################################################################
 from pathlib import Path
-from typing import List, Optional, Union
-
-from typing_extensions import Literal
+from typing import List, Optional, Union, Literal
 
 from avalanche.benchmarks.datasets import Stream51
 from avalanche.benchmarks.scenarios.deprecated.generic_benchmark_creation import (

--- a/avalanche/benchmarks/datasets/lvis_dataset/lvis_dataset.py
+++ b/avalanche/benchmarks/datasets/lvis_dataset/lvis_dataset.py
@@ -13,13 +13,12 @@
 """ LVIS PyTorch Object Detection Dataset """
 
 from pathlib import Path
-from typing import Optional, Union, List, Sequence
+from typing import Optional, Union, List, Sequence, TypedDict
 
 import torch
 from PIL import Image
 from torchvision.datasets.folder import default_loader
 from torchvision.transforms import ToTensor
-from typing_extensions import TypedDict
 
 from avalanche.benchmarks.datasets import (
     DownloadableDataset,

--- a/avalanche/benchmarks/datasets/mini_imagenet/mini_imagenet.py
+++ b/avalanche/benchmarks/datasets/mini_imagenet/mini_imagenet.py
@@ -66,10 +66,9 @@
 import csv
 import glob
 from pathlib import Path
-from typing import Union, List, Tuple, Dict
+from typing import Union, List, Tuple, Dict, Literal
 
 from torchvision.datasets.folder import default_loader
-from typing_extensions import Literal
 
 import PIL
 import numpy as np

--- a/avalanche/benchmarks/scenarios/deprecated/lazy_dataset_sequence.py
+++ b/avalanche/benchmarks/scenarios/deprecated/lazy_dataset_sequence.py
@@ -19,8 +19,8 @@ from typing import (
     Iterator,
     TypeVar,
     Union,
+    overload
 )
-from typing_extensions import overload
 from avalanche.benchmarks.utils.data import AvalancheDataset
 from avalanche.benchmarks.utils.dataset_utils import manage_advanced_indexing
 

--- a/avalanche/benchmarks/scenarios/deprecated/lazy_dataset_sequence.py
+++ b/avalanche/benchmarks/scenarios/deprecated/lazy_dataset_sequence.py
@@ -19,7 +19,7 @@ from typing import (
     Iterator,
     TypeVar,
     Union,
-    overload
+    overload,
 )
 from avalanche.benchmarks.utils.data import AvalancheDataset
 from avalanche.benchmarks.utils.dataset_utils import manage_advanced_indexing

--- a/avalanche/benchmarks/scenarios/generic_scenario.py
+++ b/avalanche/benchmarks/scenarios/generic_scenario.py
@@ -27,8 +27,8 @@ from typing import (
     Union,
     Generic,
     overload,
+    final
 )
-from typing_extensions import final
 
 import numpy as np
 

--- a/avalanche/benchmarks/scenarios/generic_scenario.py
+++ b/avalanche/benchmarks/scenarios/generic_scenario.py
@@ -27,7 +27,7 @@ from typing import (
     Union,
     Generic,
     overload,
-    final
+    final,
 )
 
 import numpy as np

--- a/avalanche/benchmarks/scenarios/online.py
+++ b/avalanche/benchmarks/scenarios/online.py
@@ -20,8 +20,8 @@ from typing import (
     TypeVar,
     Union,
     Protocol,
+    Literal
 )
-from typing_extensions import Literal
 import warnings
 from avalanche.benchmarks.utils.data import AvalancheDataset
 from avalanche.benchmarks.utils.utils import concat_datasets

--- a/avalanche/benchmarks/scenarios/online.py
+++ b/avalanche/benchmarks/scenarios/online.py
@@ -20,7 +20,7 @@ from typing import (
     TypeVar,
     Union,
     Protocol,
-    Literal
+    Literal,
 )
 import warnings
 from avalanche.benchmarks.utils.data import AvalancheDataset

--- a/avalanche/benchmarks/utils/collate_functions.py
+++ b/avalanche/benchmarks/utils/collate_functions.py
@@ -10,23 +10,19 @@
 ################################################################################
 
 import itertools
-from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import (
     List,
     TypeVar,
-    Generic,
     Sequence,
     Tuple,
     Dict,
     Union,
-    overload,
 )
 from typing_extensions import TypeAlias
 
 import torch
 from torch import Tensor
-from torch.utils.data import default_collate
 
 BatchT = TypeVar("BatchT")
 ExampleT = TypeVar("ExampleT")

--- a/avalanche/benchmarks/utils/dataset_definitions.py
+++ b/avalanche/benchmarks/utils/dataset_definitions.py
@@ -9,10 +9,9 @@
 # Website: avalanche.continualai.org                                           #
 ################################################################################
 
-from typing import TypeVar, SupportsInt, Sequence
+from typing import TypeVar, SupportsInt, Sequence, Protocol
 
 from torch.utils.data.dataset import Dataset
-from typing_extensions import Protocol
 
 T_co = TypeVar("T_co", covariant=True)
 TTargetType = TypeVar("TTargetType")

--- a/avalanche/benchmarks/utils/dataset_utils.py
+++ b/avalanche/benchmarks/utils/dataset_utils.py
@@ -11,8 +11,7 @@
 from abc import ABC, abstractmethod
 import bisect
 import copy
-from typing import Iterator, overload
-from typing_extensions import final
+from typing import Iterator, overload, final
 import numpy as np
 from numpy import ndarray
 from torch import Tensor

--- a/avalanche/benchmarks/utils/transform_groups.py
+++ b/avalanche/benchmarks/utils/transform_groups.py
@@ -28,8 +28,8 @@ from typing import (
     Union,
     Callable,
     Sequence,
+    Protocol
 )
-from typing_extensions import Protocol
 
 from avalanche.benchmarks.utils.transforms import (
     MultiParamCompose,

--- a/avalanche/benchmarks/utils/transform_groups.py
+++ b/avalanche/benchmarks/utils/transform_groups.py
@@ -28,7 +28,7 @@ from typing import (
     Union,
     Callable,
     Sequence,
-    Protocol
+    Protocol,
 )
 
 from avalanche.benchmarks.utils.transforms import (

--- a/avalanche/distributed/distributed_helper.py
+++ b/avalanche/distributed/distributed_helper.py
@@ -2,13 +2,12 @@ import os
 import pickle
 import warnings
 from io import BytesIO
-from typing import ContextManager, Optional, List, Any, Iterable, Dict, TypeVar
+from typing import ContextManager, Optional, List, Any, Iterable, Dict, TypeVar, Literal
 
 import torch
 from torch import Tensor
 from torch.nn.modules import Module
 from torch.nn.parallel import DistributedDataParallel
-from typing_extensions import Literal
 from torch.distributed import init_process_group, broadcast_object_list
 
 

--- a/avalanche/evaluation/metric_definitions.py
+++ b/avalanche/evaluation/metric_definitions.py
@@ -18,8 +18,9 @@ from typing import (
     List,
     Union,
     overload,
+    Literal,
+    Protocol
 )
-from typing_extensions import Literal, Protocol
 from .metric_results import MetricValue, MetricType, AlternativeValues
 from .metric_utils import (
     get_metric_name,

--- a/avalanche/evaluation/metric_definitions.py
+++ b/avalanche/evaluation/metric_definitions.py
@@ -19,7 +19,7 @@ from typing import (
     Union,
     overload,
     Literal,
-    Protocol
+    Protocol,
 )
 from .metric_results import MetricValue, MetricType, AlternativeValues
 from .metric_utils import (

--- a/avalanche/evaluation/metrics/confusion_matrix.py
+++ b/avalanche/evaluation/metrics/confusion_matrix.py
@@ -18,7 +18,7 @@ from typing import (
     Optional,
     TYPE_CHECKING,
     List,
-    Literal
+    Literal,
 )
 
 import wandb

--- a/avalanche/evaluation/metrics/confusion_matrix.py
+++ b/avalanche/evaluation/metrics/confusion_matrix.py
@@ -10,7 +10,6 @@
 ################################################################################
 from matplotlib.figure import Figure
 from numpy import arange
-from typing_extensions import Literal
 from typing import (
     Any,
     Callable,
@@ -19,6 +18,7 @@ from typing import (
     Optional,
     TYPE_CHECKING,
     List,
+    Literal
 )
 
 import wandb

--- a/avalanche/evaluation/metrics/detection.py
+++ b/avalanche/evaluation/metrics/detection.py
@@ -15,7 +15,7 @@ from typing import (
     Callable,
     Sequence,
     Optional,
-    Protocol
+    Protocol,
 )
 
 from avalanche.benchmarks.utils.data import AvalancheDataset

--- a/avalanche/evaluation/metrics/detection.py
+++ b/avalanche/evaluation/metrics/detection.py
@@ -15,6 +15,7 @@ from typing import (
     Callable,
     Sequence,
     Optional,
+    Protocol
 )
 
 from avalanche.benchmarks.utils.data import AvalancheDataset
@@ -41,7 +42,6 @@ from torch import Tensor
 from json import JSONEncoder
 
 from torch.utils.data import Subset, ConcatDataset
-from typing_extensions import Protocol
 
 from avalanche.evaluation import PluginMetric
 from avalanche.evaluation.metric_results import MetricValue

--- a/avalanche/evaluation/metrics/images_samples.py
+++ b/avalanche/evaluation/metrics/images_samples.py
@@ -1,4 +1,4 @@
-from typing import List, TYPE_CHECKING, Tuple
+from typing import List, TYPE_CHECKING, Tuple, Literal
 
 from torch import Tensor
 from torch.utils.data import DataLoader
@@ -14,8 +14,6 @@ from avalanche.evaluation.metric_results import (
     MetricValue,
 )
 from avalanche.evaluation.metric_utils import get_metric_name
-
-from typing_extensions import Literal
 
 
 if TYPE_CHECKING:

--- a/avalanche/evaluation/metrics/labels_repartition.py
+++ b/avalanche/evaluation/metrics/labels_repartition.py
@@ -8,6 +8,7 @@ from typing import (
     List,
     Counter,
     overload,
+    Literal
 )
 
 from matplotlib.figure import Figure
@@ -18,8 +19,6 @@ from avalanche.evaluation.metric_utils import (
     stream_type,
     default_history_repartition_image_creator,
 )
-
-from typing_extensions import Literal
 
 
 if TYPE_CHECKING:

--- a/avalanche/evaluation/metrics/labels_repartition.py
+++ b/avalanche/evaluation/metrics/labels_repartition.py
@@ -8,7 +8,7 @@ from typing import (
     List,
     Counter,
     overload,
-    Literal
+    Literal,
 )
 
 from matplotlib.figure import Figure

--- a/avalanche/evaluation/metrics/mean_scores.py
+++ b/avalanche/evaluation/metrics/mean_scores.py
@@ -11,7 +11,7 @@ classes.
 """
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Callable, Dict, Set, TYPE_CHECKING, List, Optional, TypeVar
+from typing import Callable, Dict, Set, TYPE_CHECKING, List, Optional, TypeVar, Literal
 
 import torch
 from matplotlib.axes import Axes
@@ -25,8 +25,6 @@ from avalanche.evaluation.metric_utils import get_metric_name
 from avalanche.evaluation.metrics import Mean
 from avalanche.evaluation.metric_results import MetricValue, AlternativeValues
 
-
-from typing_extensions import Literal
 
 if TYPE_CHECKING:
     from avalanche.training.templates import SupervisedTemplate

--- a/avalanche/training/plugins/lr_scheduling.py
+++ b/avalanche/training/plugins/lr_scheduling.py
@@ -1,7 +1,5 @@
 import warnings
-from typing import TYPE_CHECKING
-
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Literal
 
 from avalanche.evaluation.metrics import Mean
 from avalanche.training.plugins import SupervisedPlugin

--- a/avalanche/training/templates/strategy_mixin_protocol.py
+++ b/avalanche/training/templates/strategy_mixin_protocol.py
@@ -1,5 +1,4 @@
-from typing import Iterable, List, Optional, Sequence, Tuple, TypeVar
-from typing_extensions import Protocol
+from typing import Iterable, List, Optional, TypeVar, Protocol
 
 from torch import Tensor
 import torch

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,10 +31,9 @@ dependencies:
 - conda-forge::sphinx-autoapi
 - conda-forge::sphinx-copybutton
 - pip:
-    - typing-extensions==4.4.0
+    - typing-extensions
     - pytorchcv
     - gdown
-    - ctrl-benchmark
     - higher
     - gym
     - lvis

--- a/environment.yml
+++ b/environment.yml
@@ -25,10 +25,9 @@ dependencies:
 - conda-forge::pycocotools
 - conda-forge::torchmetrics
 - pip:
-    - typing-extensions==4.4.0
+    - typing-extensions
     - pytorchcv
     - gdown
-    - ctrl-benchmark
     - gym
     - higher
     - lvis


### PR DESCRIPTION
- Moves many imports from typing-extensions to typing. This also fixes the multiple inheritance issue (at least on Python 3.8). Only TypeAlias imports are kept because they are needed for Python<3.10.
- Removes ctrl-benchmark from the conda definition file due to ctrl-benchmark having a strict torch<2 dependency
  - This should also fix the recent issues in the CI: by installing ctrl-benchmark, PyTorch was replaced with a cuda pip version (thus ignoring conda's cpuonly).
  Related: https://discuss.pytorch.org/t/modulenotfounderror-no-module-named-torch-dynamo/193014