### PR TITLE
fix LVIS dataset download links

### DIFF
--- a/avalanche/benchmarks/datasets/lvis_dataset/lvis_data.py
+++ b/avalanche/benchmarks/datasets/lvis_dataset/lvis_data.py
@@ -13,13 +13,13 @@
 lvis_archives = [
     (
         "lvis_v1_val.json.zip",  # Validation set annotations
-        "https://s3-us-west-2.amazonaws.com/dl.fbaipublicfiles.com/LVIS"
+        "https://dl.fbaipublicfiles.com/LVIS"
         "/lvis_v1_val.json.zip",
         "87734a7f895990b9552075d7ce723e27",
     ),
     (
         "lvis_v1_train.json.zip",  # Training set annotations
-        "https://s3-us-west-2.amazonaws.com/dl.fbaipublicfiles.com/LVIS"
+        "https://dl.fbaipublicfiles.com/LVIS"
         "/lvis_v1_train.json.zip",
         "4410d837f71203af226950447ef9d422",
     ),


### PR DESCRIPTION
Download links for LVIS annotations were out-of-date and not working. Removing aws-s3 part of the link fixed the problem. 

Source: [https://groups.google.com/g/lvis-dataset/c/kVdchbMn7KA?pli=1](https://groups.google.com/g/lvis-dataset/c/kVdchbMn7KA/m/0jmFRVw1AgAJ)