### PR TITLE
Improved Efficiency of the DiskUsage Metric

### DIFF
--- a/avalanche/evaluation/metrics/disk_usage.py
+++ b/avalanche/evaluation/metrics/disk_usage.py
@@ -99,7 +99,14 @@ class DiskUsage(Metric[float]):
         total_size = 0.0
 
         if platform == "linux" or platform == "linux2":
-          total_size = float(subprocess.check_output(['du', '-sb', path]).split()[0].decode('utf-8')) / 1024
+            total_size = (
+                float(
+                    subprocess.check_output(["du", "-sb", path])
+                    .split()[0]
+                    .decode("utf-8")
+                )
+                / 1024
+            )
         else:
             for dirpath, dirnames, filenames in os.walk(path):
                 for f in filenames:
@@ -150,10 +157,7 @@ class MinibatchDiskUsage(DiskPluginMetric):
         Creates an instance of the minibatch Disk usage metric.
         """
         super(MinibatchDiskUsage, self).__init__(
-            paths_to_monitor,
-            reset_at="iteration",
-            emit_at="iteration",
-            mode="train",
+            paths_to_monitor, reset_at="iteration", emit_at="iteration", mode="train"
         )
 
     def __str__(self):
@@ -195,10 +199,7 @@ class ExperienceDiskUsage(DiskPluginMetric):
         Creates an instance of the experience Disk usage metric.
         """
         super(ExperienceDiskUsage, self).__init__(
-            paths_to_monitor,
-            reset_at="experience",
-            emit_at="experience",
-            mode="eval",
+            paths_to_monitor, reset_at="experience", emit_at="experience", mode="eval"
         )
 
     def __str__(self):
@@ -232,7 +233,7 @@ def disk_usage_metrics(
     minibatch=False,
     epoch=False,
     experience=False,
-    stream=False
+    stream=False,
 ) -> List[DiskPluginMetric]:
     """
     Helper method that can be used to obtain the desired set of

--- a/tests/evaluation/test_disk_usage.py
+++ b/tests/evaluation/test_disk_usage.py
@@ -12,5 +12,6 @@ class DiskUsageTests(unittest.TestCase):
         disk = DiskUsage()
         disk.get_dir_size(".")
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/evaluation/test_disk_usage.py
+++ b/tests/evaluation/test_disk_usage.py
@@ -1,0 +1,16 @@
+""" Disk Usage Metric Test"""
+
+import unittest
+
+from avalanche.evaluation.metrics import DiskUsage
+
+
+class DiskUsageTests(unittest.TestCase):
+    def test_basic(self):
+        """just checking that directory size is computed without errors."""
+
+        disk = DiskUsage()
+        disk.get_dir_size(".")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hello,

This PR speeds up the `DiskUsage` metric.

It turns out that if you have a lot of dirs/files in the current directory (the default target for the size inspection) especially the eval mode with `disk_usage_metrics(stream=True)` becomes super slow (the metric is computed every mini-batch). 

In my case it takes about 4 seconds for every inspection. I use the "du" command (it improves the timing of about 4x) if you are on Linux adding a warning in case the metric compute time exceeds 0.5 seconds.

Let me know if you think I should change anything.

