### PR TITLE
Changes in Dynamic Modules

### DIFF
--- a/avalanche/models/dynamic_modules.py
+++ b/avalanche/models/dynamic_modules.py
@@ -173,11 +173,9 @@ class MultiTaskModule(DynamicModule):
         self.max_class_label = max(self.max_class_label, max(curr_classes) + 1)
         super().adaptation(experience)
 
-    def eval_adaptation(self, experience: CLExperience):
-        pass
-
     def train_adaptation(self, experience: CLExperience):
         """Update known task labels."""
+        super().train_adaptation(experience)
         task_labels = experience.task_labels
         self.known_train_tasks_labels = self.known_train_tasks_labels.union(
             set(task_labels)
@@ -277,6 +275,7 @@ class IncrementalClassifier(DynamicModule):
         :param experience: data from the current experience.
         :return:
         """
+        super().train_adaptation(experience)
         device = self._adaptation_device
         in_features = self.classifier.in_features
         old_nclasses = self.classifier.out_features
@@ -304,6 +303,7 @@ class IncrementalClassifier(DynamicModule):
         self.classifier.bias[:old_nclasses] = old_b
 
     def eval_adaptation(self, experience):
+        super().eval_adaptation(experience)
         self.train_adaptation(experience)
 
     def forward(self, x, **kwargs):
@@ -404,6 +404,7 @@ class MultiHeadClassifier(MultiTaskModule):
         :param experience: data from the current experience.
         :return:
         """
+        super().train_adaptation(experience)
         device = self._adaptation_device
         curr_classes = experience.classes_in_this_experience
         task_labels = experience.task_labels
@@ -460,6 +461,7 @@ class MultiHeadClassifier(MultiTaskModule):
                     self._buffers[au_name][curr_classes] = 1
 
     def eval_adaptation(self, experience):
+        super().eval_adaptation(experience)
         self.train_adaptation(experience)
 
     def forward_single_task(self, x, task_label):

--- a/avalanche/models/dynamic_modules.py
+++ b/avalanche/models/dynamic_modules.py
@@ -21,10 +21,10 @@ from avalanche.benchmarks.scenarios import CLExperience
 from avalanche.benchmarks.utils.flat_data import ConstantSequence
 
 
-def adapt_recursive(
+def avalanche_model_adaptation(
     module: Module,
     experience: CLExperience,
-    _visited: List = None,
+    _visited=None,
     _initial_call: bool = True,
 ):
     if _visited is None:
@@ -44,7 +44,9 @@ def adapt_recursive(
 
     # Iterate over children
     for name, submodule in module.named_children():
-        adapt_recursive(submodule, experience, _visited=_visited, _initial_call=False)
+        avalanche_model_adaptation(
+            submodule, experience, _visited=_visited, _initial_call=False
+        )
 
 
 class DynamicModule(Module):
@@ -70,7 +72,7 @@ class DynamicModule(Module):
         Calls self.adaptation recursively accross
         the hierarchy of module children
         """
-        adapt_recursive(self, experience)
+        avalanche_model_adaptation(self, experience)
 
     def adaptation(self, experience: CLExperience):
         """Adapt the module (freeze units, add units...) using the current
@@ -150,7 +152,7 @@ class MultiTaskModule(DynamicModule):
         self.known_train_tasks_labels = set()
         """ Set of task labels encountered up to now. """
 
-    def adaptation(self, experience: CLExperience, adapt_submodules=True):
+    def adaptation(self, experience: CLExperience):
         """Adapt the module (freeze units, add units...) using the current
         data. Optimizers must be updated after the model adaptation.
 

--- a/avalanche/models/dynamic_modules.py
+++ b/avalanche/models/dynamic_modules.py
@@ -27,13 +27,19 @@ def avalanche_model_adaptation(
     _visited=None,
     _initial_call: bool = True,
 ):
+    # _initial_call is set to true in the first iteration of the adaptation
+    # If initial_call is not true anymore, it means that the depth of the call is
+    # more than 1 and the adaptation is considered as "automatic" <=> done inside the
+    # recursive loop, Automatic adaptation calls will not adapt modules that
+    # have the _auto_adapt set to False
+
     if _visited is None:
-        _visited = []
+        _visited = set()
 
     if module in _visited:
         return
 
-    _visited.append(module)
+    _visited.add(module)
 
     if isinstance(module, DynamicModule):
         if (not _initial_call) and (not module._auto_adapt):
@@ -67,10 +73,10 @@ class DynamicModule(Module):
         super().__init__()
         self._auto_adapt = auto_adapt
 
-    def adapt(self, experience):
+    def recursive_adaptation(self, experience):
         """
         Calls self.adaptation recursively accross
-        the hierarchy of module children
+        the hierarchy of pytorch module childrens
         """
         avalanche_model_adaptation(self, experience)
 
@@ -90,7 +96,7 @@ class DynamicModule(Module):
 
         .. warning::
             This function only adapts the current module, to recursively adapt all
-            submodules use self.adapt() instead
+            submodules use self.recursive_adaptation() instead
 
         :param experience: the current experience.
         :return:

--- a/avalanche/models/ncm_classifier.py
+++ b/avalanche/models/ncm_classifier.py
@@ -134,14 +134,17 @@ class NCMClassifier(DynamicModule):
                 self.class_means_dict[k] = torch.zeros(class_size).to(device)
         self._vectorize_means_dict()
 
-    def eval_adaptation(self, experience):
-        classes = experience.classes_in_this_experience
-        for k in classes:
-            self.max_class = max(k, self.max_class)
-        if self.class_means is not None:
-            self.init_missing_classes(
-                classes, self.class_means.shape[1], self.class_means.device
-            )
+    def adaptation(self, experience):
+        super().adaptation(experience)
+
+        if not self.training:
+            classes = experience.classes_in_this_experience
+            for k in classes:
+                self.max_class = max(k, self.max_class)
+            if self.class_means is not None:
+                self.init_missing_classes(
+                    classes, self.class_means.shape[1], self.class_means.device
+                )
 
 
 __all__ = ["NCMClassifier"]

--- a/avalanche/models/pnn.py
+++ b/avalanche/models/pnn.py
@@ -165,8 +165,8 @@ class PNNLayer(MultiTaskModule):
         :param dataset:
         :return:
         """
+        super().adaptation(experience)
         dataset = experience.dataset
-        super().train_adaptation(experience)
         task_labels = dataset.targets_task_labels
         if isinstance(task_labels, ConstantSequence):
             # task label is unique. Don't check duplicates.

--- a/avalanche/models/utils.py
+++ b/avalanche/models/utils.py
@@ -3,9 +3,14 @@ from collections import OrderedDict
 import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel
 
+from avalanche._annotations import deprecated
 from avalanche.benchmarks.scenarios import CLExperience
 from avalanche.benchmarks.utils import _make_taskaware_classification_dataset
-from avalanche.models.dynamic_modules import DynamicModule, MultiTaskModule
+from avalanche.models.dynamic_modules import (
+    DynamicModule,
+    MultiTaskModule,
+    avalanche_model_adaptation,
+)
 
 
 def is_multi_task_module(model: nn.Module) -> bool:
@@ -20,17 +25,6 @@ def avalanche_forward(model, x, task_labels):
         return model(x, task_labels)
     else:  # no task labels
         return model(x)
-
-
-def avalanche_model_adaptation(model: nn.Module, experience: CLExperience):
-    if isinstance(model, DistributedDataParallel):
-        raise RuntimeError(
-            "The model is wrapped in DistributedDataParallel. "
-            "Please unwrap it before calling this method."
-        )
-    for module in model.modules():
-        if isinstance(module, DynamicModule):
-            module.adaptation(experience)
 
 
 class FeatureExtractorBackbone(nn.Module):

--- a/notebooks/from-zero-to-hero-tutorial/02_models.ipynb
+++ b/notebooks/from-zero-to-hero-tutorial/02_models.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -39,43 +39,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SimpleCNN(\n",
-      "  (features): Sequential(\n",
-      "    (0): Conv2d(3, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-      "    (1): ReLU(inplace=True)\n",
-      "    (2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1))\n",
-      "    (3): ReLU(inplace=True)\n",
-      "    (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
-      "    (5): Dropout(p=0.25, inplace=False)\n",
-      "    (6): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-      "    (7): ReLU(inplace=True)\n",
-      "    (8): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1))\n",
-      "    (9): ReLU(inplace=True)\n",
-      "    (10): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
-      "    (11): Dropout(p=0.25, inplace=False)\n",
-      "    (12): Conv2d(64, 64, kernel_size=(1, 1), stride=(1, 1))\n",
-      "    (13): ReLU(inplace=True)\n",
-      "    (14): AdaptiveMaxPool2d(output_size=1)\n",
-      "    (15): Dropout(p=0.25, inplace=False)\n",
-      "  )\n",
-      "  (classifier): Sequential(\n",
-      "    (0): Linear(in_features=64, out_features=10, bias=True)\n",
-      "  )\n",
-      ")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from avalanche.models import SimpleCNN\n",
     "from avalanche.models import SimpleMLP\n",
@@ -99,38 +69,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "IncrementalClassifier(\n",
-      "  (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      ")\n",
-      "IncrementalClassifier(\n",
-      "  (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      ")\n",
-      "IncrementalClassifier(\n",
-      "  (classifier): Linear(in_features=784, out_features=4, bias=True)\n",
-      ")\n",
-      "IncrementalClassifier(\n",
-      "  (classifier): Linear(in_features=784, out_features=6, bias=True)\n",
-      ")\n",
-      "IncrementalClassifier(\n",
-      "  (classifier): Linear(in_features=784, out_features=8, bias=True)\n",
-      ")\n",
-      "IncrementalClassifier(\n",
-      "  (classifier): Linear(in_features=784, out_features=10, bias=True)\n",
-      ")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from avalanche.benchmarks import SplitMNIST\n",
     "from avalanche.models import IncrementalClassifier\n",
@@ -174,92 +119,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MultiHeadClassifier(\n",
-      "  (classifiers): ModuleDict(\n",
-      "    (0): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "  )\n",
-      ")\n",
-      "MultiHeadClassifier(\n",
-      "  (classifiers): ModuleDict(\n",
-      "    (0): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "  )\n",
-      ")\n",
-      "MultiHeadClassifier(\n",
-      "  (classifiers): ModuleDict(\n",
-      "    (0): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "    (1): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "  )\n",
-      ")\n",
-      "MultiHeadClassifier(\n",
-      "  (classifiers): ModuleDict(\n",
-      "    (0): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "    (1): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "    (2): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "  )\n",
-      ")\n",
-      "MultiHeadClassifier(\n",
-      "  (classifiers): ModuleDict(\n",
-      "    (0): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "    (1): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "    (2): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "    (3): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "  )\n",
-      ")\n",
-      "MultiHeadClassifier(\n",
-      "  (classifiers): ModuleDict(\n",
-      "    (0): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "    (1): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "    (2): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "    (3): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "    (4): IncrementalClassifier(\n",
-      "      (classifier): Linear(in_features=784, out_features=2, bias=True)\n",
-      "    )\n",
-      "  )\n",
-      ")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from avalanche.benchmarks import SplitMNIST\n",
     "from avalanche.models import MultiHeadClassifier\n",
