### PR TITLE
Removed old functions in doc, move ctrl-benchmark to separate tag

### DIFF
--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -37,6 +37,7 @@ Scenarios
 
     NCScenario
     NIScenario
+    benchmark_with_validation_stream
 
 Streams
 """""""""
@@ -275,9 +276,9 @@ Misc (make data-incremental, add a validation stream, ...)
     :toctree: generated
 
     data_incremental_benchmark
-    benchmark_with_validation_stream
 
 .. currentmodule:: avalanche.benchmarks.utils
+
 
 Utils (Data Loading and AvalancheDataset)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -306,9 +307,5 @@ AvalancheDataset
 
     AvalancheDataset
     make_avalanche_dataset
-    make_classification_dataset
-    classification_subset
-    make_tensor_classification_dataset
-    concat_classification_datasets
     TaskSet
     DataAttribute

--- a/extra_dependencies.txt
+++ b/extra_dependencies.txt
@@ -4,8 +4,8 @@
 # package[version_required]: tag1, tag2, ...
 
 higher:               extra
-ctrl-benchmark:       extra
 torchaudio:           extra
+ctrl-benchmark:       ctrl
 gym:                  rl
 pycocotools:          detection
 lvis:                 detection


### PR DESCRIPTION
I removed some old doc references to functions that are not present in the benchmarks module anymore.

ctrl-benchmark package does not support pytorch2 and the project is archived. the package is now installed through a separate installation tag, ctrl.