### PR TITLE
PNN adapter arguement missing in the _init_() method #1625

### DIFF
--- a/avalanche/models/pnn.py
+++ b/avalanche/models/pnn.py
@@ -20,6 +20,7 @@ class LinearAdapter(nn.Module):
         :param num_prev_modules: number of previous modules
         """
         super().__init__()
+        self.num_prev_modules = num_prev_modules
         # Eq. 1 - lateral connections
         # one layer for each previous column. Empty for the first task.
         self.lat_layers = nn.ModuleList([])


### PR DESCRIPTION
The issue is due to the num_prev_modules attribute not being initialized in the LinearAdapter class within the PNN.py module.