### PR TITLE
When import the library, appears an error said that cant import DwsCo…

### DIFF
--- a/avalanche/models/mobilenetv1.py
+++ b/avalanche/models/mobilenetv1.py
@@ -22,7 +22,7 @@ from pytorchcv.models.mobilenet import mobilenet_w1
 try:
     from pytorchcv.models.mobilenet import DwsConvBlock
 except Exception:
-    from pytorchcv.models.common import DwsConvBlock
+    from pytorchcv.models.common.conv import DwsConvBlock
 
 
 def remove_sequential(network: nn.Module, all_layers: List[nn.Module]):


### PR DESCRIPTION
…nvBlock.


The problem is at "mobilenetv1.py" file at line 25. There is  import "from pytorchcv.models.common import DwsConvBlock". The problem is that in common, there is not DwsConvBlock. Instead "DwsConvBlock" is in "pytorchcv.models.common.conv" . 

So to solve the problem must change line 25 with "from pytorchcv.models.common.conv import DwsConvBlock"