### PR TITLE
task_labels experience attribute type fix: now it is a list, not a set

### DIFF
--- a/avalanche/benchmarks/scenarios/task_aware.py
+++ b/avalanche/benchmarks/scenarios/task_aware.py
@@ -96,9 +96,10 @@ def with_task_labels(obj):
 
     def _add_task_labels(exp):
         tls = exp.dataset.targets_task_labels.uniques
+        # tls is a set, we need to convert to list to call __getitem__
+        tls = list(tls)
         if len(tls) == 1:
-            # tls is a set. we need to convert to list to call __getitem__
-            exp.task_label = list(tls)[0]
+            exp.task_label = tls[0]
         exp.task_labels = tls
         return exp
 

--- a/tests/benchmarks/scenarios/test_task_aware.py
+++ b/tests/benchmarks/scenarios/test_task_aware.py
@@ -14,7 +14,7 @@ import numpy as np
 
 class TestsTaskAware(unittest.TestCase):
     def test_taskaware(self):
-        """Common use case: add tas labels to class-incremental benchmark."""
+        """Common use case: add task labels to class-incremental benchmark."""
         n_classes, n_samples_per_class, n_features = 10, 3, 7
 
         for _ in range(10000):
@@ -58,6 +58,7 @@ class TestsTaskAware(unittest.TestCase):
         ci_train = bm_ci.train_stream
         for eid, exp in enumerate(bm_ti.train_stream):
             assert exp.task_label == eid
+            assert isinstance(exp.task_labels, list)
             assert len(ci_train[eid].dataset) == len(exp.dataset)
 
 


### PR DESCRIPTION
Hello, I found a bug in  the `task_incremental_benchmark` generator. Even with the MNIST example in the notebook "_03_benchmarks.ipynb_" `exp.task_labels` is a set not a list as the train method expects.

I think the problem is here, where we convert the set in the list only for the `task_label` attribute: https://github.com/ContinualAI/avalanche/blob/0d6f7155446b2b4b25b33b8e7d21284ca8d7d06a/avalanche/benchmarks/scenarios/task_aware.py#L89-L105

The set is never converted into a list for the attribute task_labels and in in this method we use the indexing which is not supported by a set: https://github.com/ContinualAI/avalanche/blob/0d6f7155446b2b4b25b33b8e7d21284ca8d7d06a/avalanche/evaluation/metric_utils.py#L249-L275

Below you can find the small fix + an assert I added in the TaskAware tests.