@@ -300,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -339,73 +205,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SimpleCNN(\n",
-      "  (features): Sequential(\n",
-      "    (0): Conv2d(3, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-      "    (1): ReLU(inplace=True)\n",
-      "    (2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1))\n",
-      "    (3): ReLU(inplace=True)\n",
-      "    (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
-      "    (5): Dropout(p=0.25, inplace=False)\n",
-      "    (6): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-      "    (7): ReLU(inplace=True)\n",
-      "    (8): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1))\n",
-      "    (9): ReLU(inplace=True)\n",
-      "    (10): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
-      "    (11): Dropout(p=0.25, inplace=False)\n",
-      "    (12): Conv2d(64, 64, kernel_size=(1, 1), stride=(1, 1))\n",
-      "    (13): ReLU(inplace=True)\n",
-      "    (14): AdaptiveMaxPool2d(output_size=1)\n",
-      "    (15): Dropout(p=0.25, inplace=False)\n",
-      "  )\n",
-      "  (classifier): Sequential(\n",
-      "    (0): Linear(in_features=64, out_features=10, bias=True)\n",
-      "  )\n",
-      ")\n",
-      "MultiTaskDecorator(\n",
-      "  (model): SimpleCNN(\n",
-      "    (features): Sequential(\n",
-      "      (0): Conv2d(3, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-      "      (1): ReLU(inplace=True)\n",
-      "      (2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1))\n",
-      "      (3): ReLU(inplace=True)\n",
-      "      (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
-      "      (5): Dropout(p=0.25, inplace=False)\n",
-      "      (6): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-      "      (7): ReLU(inplace=True)\n",
-      "      (8): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1))\n",
-      "      (9): ReLU(inplace=True)\n",
-      "      (10): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
-      "      (11): Dropout(p=0.25, inplace=False)\n",
-      "      (12): Conv2d(64, 64, kernel_size=(1, 1), stride=(1, 1))\n",
-      "      (13): ReLU(inplace=True)\n",
-      "      (14): AdaptiveMaxPool2d(output_size=1)\n",
-      "      (15): Dropout(p=0.25, inplace=False)\n",
-      "    )\n",
-      "    (classifier): Sequential()\n",
-      "  )\n",
-      "  (classifier): MultiHeadClassifier(\n",
-      "    (classifiers): ModuleDict(\n",
-      "      (0): IncrementalClassifier(\n",
-      "        (classifier): Linear(in_features=64, out_features=10, bias=True)\n",
-      "      )\n",
-      "    )\n",
-      "  )\n",
-      ")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from avalanche.models import as_multitask\n",
     "\n",
@@ -414,6 +220,50 @@
     "\n",
     "mt_model = as_multitask(model, 'classifier')\n",
     "print(mt_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Nested Dynamic Modules\n",
+    "Whenever one or more dynamic modules are nested one inside the other, you must call the `recursive_adaptation` method, and if they are nested inside a normal pytorch module (non dynamic), you can call the `avalanche_model_adaptation` function. Avalanche strategies will by default adapt the models before training on each experience by calling `avalanche_model_adaptation`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "benchmark = SplitMNIST(5, shuffle=False, class_ids_from_zero_in_each_exp=True, return_task_id=True)\n",
+    "\n",
+    "model = SimpleCNN(num_classes=1)\n",
+    "mt_model = as_multitask(model, 'classifier')\n",
+    "\n",
+    "print(mt_model)\n",
+    "for exp in benchmark.train_stream:\n",
+    "    mt_model.recursive_adaptation(exp)\n",
+    "print(mt_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from avalanche.models.utils import avalanche_model_adaptation\n",
+    "\n",
+    "benchmark = SplitMNIST(5, shuffle=False, class_ids_from_zero_in_each_exp=False)\n",
+    "\n",
+    "model = SimpleCNN(num_classes=1)\n",
+    "model.classifier = IncrementalClassifier(model.classifier[0].in_features, 1)\n",
+    "\n",
+    "for exp in benchmark.train_stream:\n",
+    "    avalanche_model_adaptation(model, exp)\n",
+    "    \n",
+    "print(model)"
    ]
   },
   {
@@ -439,7 +289,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -453,9 +303,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -537,7 +537,17 @@ class DynamicModelsTests(unittest.TestCase):
         for t, s in sizes.items():
             self.assertEqual(s, model.classifiers[str(t)].classifier.out_features)
 
+    def test_avalanche_adaptation(self):
+        model1 = torch.nn.Sequential(MultiHeadClassifier(in_features=6))
+        benchmark = get_fast_benchmark(use_task_labels=True, shuffle=True)
+        avalanche_model_adaptation(model1, benchmark.train_stream[0])
+
     def test_recursive_adaptation(self):
+        model1 = MultiHeadClassifier(in_features=6)
+        benchmark = get_fast_benchmark(use_task_labels=True, shuffle=True)
+        model1.recursive_adaptation(benchmark.train_stream[0])
+
+    def test_recursive_loop(self):
         model1 = MultiHeadClassifier(in_features=6)
         model2 = MultiHeadClassifier(in_features=6)
 
@@ -546,7 +556,7 @@ class DynamicModelsTests(unittest.TestCase):
         model2.layer2 = model1
 
         benchmark = get_fast_benchmark(use_task_labels=True, shuffle=True)
-        avalanche_model_adaptation(model1, benchmark.train_stream[0])
+        model1.recursive_adaptation(benchmark.train_stream[0])
 
     def test_multi_head_classifier_masking(self):
         benchmark = get_fast_benchmark(use_task_labels=True, shuffle=True)


### PR DESCRIPTION
I tried to implement the changes that would fix bugs described in Issue #1591 and also allow users to use Dynamic modules more easily outside of avalanche strategies.

To do so, I made several major changes.

- Remove old avalanche_model_adaptation method and replace it with a new version which does things differently. Instead of iterating on all modules, it iterates only on childrens, and does so recursively in order to explore the whole hierarchy. It still iterates on the hierarchy of nn.Modules and catches DynamicModules to adapt them just like before.
- Added a method adapt() to dynamicmodule that will call the new "avalanche_model_adaptation" on itself and recursively on it's submodules
- Added an _auto_adapt attribute to all DynamicModules that triggers or not the adaptation inside the avalanche_model_adaptation recursion (defaults to True). In particular, this attribute does not prevent the user to call directly module.adapt() if he wants, however if the module needs to be adapted as a second level or more module inside this recursion, it will not get adapted. This is the part that fixes the bug described in #1591, since that way we can instantiate IncrementalClassifiers inside the MultiHeadClassifier that will not be automatically adapted but rather adapted manually by the MultiHeadClassifier only if the experience used for adaptation contains the task id related to this IncrementalClassifier.
- Made a few clarification changes in IncrementalClassifier and Multiheadclassifier by replacing occurences of adaptation() implementation by train_adaptation and eval_adaptation, where if the eval_adaptation needs to be the same than train_adaptation I just call train_adaptation inside eval_adaptation (nested adaptation() override were a bit complex to understand and could lead to confusion)

For now tests do not pass, but some of them I am not sure what behaviour they were checking and if we really want this behaviour. I will also add some more tests to check that the behaviour in #1591 is solved (my local test says it is fixed for now).